### PR TITLE
Initialization auth fix

### DIFF
--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1,8 +1,8 @@
 {
   "GENERAL": {
     "PRINCIPAL_ERROR": {
-      "TITLE": "Server down error",
-      "MESSAGE": "The server is probably being restarted. Please, try it again later.",
+      "TITLE": "Server error",
+      "MESSAGE": "The server is not responding, because it is probably being restarted. Please, try it again later.",
       "ACTION": "Refresh"
     },
     "PAGE_NOT_FOUND": {

--- a/libs/general/src/lib/server-down-dialog/server-down-dialog.component.html
+++ b/libs/general/src/lib/server-down-dialog/server-down-dialog.component.html
@@ -1,11 +1,11 @@
 <h2>
-  {{data.title}}
+  {{data.title | translate}}
 </h2>
 <p>
-  {{data.message}}
+  {{data.message | translate}}
 </p>
 <div>
   <button (click)="refresh()">
-    {{data.action}}
+    {{data.action | translate}}
   </button>
 </div>

--- a/libs/perun/services/src/lib/ApiInterceptor.ts
+++ b/libs/perun/services/src/lib/ApiInterceptor.ts
@@ -66,9 +66,10 @@ export class ApiInterceptor implements HttpInterceptor {
 
   private formatErrors(error: any, req: HttpRequest<any>) {
     let rpcError;
+    console.error(error);
     if (error.error.errorId) {
       rpcError = error.error;
-    } else {
+    } else if (error.errorId) {
       rpcError = JSON.parse(error.error) as RPCError;
     }
     if (rpcError === undefined) {

--- a/libs/perun/services/src/lib/init-auth.service.ts
+++ b/libs/perun/services/src/lib/init-auth.service.ts
@@ -53,4 +53,8 @@ export class InitAuthService {
         }
       });
   }
+
+  redirectToOriginDestination(): Promise<boolean> {
+    return this.authService.redirectToOriginDestination();
+  }
 }


### PR DESCRIPTION
* There were still some problems in the initialization of apps. If a
user somehow opened gui at the /api-callback page, it would not force
him to log in.
* The new implementation should detect such situations and redirect the
user to the oidc server to log in.
* Also, the Server down error should be now at least a bit smarter. It
should show the server down error if the response error status is '0'
which is returned if the server is down. Otherwise, it should show an
error message in the error that was thrown.