### PR TITLE
Fixed async load of policies

### DIFF
--- a/apps/admin-gui/src/app/core/services/common/admin-gui-config.service.ts
+++ b/apps/admin-gui/src/app/core/services/common/admin-gui-config.service.ts
@@ -141,9 +141,12 @@ export class AdminGuiConfigService {
     throw err;
   }
 
-  private loadPolicies() {
+  private loadPolicies(): Promise<void> {
+    return new Promise((resolve, reject) => {
       this.authzSevice.getAllPolicies().subscribe( policies => {
         this.guiAuthResolver.setPerunPolicies(policies);
-      });
+        resolve();
+      }, error => reject(error));
+    });
   }
 }


### PR DESCRIPTION
* The policies were loaded asynchronously, which caused some
race-conditions. Sometimes the policies were not loaded when calling
isAuthorized methods.
* The initialization should now wait for the policies to be loaded.