### PR TITLE
Groups tree optimization

### DIFF
--- a/apps/admin-gui/src/styles.scss
+++ b/apps/admin-gui/src/styles.scss
@@ -1514,3 +1514,8 @@ th, td.mat-cell {
 .mat-tab-icon {
   font-size: 16px !important;
 }
+
+// hack to make the content of the virtual scroll be limited by its width
+.cdk-virtual-scroll-content-wrapper {
+  contain: size !important;
+}

--- a/libs/perun/components/src/lib/groups-tree/groups-tree.component.html
+++ b/libs/perun/components/src/lib/groups-tree/groups-tree.component.html
@@ -1,94 +1,66 @@
 <div class="card mt-2" *ngIf="filteredGroups.length !== 0">
-  <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
-    <mat-tree-node class="group-tree-node"
-                   *matTreeNodeDef="let group" matTreeNodePadding>            <!--leaf-->
-      <div class="group-item-content"
-           [routerLink]="disableRouting ? null : ['/organizations', group.voId, 'groups', group.id]"
-           [perunWebAppsMiddleClickRouterLink]="disableRouting ? null : ['/organizations', group.voId, 'groups', group.id]">
+  <cdk-virtual-scroll-viewport
+    class="virtual-scroll-container"
+    itemSize="48"
+    #scrollViewport
+    [minBufferPx]="48 * 5"
+    [maxBufferPx]="48 * 10"
+    [ngStyle]="{'height' : getTreeViewHeight()}">
+    <ng-container *cdkVirtualFor="let group of dataSource">
+      <!-- Note that the [style.padding-left] is essentially what cdkTreeNodePadding is doing under the hood -->
+      <div class="node" [style.padding-left]="group.level * 24 + 'px'">
+        <!-- Note that treeControl.toggle(node) is essentially what cdkTreeNodeToggle is doing under the hood -->
         <mat-checkbox color="primary"
                       *ngIf="!hideCheckbox"
-                      [disabled]="group.fullName === 'members'"
                       class="no-label-margin-bottom ml-4"
+                      [disabled]="group.fullName === 'members'"
                       [checked]="selection.isSelected(group)"
-                      (change)="leafItemSelectionToggle(group)"
-                      matTreeNodeToggle></mat-checkbox>
-        <!-- use a disabled button to provide padding for tree leaf -->
-        <button mat-icon-button disabled></button>
-        <div class="w-50">
+                      [indeterminate]="descendantsPartiallySelected(group)"
+                      (change)="itemSelectionToggle(group)"
+                      ></mat-checkbox>
+        <div
+          class="group-item-content"
+          [routerLink]="disableRouting ? null :['/organizations', group.voId, 'groups', group.id]"
+          [perunWebAppsMiddleClickRouterLink]="disableRouting ? null :['/organizations', group.voId, 'groups', group.id]">
+          <button mat-icon-button
+                  (mouseenter)="disableRouting = true"
+                  (mouseleave)="disableRouting = false"
+                  [disabled]="!group.expandable"
+                  (click)="treeControl.toggle(group)"
+                  [attr.aria-label]="'toggle ' + group.name">
+            <mat-icon class="mat-icon-rtl-mirror" *ngIf="group.expandable">
+              {{treeControl.isExpanded(group) ? 'expand_more' : 'chevron_right'}}
+            </mat-icon>
+          </button>
+          <div class="w-50">
           <span class="mr-2">
             {{group.name}}
           </span>
-          <span *ngIf="authResolver.isPerunAdmin()" class="text-muted">
+            <span *ngIf="authResolver.isPerunAdmin()" class="text-muted">
             #{{group.id}}
           </span>
-        </div>
-        <div class="w-50 text-muted description-text" #nodeDescription>
+          </div>
+          <div class="w-50 text-muted description-text" #rootDescription>
           <span
-            [matTooltipDisabled]="!isOverflowing(nodeDescription)"
             matTooltip="{{group.description}}"
             matTooltipPosition="before">
             {{group.description}}
           </span>
+          </div>
+        </div>
+        <div class="group-buttons">
+          <perun-web-apps-group-menu
+            [disabled]="group.fullName === 'members'"
+            (moveGroup)="onMoveGroup(group)"
+            (syncGroup)="onSyncDetail(group)"
+            (changeNameDescription)="onChangeNameDescription(group)"
+            [displayButtons]="displayButtons"
+            [group]="group">
+          </perun-web-apps-group-menu>
         </div>
       </div>
-      <perun-web-apps-group-menu
-        [disabled]="group.fullName === 'members'"
-        (moveGroup)="onMoveGroup(group)"
-        (changeNameDescription)="onChangeNameDescription(group)"
-        (syncGroup)="onSyncDetail(group)"
-        [displayButtons]="displayButtons"
-        [group]="group">
-      </perun-web-apps-group-menu>
-    </mat-tree-node>
-
-    <mat-tree-node
-      class="group-tree-node"
-      *matTreeNodeDef="let group;when: hasChild" matTreeNodePadding> <!--parent-->
-      <mat-checkbox color="primary"
-                    *ngIf="!hideCheckbox"
-                    class="no-label-margin-bottom ml-4"
-                    [disabled]="group.fullName === 'members'"
-                    [checked]="selection.isSelected(group)"
-                    [indeterminate]="descendantsPartiallySelected(group)"
-                    (change)="itemSelectionToggle(group)"
-                    matTreeNodeToggle></mat-checkbox>
-      <div
-        class="group-item-content"
-        [routerLink]="disableRouting ? null :['/organizations', group.voId, 'groups', group.id]"
-        [perunWebAppsMiddleClickRouterLink]="disableRouting ? null :['/organizations', group.voId, 'groups', group.id]">
-        <button mat-icon-button matTreeNodeToggle
-                [attr.aria-label]="'toggle ' + group.name">
-          <mat-icon class="mat-icon-rtl-mirror">
-            {{treeControl.isExpanded(group) ? 'expand_more' : 'chevron_right'}}
-          </mat-icon>
-        </button>
-        <div class="w-50">
-          <span class="mr-2">
-            {{group.name}}
-          </span>
-          <span *ngIf="authResolver.isPerunAdmin()" class="text-muted">
-            #{{group.id}}
-          </span>
-        </div>
-        <div class="w-50 text-muted description-text" #rootDescription>
-          <span
-            [matTooltipDisabled]="!isOverflowing(rootDescription)"
-            matTooltip="{{group.description}}"
-            matTooltipPosition="before">
-            {{group.description}}
-          </span>
-        </div>
-      </div>
-      <perun-web-apps-group-menu
-        [disabled]="group.fullName === 'members'"
-        (moveGroup)="onMoveGroup(group)"
-        (syncGroup)="onSyncDetail(group)"
-        (changeNameDescription)="onChangeNameDescription(group)"
-        [displayButtons]="displayButtons"
-        [group]="group">
-      </perun-web-apps-group-menu>
-    </mat-tree-node>
-  </mat-tree>
+    </ng-container>
+  </cdk-virtual-scroll-viewport>
 </div>
 
 <app-alert *ngIf="filteredGroups.length === 0" alert_type="warn">

--- a/libs/perun/components/src/lib/groups-tree/groups-tree.component.scss
+++ b/libs/perun/components/src/lib/groups-tree/groups-tree.component.scss
@@ -25,3 +25,24 @@ mat-tree-node {
   overflow: hidden;
   white-space: nowrap;
 }
+
+.virtual-scroll-container {
+  overflow: auto;
+}
+
+cdk-tree-node {
+  display: block;
+}
+
+.node {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  flex: 1;
+  word-wrap: break-word;
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, .05);
+  }
+}

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -66,6 +66,7 @@ import { MemberSearchSelectComponent } from './member-search-select/member-searc
 import { FacilitySearchSelectComponent } from './facility-search-select/facility-search-select.component';
 import { UserSearchSelectComponent } from './user-search-select/user-search-select.component';
 import { ExpirationSelectComponent } from './expiration-select/expiration-select.component';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @Injectable()
 export class AppDateAdapter extends NativeDateAdapter {
@@ -126,7 +127,8 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     MatRadioModule,
     MatOptionModule,
     MatSelectModule,
-    NgxMatSelectSearchModule
+    NgxMatSelectSearchModule,
+    ScrollingModule
   ],
   declarations: [
     VoSelectTableComponent,


### PR DESCRIPTION
* The tree view of groups was not optimized for a large number of
groups. With the number of groups being high (e.g. 1000) the whole
application would lag and freeze.
* The tree view component has been reworked so it uses a virtual scoll.
This improves the performance by a lot. I have tested this changes on a
vo with 3000 groups and it works much better.
* I have also removed the check that the group description is shown only
if it doesn't fit. This check caused some errors because it used native
html properties to detect this. Also, this way the behaviour is more
consistent.