### PR TITLE
OIDC - configurable property load_user_info

### DIFF
--- a/apps/admin-gui/src/assets/config/defaultConfig.json
+++ b/apps/admin-gui/src/assets/config/defaultConfig.json
@@ -8,7 +8,8 @@
     "oauth_client_id": "411471d9-5e3d-48bd-9717-25f1fa634d20",
     "oauth_post_logout_redirect_uri": "",
     "oauth_redirect_uri": "http://gui-dev.org/api-callback",
-    "oauth_silent_redirect_uri": "http://gui-dev.org/silent-refresh.html"
+    "oauth_silent_redirect_uri": "http://gui-dev.org/silent-refresh.html",
+    "oauth_load_user_info": false
   },
   "login_namespace_attributes": [
     "urn:perun:user:attribute-def:def:login-namespace:einfra",

--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -43,7 +43,7 @@ export class AuthService {
       response_type: 'id_token token',
       scope: 'openid profile perun_api perun_admin',
       filterProtocolClaims: true,
-      loadUserInfo: true,
+      loadUserInfo: this.store.get('oidc_client', 'oauth_load_user_info'),
       automaticSilentRenew: true,
       silent_redirect_uri: this.store.get('oidc_client', 'oauth_silent_redirect_uri')
     };


### PR DESCRIPTION
* We need to be able to configure the loadUserInfo property of OIDC
because of SATOSA. Right now we do not actually need to load the user
info so it can be set to false by default.