### PR TITLE
Bugfix: Close sidebar when changed size of the window

### DIFF
--- a/apps/admin-gui/src/app/app.component.html
+++ b/apps/admin-gui/src/app/app.component.html
@@ -16,7 +16,7 @@
   <mat-sidenav #sidenav
                [ngStyle]="{'border-color': sideBarBorderColor}"
                [mode]="sidebarMode"
-               [opened]="true"
+               [opened]="!isMobile()"
                [fixedInViewport]="true"
                [fixedTopGap]="getTopGap()">
 


### PR DESCRIPTION
* Sidemenu is closed when window is shrunk so that the style of side menu is changed
* Resolves #114 