### PR TITLE
BugFix - correct detection of not logged users

### DIFF
--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -77,7 +77,7 @@ export class AuthService {
 
   isLoggedInPromise(): Observable<boolean> {
     return from(this.manager.getUser()).pipe(map<User, boolean>((user) => {
-      return !!user;
+      return !!user && !user.expired;
     }));
   }
 


### PR DESCRIPTION
* The method isLoggedInPromise didn't check if the current user is
expired, only that it exists. Because of that, when some user expired
and refreshed the page, the application didn't notice that he has
expired and didn't force him to log in.