### PR TITLE
Fix for Issue 330: group - members - search field too short 

### DIFF
--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.scss
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.scss
@@ -1,0 +1,3 @@
+.search-field {
+    width: 300px;
+}


### PR DESCRIPTION
Closes #330 .

Added css for search-field class in component scss file.

Files Changed: group-members.component.scss