### PR TITLE
Group tree view description

### DIFF
--- a/apps/admin-gui/src/styles.scss
+++ b/apps/admin-gui/src/styles.scss
@@ -1502,4 +1502,5 @@ th, td.mat-cell {
 //font size of tooltip
 .mat-tooltip {
   font-size: 14px !important;
+  word-wrap: break-word !important;
 }

--- a/libs/perun/components/src/lib/group-menu/group-menu.component.html
+++ b/libs/perun/components/src/lib/group-menu/group-menu.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="displayButtons" class="buttons-container">
-  <button [cdkCopyToClipboard]="group.name" [matTooltipPosition]="'above'" class="ml-auto"
+  <button [cdkCopyToClipboard]="group.name" [matTooltipPosition]="'above'" class="ml-auto horiz_right"
           mat-icon-button matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.COPY' | translate}}">
     <mat-icon>
       file_copy
@@ -7,11 +7,12 @@
   </button>
 
   <span [matTooltipPosition]="'above'"
-        [matTooltip]="group | groupSyncToolTip | translate">
+        [matTooltip]="group | groupSyncToolTip | translate"
+        *ngIf="syncAuth"
+        >
     <button (click)="onSyncDetail()"
             [disabled]="(group | groupSyncIcon) === 'sync_disabled'"
-            mat-icon-button
-            *ngIf="syncAuth">
+            mat-icon-button>
     <mat-icon class="{{group | groupSyncIconColor}}">
       {{group | groupSyncIcon}}
     </mat-icon>
@@ -19,29 +20,32 @@
   </span>
 
 
-  <button
-    *ngIf="moveAuth"
-    (click)="onMoveGroup()"
-    [matTooltipPosition]="'above'"
-    [disabled]="disabled"
-    mat-icon-button
-    matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.MOVE' | translate}}">
-    <mat-icon>arrow_right_alt</mat-icon>
-  </button>
-  <button
-    *ngIf="editAuth"
-    [disabled]="disabled"
-    (click)="onChangeNameDescription()"
-    [matTooltipPosition]="'above'"
-    mat-icon-button matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.RENAME' | translate}}">
-    <mat-icon>text_format</mat-icon>
-  </button>
+  <span [matTooltipPosition]="'above'"
+        matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.MOVE' | translate}}"
+        *ngIf="moveAuth">
+    <button
+      (click)="onMoveGroup()"
+      [disabled]="disabled"
+      mat-icon-button>
+      <mat-icon>arrow_right_alt</mat-icon>
+    </button>
+  </span>
+  <span [matTooltipPosition]="'above'"
+        matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_MENU.RENAME' | translate}}"
+        *ngIf="editAuth">
+    <button
+      [disabled]="disabled"
+      (click)="onChangeNameDescription()"
+      mat-icon-button>
+      <mat-icon>text_format</mat-icon>
+    </button>
+  </span>
 </div>
 <div *ngIf="!displayButtons">
   <button [mat-menu-trigger-for]="groupMenu" mat-icon-button>
     <mat-icon>more_vert</mat-icon>
   </button>
-  <mat-menu #groupMenu="matMenu" >
+  <mat-menu #groupMenu="matMenu">
     <button [cdkCopyToClipboard]="group.name" mat-menu-item>
       <mat-icon>
         file_copy

--- a/libs/perun/components/src/lib/group-menu/group-menu.component.scss
+++ b/libs/perun/components/src/lib/group-menu/group-menu.component.scss
@@ -1,3 +1,8 @@
 .buttons-container {
   white-space: nowrap;
+  width: 160px;
+}
+
+.horiz_right{
+  float: right;
 }

--- a/libs/perun/components/src/lib/groups-tree/groups-tree.component.html
+++ b/libs/perun/components/src/lib/groups-tree/groups-tree.component.html
@@ -22,8 +22,13 @@
             #{{group.id}}
           </span>
         </div>
-        <div class="w-50 text-muted description-text overflow-ellipsis" matTooltip="{{group.description}}" matTooltipPosition="before">
-          {{group.description}}
+        <div class="w-50 text-muted description-text" #nodeDescription>
+          <span
+            [matTooltipDisabled]="!isOverflowing(nodeDescription)"
+            matTooltip="{{group.description}}"
+            matTooltipPosition="before">
+            {{group.description}}
+          </span>
         </div>
       </div>
       <perun-web-apps-group-menu
@@ -65,8 +70,13 @@
             #{{group.id}}
           </span>
         </div>
-        <div class="w-50 text-muted description-text overflow-ellipsis" matTooltip="{{group.description}}" matTooltipPosition="before">
-          {{group.description}}
+        <div class="w-50 text-muted description-text" #rootDescription>
+          <span
+            [matTooltipDisabled]="!isOverflowing(rootDescription)"
+            matTooltip="{{group.description}}"
+            matTooltipPosition="before">
+            {{group.description}}
+          </span>
         </div>
       </div>
       <perun-web-apps-group-menu

--- a/libs/perun/components/src/lib/groups-tree/groups-tree.component.scss
+++ b/libs/perun/components/src/lib/groups-tree/groups-tree.component.scss
@@ -21,5 +21,7 @@ mat-tree-node {
   display: -webkit-box !important;
   -webkit-line-clamp: 1 !important;
   -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
   overflow: hidden;
+  white-space: nowrap;
 }

--- a/libs/perun/components/src/lib/groups-tree/groups-tree.component.ts
+++ b/libs/perun/components/src/lib/groups-tree/groups-tree.component.ts
@@ -248,4 +248,8 @@ export class GroupsTreeComponent implements OnChanges {
   onMoveGroup(group: GroupFlatNode) {
     this.moveGroup.emit(group);
   }
+
+  isOverflowing(el) {
+    return (el.offsetWidth < el.scrollWidth);
+  }
 }


### PR DESCRIPTION
Resolves #540 

* description text is now shown in tooltip only if description is too  long
* made group menu buttons always visible but disabled according to user rights to fix description offset caused by non constant 
   number of  buttons shown