### PR TITLE
Corrected probable error in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ng serve admin-gui --public-host=http://localhost:4200 --disable-host-check
 Command to serve the consolidator:
 
 ```shell script
-nx serve consolidator --disable-host-check --baseHref=/krb/nic/ --deployUrl=/krb/nic/ --publicHost=localhost:4200
+ng serve consolidator --disable-host-check --baseHref=/krb/nic/ --deployUrl=/krb/nic/ --publicHost=localhost:4200
 ```
 
 ## Apache config


### PR DESCRIPTION
In Readme,
The command for running  consolidator is as below:
**nx** serve consolidator --disable-host-check --baseHref=/krb/nic/ --deployUrl=/krb/nic/ --publicHost=localhost:4200

In my opinion, it should be:
**ng** serve consolidator --disable-host-check --baseHref=/krb/nic/ --deployUrl=/krb/nic/ --publicHost=localhost:4200
