### PR TITLE
BugFix - add group admin

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.html
@@ -14,7 +14,7 @@
         <mat-label>{{'DIALOGS.ADD_GROUPS.SELECT_VO' | translate}}</mat-label>
         <input type="text" placeholder="{{'DIALOGS.ADD_GROUPS.SELECT_VO' | translate}}" aria-label="Assignee" matInput
                [formControl]="myControl" [matAutocomplete]="auto">
-        <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn" (optionSelected)="showVoGroups()">
+        <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn" (optionSelected)="showVoGroups($event)">
           <mat-option *ngFor="let vo of filteredOptions | async" [value]="vo">
             {{vo.name}}
           </mat-option>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.ts
@@ -21,6 +21,7 @@ import {
   TableConfigService
 } from '@perun-web-apps/config/table-config';
 import { PageEvent } from '@angular/material/paginator';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 
 export interface AddGroupManagerDialogData {
   complementaryObject: Vo | Group | Facility;
@@ -111,18 +112,12 @@ export class AddGroupManagerDialogComponent implements OnInit {
     return this.vos.filter(option => option.name.toLowerCase().includes(<string>filterValue));
   }
 
-  showVoGroups() {
+  showVoGroups(event: MatAutocompleteSelectedEvent) {
     this.loading = true;
-    this.filteredOptions.subscribe( values => {
-      if ( values.length !== 0) {
-        this.selected = values[0].id;
-
-        this.groupService.getAllGroups(this.selected).subscribe(groups => {
-          this.groups = groups;
-          this.loading = false;
-          this.firstSearchDone = true;
-        }, () => this.loading = false);
-      }
+    this.groupService.getAllGroups(event.option.value.id).subscribe(groups => {
+      this.groups = groups;
+      this.loading = false;
+      this.firstSearchDone = true;
     }, () => this.loading = false);
   }
 


### PR DESCRIPTION
* There was a bug when adding a group admin. When selecting a VO, the
loaded groups were not actually from the selected vo but from some other
vo.
* The implementation has been fixed so the shown groups belong to the
selected vo.