### PR TITLE
Move group bug fix

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/move-group-dialog/move-group-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/move-group-dialog/move-group-dialog.component.html
@@ -23,13 +23,16 @@
       <input
         matInput
         placeholder="{{'DIALOGS.MOVE_GROUP.GROUP_SELECT' | translate}}"
+        required
+        (change)="selectedGroup = null"
         [matAutocomplete]="groupSelectAutocomplete"
         [formControl]="otherGroupsCtrl">
       <!--suppress AngularInvalidExpressionResultType -->
       <mat-autocomplete
         #groupSelectAutocomplete="matAutocomplete"
         [displayWith]="displayFn">
-        <mat-option *ngFor="let group of filteredGroups | async" [value]="group">
+        <mat-option *ngFor="let group of filteredGroups | async" [value]="group"
+                    (click)="selectedGroup = group">
           <span>{{group.name}}</span>
         </mat-option>
       </mat-autocomplete>
@@ -39,18 +42,22 @@
   </mat-spinner>
   <div mat-dialog-actions>
     <button
-      mat-flat-button
       (click)="close()"
-      class="ml-auto">
+      class="ml-auto"
+      mat-flat-button>
       {{'DIALOGS.MOVE_GROUP.CANCEL' | translate}}
     </button>
-    <button
-      [disabled]="(!this.otherGroupsCtrl.value && moveOption !== 'toRoot') || loading"
-      mat-flat-button
-      class="ml-2"
-      (click)="confirm()"
-      color="accent">
+    <span matTooltip="{{'DIALOGS.MOVE_GROUP.DISABLED_HINT' | translate}}"
+          [matTooltipPosition]="'above'"
+          [matTooltipDisabled]="selectedGroup !== null || moveOption === 'toRoot'">
+      <button
+        (click)="confirm()"
+        [disabled]="((otherGroupsCtrl.invalid || selectedGroup === null) && moveOption !== 'toRoot') || loading"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
       {{'DIALOGS.MOVE_GROUP.CONFIRM' | translate}}
-    </button>
+      </button>
+    </span>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/move-group-dialog/move-group-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/move-group-dialog/move-group-dialog.component.ts
@@ -1,6 +1,6 @@
 import {Component, Inject, OnInit} from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import {FormControl} from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
 import {openClose} from '@perun-web-apps/perun/animations';
@@ -45,9 +45,11 @@ export class MoveGroupDialogComponent implements OnInit {
 
   otherGroups: Group[] = [];
   filteredGroups: Observable<Group[]>;
-  otherGroupsCtrl = new FormControl();
+  otherGroupsCtrl = new FormControl(null, [Validators.required]);
   moveOption: 'toGroup' | 'toRoot';
   loading = false;
+
+  selectedGroup: Group = null;
 
   ngOnInit() {
     this.loading = true;

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -753,7 +753,8 @@
       "NO_GROUP": "Move to the root",
       "TO_GROUP": "Move under a group",
       "ERROR": "Failed to move group",
-      "SUCCESS": "Group successfully moved"
+      "SUCCESS": "Group successfully moved",
+      "DISABLED_HINT": "You must select an existing group."
     },
     "CREATE_GROUP": {
       "TITLE": "Create group",

--- a/libs/perun/components/src/lib/group-menu/group-menu.component.html
+++ b/libs/perun/components/src/lib/group-menu/group-menu.component.html
@@ -16,17 +16,24 @@
     </mat-icon>
   </button>
 
-  <button (click)="onMoveGroup()" [matTooltipPosition]="'above'" mat-icon-button
-          matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.MOVE' | translate}}">
+  <button
+    (click)="onMoveGroup()"
+    [matTooltipPosition]="'above'"
+    [disabled]="disabled"
+    mat-icon-button
+    matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.MOVE' | translate}}">
     <mat-icon>arrow_right_alt</mat-icon>
   </button>
-  <button (click)="onChangeNameDescription()" [matTooltipPosition]="'above'"
-          mat-icon-button matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.RENAME' | translate}}">
+  <button
+    [disabled]="disabled"
+    (click)="onChangeNameDescription()"
+    [matTooltipPosition]="'above'"
+    mat-icon-button matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.RENAME' | translate}}">
     <mat-icon>text_format</mat-icon>
   </button>
 </div>
 <div *ngIf="!displayButtons">
-  <button [disabled]="disabled" [mat-menu-trigger-for]="groupMenu" mat-icon-button>
+  <button [mat-menu-trigger-for]="groupMenu" mat-icon-button>
     <mat-icon>more_vert</mat-icon>
   </button>
   <mat-menu #groupMenu="matMenu" >
@@ -45,11 +52,11 @@
       </mat-icon>
       <span>{{group | groupSyncToolTip | translate}}</span>
     </button>
-    <button (click)="onMoveGroup()" mat-menu-item>
+    <button (click)="onMoveGroup()" [disabled]="disabled" mat-menu-item>
       <mat-icon>arrow_right_alt</mat-icon>
       <span>{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.MOVE' | translate}}</span>
     </button>
-    <button (click)="onChangeNameDescription()" mat-menu-item>
+    <button (click)="onChangeNameDescription()" [disabled]="disabled" mat-menu-item>
       <mat-icon>text_format</mat-icon>
       <span>{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.RENAME' | translate}}</span>
     </button>


### PR DESCRIPTION
Resolves #413  and Resolves #414 

* disabled option to move 'members' group as it cannot be moved
* fix bug when moving group under non-existing one would move the group to top level