### PR TITLE
Devel info

### DIFF
--- a/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.html
+++ b/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.html
@@ -16,6 +16,18 @@
   </a>
 </div>
 
+<div id="nav-devel-info" *ngIf="isDevel">
+  <span class="text-warning">
+    ~ 🗲&nbsp;
+  </span>
+  <span class="text-danger">
+    DEVEL
+  </span>
+  <span class="text-warning">
+    &nbsp;🗲 ~
+  </span>
+</div>
+
 <div id="nav-menu-user-info" [ngStyle]="{'color': navTextColor}">
   <button mat-icon-button (click)="showNotificationHistory()" [matTooltip]="'NAV.NOTIFICATIONS_TOOLTIP'|translate">
     <mat-icon [ngStyle]="{'color': iconColor}"

--- a/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.scss
+++ b/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.scss
@@ -5,6 +5,14 @@
   padding-right: 16px;
 }
 
+#nav-devel-info {
+  font-weight: 500;
+  font-size: 1.4rem;
+  display: flex;
+  align-items: center;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+}
+
 #nav-menu-icons {
   margin-left: 8px;
   display: flex;

--- a/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.ts
+++ b/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.ts
@@ -41,11 +41,13 @@ export class PerunNavComponent implements OnInit, AfterViewInit {
   principal: PerunPrincipal;
   logo: any;
   logoPadding = this.storeService.get('logo_padding');
+  isDevel = false;
 
   ngAfterViewInit(): void {
   }
 
   ngOnInit(): void {
+    this.isDevel = this.storeService.get('isDevel');
     this.logo = this.sanitizer.bypassSecurityTrustHtml(this.store.get('logo'));
     this.logoutEnabled = this.storeService.get('log_out_enabled');
   }

--- a/apps/admin-gui/src/assets/config/defaultConfig.json
+++ b/apps/admin-gui/src/assets/config/defaultConfig.json
@@ -1,6 +1,7 @@
 {
   "config": "default",
   "api_url": "http://localhost/krb/rpc",
+  "isDevel": false,
 
   "oidc_client" : {
     "oauth_authority": "https://login.cesnet.cz/oidc/",


### PR DESCRIPTION
* On devel instances, we need to be able to distinguish between
production and devel instances. To do this, it is now possible to set a
config boolean variable named `isDevel`. If this is set to true, info is
shown in the nav bar.

* Resolves #386 