### PR TITLE
Fixed height of the beta warning

### DIFF
--- a/apps/admin-gui/src/app/app.component.scss
+++ b/apps/admin-gui/src/app/app.component.scss
@@ -30,7 +30,7 @@
   overflow: hidden;
   height: 48px;
   position: fixed;
-  z-index: 999999;
+  z-index: 999;
   top: 0;
   background-color: rgb(255, 191, 197);
   width: 100%;


### PR DESCRIPTION
* The beta warning lvl was too height so the dialogs were partially
hidden behind it.