### PR TITLE
Refactor table options button

### DIFF
--- a/libs/perun/components/src/lib/table-options/table-options.component.scss
+++ b/libs/perun/components/src/lib/table-options/table-options.component.scss
@@ -1,4 +1,5 @@
 .position-right {
   position: absolute;
   right: 20px;
+  margin: -1.25rem;
 }


### PR DESCRIPTION
* added negative margit to table option button
I guess this could be one of the simpliest solutions
Screen of table where it previously have problem:
![image](https://user-images.githubusercontent.com/32871167/79068940-c646fb00-7cca-11ea-9445-4d7a6423ceba.png)
Cardbody have padding and I placed the export button to that padding, so that text of the headers don't overlap the options button
![image](https://user-images.githubusercontent.com/32871167/79068952-dc54bb80-7cca-11ea-9ccd-a9fe539b840d.png)
resolves #187 