### PR TITLE
Sidemenu repair

### DIFF
--- a/apps/admin-gui/src/app/shared/side-menu/side-menu.component.html
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu.component.html
@@ -68,7 +68,8 @@
       <app-side-menu-item
         [sideNav]="sideNav"
         [item]="item"
-        [index]="i">
+        [index]="i"
+        [showLinks]="true">
       </app-side-menu-item>
     </div>
   </div>


### PR DESCRIPTION
* in admin section - when trying to look for some user and show the user detail, in sidemenu the item did show up but without but without the item "links"/"properties"
* now they show up