### PR TITLE
AdminGui - attribute definitions sort

### DIFF
--- a/apps/admin-gui/src/app/admin/components/attr-def-list/attr-def-list.component.ts
+++ b/apps/admin-gui/src/app/admin/components/attr-def-list/attr-def-list.component.ts
@@ -50,7 +50,10 @@ export class AttrDefListComponent implements OnChanges, AfterViewInit {
       this.dataSource.sortingDataAccessor = (item, property) => {
         if (property === 'namespace') {
           return item.namespace.substring(item.namespace.lastIndexOf(':') + 1, item.namespace.length);
-        } else {
+        } else if (property === 'friendlyName') {
+          return item[property].toLowerCase();
+        }
+        else {
           return item[property];
         }
       };


### PR DESCRIPTION
* The sorting of attribute definition was case sensitive, now it is not.