### PR TITLE
Configurable oidc response type

### DIFF
--- a/apps/admin-gui/src/assets/config/defaultConfig.json
+++ b/apps/admin-gui/src/assets/config/defaultConfig.json
@@ -11,7 +11,8 @@
     "oauth_redirect_uri": "http://gui-dev.org/api-callback",
     "oauth_silent_redirect_uri": "http://gui-dev.org/silent-refresh.html",
     "oauth_load_user_info": false,
-    "oauth_scopes": "openid profile perun_api perun_admin"
+    "oauth_scopes": "openid profile perun_api perun_admin",
+    "oauth_response_type": "id_token token"
   },
   "login_namespace_attributes": [
     "urn:perun:user:attribute-def:def:login-namespace:einfra",

--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -40,7 +40,7 @@ export class AuthService {
       client_id: this.store.get('oidc_client', 'oauth_client_id'),
       redirect_uri: this.store.get('oidc_client', 'oauth_redirect_uri'),
       post_logout_redirect_uri: this.store.get('oidc_client', 'oauth_post_logout_redirect_uri'),
-      response_type: 'id_token token',
+      response_type: this.store.get('oidc_client', 'oauth_response_type'),
       scope: this.store.get('oidc_client', 'oauth_scopes'),
       filterProtocolClaims: true,
       loadUserInfo: this.store.get('oidc_client', 'oauth_load_user_info'),


### PR DESCRIPTION
* On some instances we need to be able to change the response type for
oidc.
* Response type is now loaded from the configuration.