### PR TITLE
users organizations and groups in Admin section 

### DIFF
--- a/apps/admin-gui/src/app/admin/admin-routing.module.ts
+++ b/apps/admin-gui/src/app/admin/admin-routing.module.ts
@@ -94,12 +94,12 @@ const routes: Routes = [
       {
         path: 'organizations',
         component: UserOrganizationsComponent,
-        data: {animation: 'UserOrganizationsPage'}
+        data: {animation: 'UserOrganizationsPage', showPrincipal: false}
       },
       {
         path: 'groups',
         component: UserGroupsComponent,
-        data: {animation: 'UserGroupsPage'}
+        data: {animation: 'UserGroupsPage', showPrincipal: false}
       },
       {
         path: 'settings',
@@ -118,7 +118,7 @@ const routes: Routes = [
           {
             path: 'facilityAttributes',
             component: UserSettingsFacilityAttributesComponent,
-            data: {animation: 'UserSettingsFacilityAttributesPage'}
+            data: {animation: 'UserSettingsFacilityAttributesPage', showPrincipal: false}
           },
           {
             path: 'roles',

--- a/apps/admin-gui/src/app/app-routing.module.ts
+++ b/apps/admin-gui/src/app/app-routing.module.ts
@@ -47,12 +47,12 @@ const routes: Routes = [
       {
         path: 'organizations',
         component: UserOrganizationsComponent,
-        data: {animation: 'UserOrganizationsPage'}
+        data: {animation: 'UserOrganizationsPage', showPrincipal: true}
       },
       {
         path: 'groups',
         component: UserGroupsComponent,
-        data: {animation: 'UserGroupsPage'}
+        data: {animation: 'UserGroupsPage', showPrincipal: true}
       },
       {
         path: 'settings',
@@ -71,7 +71,7 @@ const routes: Routes = [
           {
             path: 'facilityAttributes',
             component: UserSettingsFacilityAttributesComponent,
-            data: {animation: 'UserSettingsFacilityAttributesPage'}
+            data: {animation: 'UserSettingsFacilityAttributesPage', showPrincipal: true}
           },
           {
             path: 'roles',

--- a/apps/admin-gui/src/app/shared/components/user-detail-page/user-groups/user-groups.component.html
+++ b/apps/admin-gui/src/app/shared/components/user-detail-page/user-groups/user-groups.component.html
@@ -1,6 +1,7 @@
 <perun-web-apps-refresh-button (refresh)="refreshTable()"></perun-web-apps-refresh-button>
 
-<h1 class="page-subtitle pt-2">{{'SHARED.COMPONENTS.USER_DETAIL.GROUPS.MEMBER_GROUPS' | translate}}</h1>
+<h1 *ngIf="this.showPrincipal" class="page-subtitle pt-2">{{'SHARED.COMPONENTS.USER_DETAIL.GROUPS.YOU_ARE_MEMBER' | translate}}</h1>
+<h1 *ngIf="!this.showPrincipal" class="page-subtitle pt-2">{{'SHARED.COMPONENTS.USER_DETAIL.GROUPS.USER_IS_MEMBER' | translate}}</h1>
 
 <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
 <div *ngIf="!loading">
@@ -14,7 +15,8 @@
 </div>
 
 <div *ngIf="adminsGroups.length != 0">
-  <h1 class="page-subtitle pt-5">{{'SHARED.COMPONENTS.USER_DETAIL.GROUPS.ADMINS_GROUPS' | translate}}</h1>
+  <h1 *ngIf="this.showPrincipal" class="page-subtitle pt-5">{{'SHARED.COMPONENTS.USER_DETAIL.GROUPS.YOU_ARE_ADMIN' | translate}}</h1>
+  <h1 *ngIf="!this.showPrincipal" class="page-subtitle pt-5">{{'SHARED.COMPONENTS.USER_DETAIL.GROUPS.USER_IS_ADMIN' | translate}}</h1>
 
   <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
   <div *ngIf="!loading">

--- a/apps/admin-gui/src/app/shared/components/user-detail-page/user-organizations/user-organizations.component.html
+++ b/apps/admin-gui/src/app/shared/components/user-detail-page/user-organizations/user-organizations.component.html
@@ -1,11 +1,11 @@
-<h1 class="page-subtitle">{{'SHARED_LIB.PERUN.ORGANIZATIONS.TITLE' | translate}}</h1>
 <perun-web-apps-refresh-button (refresh)="refreshTable()" *ngIf="!loading"></perun-web-apps-refresh-button>
 <perun-web-apps-immediate-filter (filter)="applyFilter($event)" *ngIf="!loading"
                                  [placeholder]="'SHARED_LIB.PERUN.ORGANIZATIONS.FILTER'"></perun-web-apps-immediate-filter>
 <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
 
 <div *ngIf="!loading && vosWhereIsMember.length !== 0">
-  <h1 class="page-subtitle">{{'SHARED_LIB.PERUN.ORGANIZATIONS.IS_MEMBER' | translate}}</h1>
+  <h1 *ngIf="this.showPrincipal" class="page-subtitle">{{'SHARED_LIB.PERUN.ORGANIZATIONS.YOU_ARE_MEMBER' | translate}}</h1>
+  <h1 *ngIf="!this.showPrincipal" class="page-subtitle">{{'SHARED_LIB.PERUN.ORGANIZATIONS.USER_IS_MEMBER' | translate}}</h1>
   <perun-web-apps-vo-select-table [displayedColumns]="displayedColumns"
                                   [pageSize]="memberPageSize"
                                   (page)="memberPageChanged($event)"
@@ -15,7 +15,8 @@
 </div>
 
 <div *ngIf="!loading && vosWhereIsAdmin.length !== 0" class="mt-5">
-  <h1 class="page-subtitle">{{'SHARED_LIB.PERUN.ORGANIZATIONS.IS_ADMIN' | translate}}</h1>
+  <h1 *ngIf="this.showPrincipal" class="page-subtitle">{{'SHARED_LIB.PERUN.ORGANIZATIONS.YOU_ARE_ADMIN' | translate}}</h1>
+  <h1 *ngIf="!this.showPrincipal" class="page-subtitle">{{'SHARED_LIB.PERUN.ORGANIZATIONS.USER_IS_ADMIN' | translate}}</h1>
   <perun-web-apps-vo-select-table [displayedColumns]="displayedColumns"
                                   [pageSize]="adminPageSize"
                                   (page)="adminPageChanged($event)"

--- a/apps/admin-gui/src/app/shared/components/user-detail-page/user-organizations/user-organizations.component.ts
+++ b/apps/admin-gui/src/app/shared/components/user-detail-page/user-organizations/user-organizations.component.ts
@@ -1,11 +1,12 @@
 import { Component, HostBinding, OnInit } from '@angular/core';
-import { PerunPrincipal, UsersManagerService, Vo } from '@perun-web-apps/perun/openapi';
+import { UsersManagerService, Vo } from '@perun-web-apps/perun/openapi';
 import { GuiAuthResolver, StoreService } from '@perun-web-apps/perun/services';
 import { PageEvent } from '@angular/material/paginator';
 import {
   TABLE_USER_PROFILE_ADMIN_SELECT, TABLE_USER_PROFILE_MEMBER_SELECT,
   TableConfigService
 } from '@perun-web-apps/config/table-config';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-user-organizations',
@@ -20,11 +21,11 @@ export class UserOrganizationsComponent implements OnInit {
     private usersService: UsersManagerService,
     private authResolver: GuiAuthResolver,
     private tableConfigService: TableConfigService,
-    private store: StoreService
+    private store: StoreService,
+    private route: ActivatedRoute
   ) {
   }
 
-  principal: PerunPrincipal;
   vosWhereIsAdmin: Vo[];
   vosWhereIsMember: Vo[];
   loading: boolean;
@@ -36,13 +37,16 @@ export class UserOrganizationsComponent implements OnInit {
   memberPageSize: number;
   adminTableId = TABLE_USER_PROFILE_ADMIN_SELECT;
   memberTableId = TABLE_USER_PROFILE_MEMBER_SELECT;
+  showPrincipal: boolean;
 
   ngOnInit() {
     this.adminPageSize = this.tableConfigService.getTablePageSize(this.adminTableId);
     this.memberPageSize = this.tableConfigService.getTablePageSize(this.memberTableId);
-    this.principal = this.store.getPerunPrincipal();
-    this.userId = this.principal.user.id;
-
+    if ((this.showPrincipal = this.route.snapshot.data.showPrincipal) === true) {
+      this.userId = this.store.getPerunPrincipal().user.id;
+    } else {
+      this.route.parent.params.subscribe(params => this.userId = params['userId']);
+    }
     this.refreshTable();
   }
 

--- a/apps/admin-gui/src/app/shared/components/user-detail-page/user-overview/user-overview.component.ts
+++ b/apps/admin-gui/src/app/shared/components/user-detail-page/user-overview/user-overview.component.ts
@@ -28,19 +28,19 @@ export class UserOverviewComponent implements OnInit {
       {
         cssIcon: 'perun-vo',
         url: `organizations`,
-        label: 'MENU_ITEMS.USER.ORGANIZATIONS',
+        label: 'MENU_ITEMS.ADMIN.ORGANIZATIONS',
         style: 'user-btn'
       },
       {
         cssIcon: 'perun-group',
         url: `groups`,
-        label: 'MENU_ITEMS.USER.GROUPS',
+        label: 'MENU_ITEMS.ADMIN.GROUPS',
         style: 'user-btn'
       },
       {
         cssIcon: 'perun-settings2',
         url: `settings`,
-        label: 'MENU_ITEMS.USER.SETTINGS',
+        label: 'MENU_ITEMS.ADMIN.SETTINGS',
         style: 'user-btn'
       }
     ];

--- a/apps/admin-gui/src/app/shared/components/user-detail-page/user-settings/user-settings-facility-attributes/user-settings-facility-attributes.component.ts
+++ b/apps/admin-gui/src/app/shared/components/user-detail-page/user-settings/user-settings-facility-attributes/user-settings-facility-attributes.component.ts
@@ -12,17 +12,23 @@ export class UserSettingsFacilityAttributesComponent implements OnInit {
 
   constructor(protected route: ActivatedRoute,
               private storage: StoreService,
-              private facilitiesManagerService: FacilitiesManagerService) {
+              private facilitiesManagerService: FacilitiesManagerService,
+              private store: StoreService) {
   }
 
   userId: number;
   facilities: Facility[] = [];
   loading: boolean;
+  showPrincipal: boolean
 
 
   ngOnInit(): void {
     this.loading = true;
-    this.userId = this.storage.getPerunPrincipal().userId;
+    if ((this.showPrincipal = this.route.snapshot.data.showPrincipal) === true) {
+      this.userId = this.store.getPerunPrincipal().user.id;
+    } else {
+      this.route.parent.parent.params.subscribe(params => this.userId = params['userId']);
+    }
 
     this.facilitiesManagerService.getAssignedFacilitiesByUser(this.userId).subscribe(facilities => {
       this.facilities = facilities;

--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
@@ -68,7 +68,7 @@ export class SideMenuItemService {
       expandable: false,
       label: 'MAIN_MENU.HOME',
       colorClass: 'base-item-color-activated',
-      icon: 'perun-user',
+      icon: 'perun-home-white',
       baseColorClass: 'base-item-color',
       baseColorClassRegex: '^dont-use$',
       activatedClass: 'dark-item-activated',
@@ -453,17 +453,17 @@ export class SideMenuItemService {
           activatedRegex: `${regex}$`
         },
         {
-          label: 'MENU_ITEMS.USER.ORGANIZATIONS',
+          label: 'MENU_ITEMS.ADMIN.ORGANIZATIONS',
           url: [`${path}/organizations`],
           activatedRegex: `${regex}/organizations`
         },
         {
-          label: 'MENU_ITEMS.USER.GROUPS',
+          label: 'MENU_ITEMS.ADMIN.GROUPS',
           url: [`${path}/groups`],
           activatedRegex: `${regex}/groups`
         },
         {
-          label: 'MENU_ITEMS.USER.SETTINGS',
+          label: 'MENU_ITEMS.ADMIN.SETTINGS',
           url: [`${path}/settings`],
           activatedRegex: `${regex}/settings$`,
           children: [

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -582,7 +582,10 @@
       "ATTRIBUTES": "Attributes",
       "VISUALIZER": "Visualizer",
       "USERS": "Users",
-      "EXT_SOURCES": "External sources"
+      "EXT_SOURCES": "External sources",
+      "GROUPS": "Groups",
+      "SETTINGS": "Settings",
+      "ORGANIZATIONS": "Organizations"
     },
     "VISUALIZER": {
       "ATTR_DEPENDENCIES": "Modules dependencies",
@@ -590,9 +593,9 @@
     },
     "USER": {
       "OVERVIEW": "Overview",
-      "GROUPS": "Groups",
-      "SETTINGS": "Settings",
-      "ORGANIZATIONS": "Organizations",
+      "GROUPS": "My groups",
+      "SETTINGS": "My settings",
+      "ORGANIZATIONS": "My organizations",
       "DETAIL": "Detail",
       "ATTRIBUTES": "Attributes",
       "FACILITY_ATTRIBUTES": "Facility attributes",
@@ -1337,8 +1340,10 @@
       },
       "USER_DETAIL": {
         "GROUPS": {
-          "MEMBER_GROUPS": "Groups where you are member",
-          "ADMINS_GROUPS": "Groups where you are admin"
+          "YOU_ARE_MEMBER": "Groups where you are member",
+          "YOU_ARE_ADMIN": "Groups where you are admin",
+          "USER_IS_MEMBER": "Groups where user is member",
+          "USER_IS_ADMIN": "Groups where user is admin"
         }
       },
       "HOSTS_LIST" : {
@@ -1448,8 +1453,10 @@
       "ORGANIZATIONS": {
         "TITLE": "User organizations",
         "FILTER": "Filter by name or ID",
-        "IS_ADMIN": "Organizations where you are admin",
-        "IS_MEMBER": "Organizations where you are member"
+        "YOU_ARE_ADMIN": "Organizations where you are admin",
+        "YOU_ARE_MEMBER": "Organizations where you are member",
+        "USER_IS_ADMIN": "Organizations where user is admin",
+        "USER_IS_MEMBER": "Organizations where user is member"
       },
       "GROUPS": {
         "MEMBER_GROUPS": "Member groups",

--- a/apps/admin-gui/src/assets/img/PerunWebImages/home-white.svg
+++ b/apps/admin-gui/src/assets/img/PerunWebImages/home-white.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16pt" height="16pt" viewBox="0 0 16 16" version="1.1">
+<g id="surface1">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 6.667969 13.332031 L 6.667969 9.332031 L 9.332031 9.332031 L 9.332031 13.332031 L 12.667969 13.332031 L 12.667969 8 L 14.667969 8 L 8 2 L 1.332031 8 L 3.332031 8 L 3.332031 13.332031 Z M 6.667969 13.332031 "/>
+</g>
+</svg>

--- a/libs/perun/services/src/lib/custom-icon.service.ts
+++ b/libs/perun/services/src/lib/custom-icon.service.ts
@@ -135,6 +135,10 @@ export class CustomIconService {
     {
       url: 'assets/img/PerunWebImages/host-blue.svg',
       name: 'perun-hosts'
+    },
+    {
+      url: 'assets/img/PerunWebImages/home-white.svg',
+      name: 'perun-home-white'
     }
   ];
 


### PR DESCRIPTION
resolves #273 
* fixed bug where users groups and VOs are not the ones from shown user but from principal
* when using user-organizations and user-groups components you have to add parameter to routing module (see  changed code), that determines if you want to show entities related to specified user or principal.
* changed home icon in side menu
* changed subTitles in Side-menu/Home (organizations => my organizations, ...)