### PR TITLE
Fixed NOT handling of errors in requests.

### DIFF
--- a/libs/perun/services/src/lib/ApiInterceptor.ts
+++ b/libs/perun/services/src/lib/ApiInterceptor.ts
@@ -47,22 +47,17 @@ export class ApiInterceptor implements HttpInterceptor {
       }
     });
 
-    // Also handle errors globally
-    return next.handle(req).pipe(
-      tap(x => {
-        // reset error handling only on API response
-        if (x.type !== 0){
-          this.apiRequestConfiguration.shouldHandleError();
-        }
+    // Also handle errors globally, if not disabled
+    const shouldHandleError = this.apiRequestConfiguration.shouldHandleError();
 
-        return x;
-        }, err => {
+    return next.handle(req).pipe(
+      tap(x => x, err => {
         // Handle this err
         const errRpc = this.formatErrors(err, req);
         if (errRpc === undefined) {
           return throwError(err);
         }
-        if (this.apiRequestConfiguration.shouldHandleError()) {
+        if (shouldHandleError) {
           this.notificator.showRPCError(errRpc);
         } else {
           return throwError(errRpc);


### PR DESCRIPTION
* There was a problem which might cause incorrect behaviour of the
service which can be used to disable global handling of notifications.
The problem was, that the information, if the request error should be
handled, was loaded AFTER the response was received. Now, this
information is loaded BEFORE the request is send.