### PR TITLE
Resource list - height of rows

### DIFF
--- a/libs/perun/components/src/lib/resources-list/resources-list.component.scss
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.scss
@@ -2,10 +2,6 @@ table {
   width: 100% !important;
 }
 
-.mat-row {
-  height: auto;
-}
-
 .mat-cell {
   padding: 8px 8px 8px 0;
 }


### PR DESCRIPTION
Resolves#366

I found out that in resources-list.component.scss was one class 'mat-row' wrongly named and that caused that rows had smaller height than others lists. So I changed class name 'mat-row' to 'mat-row-height'.