### PR TITLE
Search select rework

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/application-form-copy-items-dialog/application-form-copy-items-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/application-form-copy-items-dialog/application-form-copy-items-dialog.component.html
@@ -17,6 +17,7 @@
     <perun-web-apps-group-search-select
       class="long-input"
       [groups]="groups"
+      [disableAutoSelect]="true"
       (groupSelected)="selectedGroup = ($event)">
     </perun-web-apps-group-search-select>
   </div>
@@ -32,7 +33,7 @@
       mat-flat-button
       class="ml-2"
       color="accent"
-      [disabled]="!selectedVo || !selectedGroup || loading"
+      [disabled]="(!selectedVo && !selectedGroup) || loading"
       (click)="submit()">
       {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.SUBMIT_BUTTON' | translate}}
     </button>

--- a/apps/admin-gui/src/app/shared/components/dialogs/application-form-copy-items-dialog/application-form-copy-items-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/application-form-copy-items-dialog/application-form-copy-items-dialog.component.ts
@@ -27,9 +27,8 @@ export class ApplicationFormCopyItemsDialogComponent implements OnInit {
 
   vos: Vo[] = [];
   groups: Group[] = [];
-  fakeGroup: Group;
   selectedVo: Vo;
-  selectedGroup: Group;
+  selectedGroup: Group = null;
   privilegeMessage: string;
   noFormMessage: string;
   theme: string;
@@ -48,19 +47,12 @@ export class ApplicationFormCopyItemsDialogComponent implements OnInit {
     translateService.get('DIALOGS.APPLICATION_FORM_COPY_ITEMS.NO_FORM').subscribe(res => this.noFormMessage = res);
   }
 
+  nameFunction = (group: Group) => group.name;
+
   ngOnInit() {
     this.loading = true;
     this.theme = this.data.theme;
     this.translateService.get('DIALOGS.APPLICATION_FORM_COPY_ITEMS.NO_GROUP_SELECTED').subscribe( text => {
-      this.fakeGroup = {
-        id: -1,
-        name: text,
-        voId: 0,
-        parentGroupId: 0,
-        shortName: '',
-        description: '',
-        beanName: 'Group'
-      };
 
       this.voService.getMyVos().subscribe(vos => {
 
@@ -88,7 +80,7 @@ export class ApplicationFormCopyItemsDialogComponent implements OnInit {
     this.apiRequest.dontHandleErrorForNext();
     this.loading = true;
     if (this.data.groupId) { // checking if the dialog is for group or Vo
-      if (this.selectedGroup === this.fakeGroup) {   // no group selected
+      if (this.selectedGroup === null) {   // no group selected
         this.registrarManager.copyFormFromVoToGroup(this.selectedVo.id, this.data.groupId).subscribe(() => {
           this.notificatorService.showSuccess(this.successMessage);
           this.dialogRef.close(true);
@@ -116,7 +108,7 @@ export class ApplicationFormCopyItemsDialogComponent implements OnInit {
         });
       }
     } else {
-      if (this.selectedGroup === this.fakeGroup) {       // no group selected
+      if (this.selectedGroup === null) {       // no group selected
         this.registrarManager.copyFormFromVoToVo(this.selectedVo.id, this.data.voId).subscribe(() => {
           this.notificatorService.showSuccess(this.successMessage);
           this.dialogRef.close(true);
@@ -154,12 +146,12 @@ export class ApplicationFormCopyItemsDialogComponent implements OnInit {
   getGroups() {
     if (this.selectedVo !== undefined) {
       this.groupService.getAllGroups(this.selectedVo.id).subscribe(groups => {
-        this.groups = [this.fakeGroup].concat(groups);
+        this.groups = groups;
       });
     } else {
-      this.groups = [this.fakeGroup];
+      this.groups = [];
     }
-    this.selectedGroup = this.fakeGroup;
+    this.selectedGroup = null;
   }
 
 }

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-group-dialog/create-group-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-group-dialog/create-group-dialog.component.html
@@ -37,6 +37,7 @@
       <perun-web-apps-group-search-select
         *ngIf="asSubgroup"
         class="long-input"
+        [disableAutoSelect]="true"
         [groups]="voGroups"
         (groupSelected)="selectedParent = $event">
       </perun-web-apps-group-search-select>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-group-dialog/create-group-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-group-dialog/create-group-dialog.component.ts
@@ -54,6 +54,7 @@ export class CreateGroupDialogComponent implements OnInit{
 
   successMessage: string;
   successSubGroupMessage: string;
+  nameFunction = (group: Group) => group.name;
 
   ngOnInit() {
     this.theme = this.data.theme;

--- a/apps/admin-gui/src/app/shared/components/dialogs/notifications-copy-mails-dialog/notifications-copy-mails-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/notifications-copy-mails-dialog/notifications-copy-mails-dialog.component.html
@@ -17,6 +17,7 @@
     <perun-web-apps-group-search-select
       class="long-input"
       [groups]="groups"
+      [disableAutoSelect]="true"
       (groupSelected)="selectedGroup = ($event)">
     </perun-web-apps-group-search-select>
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/notifications-copy-mails-dialog/notifications-copy-mails-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/notifications-copy-mails-dialog/notifications-copy-mails-dialog.component.ts
@@ -43,6 +43,7 @@ export class NotificationsCopyMailsDialogComponent implements OnInit {
   selectedGroup: Group = null;
   theme: string;
   loading = false;
+  nameFunction = (group: Group) => group.name;
 
   ngOnInit() {
     this.theme = this.data.theme;

--- a/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.html
@@ -3,36 +3,36 @@
   <app-alert *ngIf="entityValues.length === 0 && !loading" alert_type="warn">{{noEntityMessage}}</app-alert>
 
   <div *ngIf="entityValues.length !== 0">
-    <div class="flex-row w-35">
-    <perun-web-apps-group-search-select
-      *ngIf="secondEntity === 'group'"
-      [groups]="entityValues"
-      (groupSelected)="specifySecondEntity($event)">
-    </perun-web-apps-group-search-select>
+    <div class="flex-row">
+      <perun-web-apps-group-search-select
+        *ngIf="secondEntity === 'group'"
+        [groups]="entityValues"
+        (groupSelected)="specifySecondEntity($event)">
+      </perun-web-apps-group-search-select>
 
-    <perun-web-apps-resource-search-select
-      *ngIf="secondEntity === 'resource'"
-      [resources]="entityValues"
-      (resourceSelected)="specifySecondEntity($event)">
-    </perun-web-apps-resource-search-select>
+      <perun-web-apps-resource-search-select
+        *ngIf="secondEntity === 'resource'"
+        [resources]="entityValues"
+        (resourceSelected)="specifySecondEntity($event)">
+      </perun-web-apps-resource-search-select>
 
-    <perun-web-apps-member-search-select
-      *ngIf="secondEntity === 'member'"
-      [members]="entityValues"
-      (memberSelected)="specifySecondEntity($event)">
-    </perun-web-apps-member-search-select>
+      <perun-web-apps-member-search-select
+        *ngIf="secondEntity === 'member'"
+        [members]="entityValues"
+        (memberSelected)="specifySecondEntity($event)">
+      </perun-web-apps-member-search-select>
 
-    <perun-web-apps-facility-search-select
-      *ngIf="secondEntity === 'facility'"
-      [facilities]="entityValues"
-      (facilitySelected)="specifySecondEntity($event)">
-    </perun-web-apps-facility-search-select>
+      <perun-web-apps-facility-search-select
+        *ngIf="secondEntity === 'facility'"
+        [facilities]="entityValues"
+        (facilitySelected)="specifySecondEntity($event)">
+      </perun-web-apps-facility-search-select>
 
-    <perun-web-apps-user-search-select
-      *ngIf="secondEntity === 'user'"
-      [users]="entityValues"
-      (userSelected)="specifySecondEntity($event)">
-    </perun-web-apps-user-search-select>
+      <perun-web-apps-user-search-select
+        *ngIf="secondEntity === 'user'"
+        [users]="entityValues"
+        (userSelected)="specifySecondEntity($event)">
+      </perun-web-apps-user-search-select>
     </div>
 
     <perun-web-apps-refresh-button (refresh)="getAttributes(specificSecondEntity.id)"></perun-web-apps-refresh-button>

--- a/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.ts
+++ b/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.ts
@@ -15,6 +15,7 @@ import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { EditAttributeDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { CreateAttributeDialogComponent } from '../dialogs/create-attribute-dialog/create-attribute-dialog.component';
 import { MembersService } from '@perun-web-apps/perun/services';
+import { Urns } from '@perun-web-apps/perun/urns';
 
 @Component({
   selector: 'app-two-entity-attribute-page',
@@ -92,7 +93,8 @@ export class TwoEntityAttributePageComponent implements OnInit {
             });
             break;
           case 'member':
-            this.membersManagerService.getCompleteRichMembersForGroup(this.firstEntityId, []).subscribe(members => {
+            // return one attribute because if an empty list is passed, all attributes are returned
+            this.membersManagerService.getCompleteRichMembersForGroup(this.firstEntityId, [Urns.MEMBER_CORE_ID]).subscribe(members => {
               this.entityValues = members;
               this.preselectEntity();
               this.loading = false;

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2067,7 +2067,7 @@
         "GROUP_SEARCH_SELECT": {
           "SELECT_GROUP": "Select group",
           "FIND_GROUP": "Find group...",
-          "NO_GROUP_FOUND": "No matching found"
+          "NO_GROUP_FOUND": "No matching group found"
         },
         "VO_SELECT_TABLE": {
           "ID": "Id",

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.css
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.css
@@ -1,0 +1,4 @@
+.selected-options-bottom {
+  visibility: hidden;
+  position: absolute;
+}

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.html
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.html
@@ -1,0 +1,30 @@
+<mat-form-field class="w-100">
+  <mat-select
+    (openedChange)="openChange($event)"
+    placeholder="{{selectPlaceholder}}"
+    [formControl]="entitiesCtrl">
+    <mat-option>
+      <ngx-mat-select-search
+
+        placeholderLabel="{{findPlaceholder}}"
+        noEntriesFoundLabel="{{noEntriesText}}"
+        [clearSearchInput]="false"
+        [formControl]="entityFilterCtrl">
+      </ngx-mat-select-search>
+    </mat-option>
+    <mat-option class="selected-options-bottom" *ngIf="entitiesCtrl?.value" [value]="entitiesCtrl?.value">
+      {{mainTextFunction(entitiesCtrl?.value)}} <span class="text-muted muted">{{secondaryTextFunction(entitiesCtrl?.value)}}</span>
+    </mat-option>
+    <cdk-virtual-scroll-viewport
+      itemSize="48"
+      [style.height.px]="getViewportHeight()"
+      #scrollViewport
+      [minBufferPx]="5 * 48"
+      [maxBufferPx]="10 * 48">
+      <mat-option *cdkVirtualFor="let entity of filteredEntities | async" [value]="entity">
+        {{mainTextFunction(entity)}} <span class="text-muted muted">{{secondaryTextFunction(entity)}}</span>
+      </mat-option>
+    </cdk-virtual-scroll-viewport>
+  </mat-select>
+</mat-form-field>
+

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.spec.ts
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EntitySearchSelectComponent } from './entity-search-select.component';
+
+describe('EntitySearchSelectComponent', () => {
+  let component: EntitySearchSelectComponent;
+  let fixture: ComponentFixture<EntitySearchSelectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EntitySearchSelectComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EntitySearchSelectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.ts
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.ts
@@ -1,0 +1,141 @@
+import {
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
+import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { FormControl } from '@angular/forms';
+import { ReplaySubject, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { PerunBean } from '@perun-web-apps/perun/openapi';
+import { stringify } from 'querystring';
+
+@Component({
+  selector: 'perun-web-apps-entity-search-select',
+  templateUrl: './entity-search-select.component.html',
+  styleUrls: ['./entity-search-select.component.css']
+})
+export class EntitySearchSelectComponent<T extends PerunBean> implements OnInit, OnChanges, OnDestroy {
+
+  constructor(
+    public cd: ChangeDetectorRef,
+  ) { }
+
+  @Input()
+  entities: T[];
+
+  @Input()
+  selectPlaceholder = 'Select';
+
+  @Input()
+  findPlaceholder = 'Find...';
+
+  @Input()
+  noEntriesText = 'Nothing found';
+
+  @Input()
+  disableAutoSelect = false;
+
+  @Output()
+  entitySelected = new EventEmitter<T>();
+
+  @ViewChild('scrollViewport', {static: false})
+  scrollViewport: CdkVirtualScrollViewport;
+
+  entitiesCtrl: FormControl = new FormControl();
+  entityFilterCtrl: FormControl = new FormControl();
+  filteredEntities = new ReplaySubject<T[]>(1);
+
+  private entitiesLen = 0;
+
+  protected _onDestroy = new Subject<void>();
+
+  @Input()
+  searchFunction: (entity: T) => string;
+
+  @Input()
+  mainTextFunction: (entity: T) => string = entity => stringify(entity);
+
+  @Input()
+  secondaryTextFunction: (entity: T) => string = entity => '#' + entity.id;
+
+
+  ngOnInit(): void {
+    this.entitiesCtrl.valueChanges.subscribe(user => this.entitySelected.emit(user));
+
+    if (!this.disableAutoSelect) {
+      this.entitiesCtrl.setValue(this.entities[0]);
+    }
+
+    this.filteredEntities.subscribe((entities) => this.entitiesLen = entities.length);
+
+    this.entityFilterCtrl.valueChanges
+      .pipe(takeUntil(this._onDestroy))
+      .subscribe(() => {
+        this.filterEntites();
+      });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!!changes['entities']) {
+
+      this.filteredEntities.next(this.entities.slice());
+    }
+  }
+
+  ngOnDestroy() {
+    this._onDestroy.next();
+    this._onDestroy.complete();
+  }
+
+  private filterEntites() {
+    if (!this.entities) {
+      return;
+    }
+    // get the search keyword
+    let search = this.entityFilterCtrl.value;
+    if (!search) {
+      this.filteredEntities.next(this.entities.slice());
+      this.cd.detectChanges();
+      return;
+    } else {
+      search = this.normalize(search);
+    }
+    // filter the banks
+    this.filteredEntities.next(
+      this.entities.filter(entity => this.normalize(this.searchFunction(entity)).indexOf(search) >=0)
+    );
+    this.cd.detectChanges();
+  }
+
+  /**
+   * Transforms given string to ASCII and lower case
+   * @param data
+   */
+  normalize(data: string): string {
+    return data.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+  }
+
+  openChange($event: boolean) {
+    this.scrollViewport.scrollToIndex(0);
+    this.scrollViewport.checkViewportSize();
+  }
+
+  getViewportHeight() {
+    let height = this.entitiesLen * 48;
+    if (height > 192) {
+      height = 192;
+    }
+    if (!!this.scrollViewport) {
+      this.scrollViewport.checkViewportSize();
+    }
+    return height;
+  }
+}

--- a/libs/perun/components/src/lib/facility-search-select/facility-search-select.component.html
+++ b/libs/perun/components/src/lib/facility-search-select/facility-search-select.component.html
@@ -1,17 +1,9 @@
-<mat-form-field class="w-100">
-  <mat-select
-    placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.FACILITY_SEARCH_SELECT.SELECT_FACILITY' | translate}}"
-    [formControl]="facilityCtrl">
-    <mat-option>
-      <ngx-mat-select-search
-        placeholderLabel="{{'SHARED_LIB.PERUN.COMPONENTS.FACILITY_SEARCH_SELECT.FIND_FACILITY' | translate}}"
-        noEntriesFoundLabel="{{'SHARED_LIB.PERUN.COMPONENTS.FACILITY_SEARCH_SELECT.NO_FACILITY_FOUND' | translate}}"
-        [formControl]="facilityFilterCtrl">
-      </ngx-mat-select-search>
-    </mat-option>
-    <mat-option *ngFor="let facility of filteredFacilities | async" [value]="facility">
-      {{facility.name}}
-    </mat-option>
-  </mat-select>
-</mat-form-field>
-
+<perun-web-apps-entity-search-select
+  [entities]="facilities"
+  (entitySelected)="this.facilitySelected.emit($event)"
+  [searchFunction]="nameFunction"
+  [mainTextFunction]="nameFunction"
+  [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.FACILITY_SEARCH_SELECT.SELECT_FACILITY' | translate"
+  [findPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.FACILITY_SEARCH_SELECT.FIND_FACILITY' | translate"
+  [noEntriesText]="'SHARED_LIB.PERUN.COMPONENTS.FACILITY_SEARCH_SELECT.NO_FACILITY_FOUND' | translate">
+</perun-web-apps-entity-search-select>

--- a/libs/perun/components/src/lib/facility-search-select/facility-search-select.component.ts
+++ b/libs/perun/components/src/lib/facility-search-select/facility-search-select.component.ts
@@ -1,16 +1,12 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Facility } from '@perun-web-apps/perun/openapi';
-import { FormControl } from '@angular/forms';
-import { ReplaySubject, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'perun-web-apps-facility-search-select',
   templateUrl: './facility-search-select.component.html',
   styleUrls: ['./facility-search-select.component.css']
 })
-export class FacilitySearchSelectComponent implements OnInit, OnChanges, OnDestroy {
-
+export class FacilitySearchSelectComponent {
 
   constructor() { }
 
@@ -19,50 +15,5 @@ export class FacilitySearchSelectComponent implements OnInit, OnChanges, OnDestr
 
   @Output()
   facilitySelected = new EventEmitter<Facility>();
-
-  facilityCtrl: FormControl = new FormControl();
-  facilityFilterCtrl: FormControl = new FormControl();
-  filteredFacilities = new ReplaySubject<Facility[]>(1);
-
-  protected _onDestroy = new Subject<void>();
-
-  ngOnInit(): void {
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    this.filteredFacilities.next(this.facilities.slice());
-
-    this.facilityCtrl.setValue(this.facilities[0]);
-
-    this.facilityCtrl.valueChanges.subscribe(resource => this.facilitySelected.emit(resource));
-
-    this.facilityFilterCtrl.valueChanges
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe(() => {
-        this.filterFacilities();
-      });
-  }
-
-  ngOnDestroy() {
-    this._onDestroy.next();
-    this._onDestroy.complete();
-  }
-
-  private filterFacilities() {
-    if (!this.facilities) {
-      return;
-    }
-    // get the search keyword
-    let search = this.facilityFilterCtrl.value;
-    if (!search) {
-      this.filteredFacilities.next(this.facilities.slice());
-      return;
-    } else {
-      search = search.toLowerCase();
-    }
-    // filter the banks
-    this.filteredFacilities.next(
-      this.facilities.filter(option => option.name.toLowerCase().indexOf(search) >=0)
-    );
-  }
+  nameFunction = (facility: Facility) => facility.name;
 }

--- a/libs/perun/components/src/lib/group-search-select/group-search-select.component.html
+++ b/libs/perun/components/src/lib/group-search-select/group-search-select.component.html
@@ -1,16 +1,11 @@
-<mat-form-field class="w-100">
-  <mat-select
-    placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_SEARCH_SELECT.SELECT_GROUP' | translate}}"
-    [formControl]="groupCtrl">
-    <mat-option>
-      <ngx-mat-select-search
-        placeholderLabel="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_SEARCH_SELECT.FIND_GROUP' | translate}}"
-        noEntriesFoundLabel="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_SEARCH_SELECT.NO_GROUP_FOUND' | translate}}"
-        [formControl]="groupFilterCtrl">
-      </ngx-mat-select-search>
-    </mat-option>
-    <mat-option *ngFor="let grp of filteredGroups | async" [value]="grp">
-      {{grp.name}}
-    </mat-option>
-  </mat-select>
-</mat-form-field>
+<perun-web-apps-entity-search-select
+  class="long-input"
+  [entities]="groups"
+  (entitySelected)="this.groupSelected.emit($event)"
+  [disableAutoSelect]="disableAutoSelect"
+  [mainTextFunction]="nameFunction"
+  [searchFunction]="nameFunction"
+  [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.GROUP_SEARCH_SELECT.SELECT_GROUP' | translate"
+  [findPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.GROUP_SEARCH_SELECT.FIND_GROUP' | translate"
+  [noEntriesText]="'SHARED_LIB.PERUN.COMPONENTS.GROUP_SEARCH_SELECT.NO_GROUP_FOUND' | translate">
+</perun-web-apps-entity-search-select>

--- a/libs/perun/components/src/lib/group-search-select/group-search-select.component.ts
+++ b/libs/perun/components/src/lib/group-search-select/group-search-select.component.ts
@@ -1,15 +1,12 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Group } from '@perun-web-apps/perun/openapi';
-import { FormControl } from '@angular/forms';
-import { ReplaySubject, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'perun-web-apps-group-search-select',
   templateUrl: './group-search-select.component.html',
   styleUrls: ['./group-search-select.component.css']
 })
-export class GroupSearchSelectComponent implements OnInit, OnChanges, OnDestroy {
+export class GroupSearchSelectComponent {
 
   @Input()
   groups: Group[];
@@ -17,50 +14,8 @@ export class GroupSearchSelectComponent implements OnInit, OnChanges, OnDestroy 
   @Output()
   groupSelected = new EventEmitter<Group>();
 
-  groupCtrl: FormControl = new FormControl();
-  groupFilterCtrl: FormControl = new FormControl();
-  filteredGroups = new ReplaySubject<Group[]>(1);
+  @Input()
+  disableAutoSelect = false;
 
-  protected _onDestroy = new Subject<void>();
-
-  ngOnInit(): void {
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    this.filteredGroups.next(this.groups.slice());
-
-    this.groupCtrl.setValue(this.groups[0]);
-
-    this.groupCtrl.valueChanges.subscribe(grp => this.groupSelected.emit(grp));
-
-    this.groupFilterCtrl.valueChanges
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe(() => {
-        this.filterGroups();
-      });
-  }
-
-  ngOnDestroy() {
-    this._onDestroy.next();
-    this._onDestroy.complete();
-  }
-
-  private filterGroups() {
-    if (!this.groups) {
-      return;
-    }
-    // get the search keyword
-    let search = this.groupFilterCtrl.value;
-    if (!search) {
-      this.filteredGroups.next(this.groups.slice());
-      return;
-    } else {
-      search = search.toLowerCase();
-    }
-    // filter the banks
-    this.filteredGroups.next(
-      this.groups.filter(option => option.name.toLowerCase().indexOf(search) >=0)
-    );
-  }
-
+  nameFunction = (group: Group) => group.name;
 }

--- a/libs/perun/components/src/lib/member-search-select/member-search-select.component.html
+++ b/libs/perun/components/src/lib/member-search-select/member-search-select.component.html
@@ -1,17 +1,9 @@
-<mat-form-field class="w-100">
-  <mat-select
-    placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_SEARCH_SELECT.SELECT_MEMBER' | translate}}"
-    [formControl]="memberCtrl">
-    <mat-option>
-      <ngx-mat-select-search
-        placeholderLabel="{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_SEARCH_SELECT.FIND_MEMBER' | translate}}"
-        noEntriesFoundLabel="{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_SEARCH_SELECT.NO_MEMBER_FOUND' | translate}}"
-        [formControl]="memberFilterCtrl">
-      </ngx-mat-select-search>
-    </mat-option>
-    <mat-option *ngFor="let member of filteredMembers | async" [value]="member">
-      {{member.user | userFullName}} <span class="text-muted muted">#{{member.id}}</span>
-    </mat-option>
-  </mat-select>
-</mat-form-field>
-
+<perun-web-apps-entity-search-select
+  [entities]="members"
+  (entitySelected)="this.memberSelected.emit($event)"
+  [searchFunction]="memberFullNameFunction"
+  [mainTextFunction]="memberFullNameFunction"
+  [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.MEMBER_SEARCH_SELECT.SELECT_MEMBER' | translate"
+  [findPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.MEMBER_SEARCH_SELECT.FIND_MEMBER' | translate"
+  [noEntriesText]="'SHARED_LIB.PERUN.COMPONENTS.MEMBER_SEARCH_SELECT.NO_MEMBER_FOUND' | translate">
+</perun-web-apps-entity-search-select>

--- a/libs/perun/components/src/lib/member-search-select/member-search-select.component.ts
+++ b/libs/perun/components/src/lib/member-search-select/member-search-select.component.ts
@@ -1,8 +1,5 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { RichMember } from '@perun-web-apps/perun/openapi';
-import { FormControl } from '@angular/forms';
-import { ReplaySubject, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { parseFullName } from '@perun-web-apps/perun/utils';
 
 @Component({
@@ -10,8 +7,7 @@ import { parseFullName } from '@perun-web-apps/perun/utils';
   templateUrl: './member-search-select.component.html',
   styleUrls: ['./member-search-select.component.css']
 })
-export class MemberSearchSelectComponent implements OnInit, OnChanges, OnDestroy {
-
+export class MemberSearchSelectComponent {
 
   constructor() { }
 
@@ -20,51 +16,5 @@ export class MemberSearchSelectComponent implements OnInit, OnChanges, OnDestroy
 
   @Output()
   memberSelected = new EventEmitter<RichMember>();
-
-  memberCtrl: FormControl = new FormControl();
-  memberFilterCtrl: FormControl = new FormControl();
-  filteredMembers = new ReplaySubject<RichMember[]>(1);
-
-  protected _onDestroy = new Subject<void>();
-
-  ngOnInit(): void {
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    this.filteredMembers.next(this.members.slice());
-
-    this.memberCtrl.setValue(this.members[0]);
-
-    this.memberCtrl.valueChanges.subscribe(member => this.memberSelected.emit(member));
-
-    this.memberFilterCtrl.valueChanges
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe(() => {
-        this.filterMembers();
-      });
-  }
-
-  ngOnDestroy() {
-    this._onDestroy.next();
-    this._onDestroy.complete();
-  }
-
-  private filterMembers() {
-    if (!this.members) {
-      return;
-    }
-    // get the search keyword
-    let search = this.memberFilterCtrl.value;
-    if (!search) {
-      this.filteredMembers.next(this.members.slice());
-      return;
-    } else {
-      search = search.toLowerCase();
-    }
-    // filter the banks
-    this.filteredMembers.next(
-      this.members.filter(option => parseFullName(option.user).toLowerCase().indexOf(search) >=0)
-    );
-  }
-
+  memberFullNameFunction = (member: RichMember) => parseFullName(member.user);
 }

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -61,6 +61,7 @@ import { MembersListComponent } from './members-list/members-list.component';
 import { TaskResultsListComponent } from './task-results-list/task-results-list.component';
 import { GroupSearchSelectComponent } from './group-search-select/group-search-select.component';
 import { MiddleClickRouterLinkDirective } from '@perun-web-apps/perun/directives';
+import { EntitySearchSelectComponent } from './entity-search-select/entity-search-select.component';
 import { ResourceSearchSelectComponent } from './resource-search-select/resource-search-select.component';
 import { MemberSearchSelectComponent } from './member-search-select/member-search-select.component';
 import { FacilitySearchSelectComponent } from './facility-search-select/facility-search-select.component';
@@ -168,7 +169,8 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     UserSearchSelectComponent,
     ExpirationSelectComponent,
     RecentlyViewedIconComponent,
-    FacilitySelectTableComponent
+    FacilitySelectTableComponent,
+    EntitySearchSelectComponent,
   ],
   exports: [
     VoSelectTableComponent,
@@ -205,7 +207,8 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     UserSearchSelectComponent,
     ExpirationSelectComponent,
     RecentlyViewedIconComponent,
-    FacilitySelectTableComponent
+    FacilitySelectTableComponent,
+    EntitySearchSelectComponent,
   ],
   providers: [
     { provide: DateAdapter, useClass: AppDateAdapter },

--- a/libs/perun/components/src/lib/resource-search-select/resource-search-select.component.html
+++ b/libs/perun/components/src/lib/resource-search-select/resource-search-select.component.html
@@ -1,16 +1,9 @@
-<mat-form-field class="w-100">
-  <mat-select
-    placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.RESOURCE_SEARCH_SELECT.SELECT_RESOURCE' | translate}}"
-    [formControl]="resourceCtrl">
-    <mat-option>
-      <ngx-mat-select-search
-        placeholderLabel="{{'SHARED_LIB.PERUN.COMPONENTS.RESOURCE_SEARCH_SELECT.FIND_RESOURCE' | translate}}"
-        noEntriesFoundLabel="{{'SHARED_LIB.PERUN.COMPONENTS.RESOURCE_SEARCH_SELECT.NO_RESOURCE_FOUND' | translate}}"
-        [formControl]="resourceFilterCtrl">
-      </ngx-mat-select-search>
-    </mat-option>
-    <mat-option *ngFor="let resource of filteredResources | async" [value]="resource">
-      {{resource.name}}
-    </mat-option>
-  </mat-select>
-</mat-form-field>
+<perun-web-apps-entity-search-select
+  [entities]="resources"
+  (entitySelected)="this.resourceSelected.emit($event)"
+  [searchFunction]="nameFunction"
+  [mainTextFunction]="nameFunction"
+  [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCE_SEARCH_SELECT.SELECT_RESOURCE' | translate"
+  [findPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCE_SEARCH_SELECT.FIND_RESOURCE' | translate"
+  [noEntriesText]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCE_SEARCH_SELECT.NO_RESOURCE_FOUND' | translate">
+</perun-web-apps-entity-search-select>

--- a/libs/perun/components/src/lib/resource-search-select/resource-search-select.component.ts
+++ b/libs/perun/components/src/lib/resource-search-select/resource-search-select.component.ts
@@ -1,16 +1,12 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Resource } from '@perun-web-apps/perun/openapi';
-import { FormControl } from '@angular/forms';
-import { ReplaySubject, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'perun-web-apps-resource-search-select',
   templateUrl: './resource-search-select.component.html',
   styleUrls: ['./resource-search-select.component.css']
 })
-export class ResourceSearchSelectComponent implements OnInit, OnChanges, OnDestroy {
-
+export class ResourceSearchSelectComponent {
 
   constructor() { }
 
@@ -20,49 +16,5 @@ export class ResourceSearchSelectComponent implements OnInit, OnChanges, OnDestr
   @Output()
   resourceSelected = new EventEmitter<Resource>();
 
-  resourceCtrl: FormControl = new FormControl();
-  resourceFilterCtrl: FormControl = new FormControl();
-  filteredResources = new ReplaySubject<Resource[]>(1);
-
-  protected _onDestroy = new Subject<void>();
-
-  ngOnInit(): void {
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    this.filteredResources.next(this.resources.slice());
-
-    this.resourceCtrl.setValue(this.resources[0]);
-
-    this.resourceCtrl.valueChanges.subscribe(resource => this.resourceSelected.emit(resource));
-
-    this.resourceFilterCtrl.valueChanges
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe(() => {
-        this.filterResources();
-      });
-  }
-
-  ngOnDestroy() {
-    this._onDestroy.next();
-    this._onDestroy.complete();
-  }
-
-  private filterResources() {
-    if (!this.resources) {
-      return;
-    }
-    // get the search keyword
-    let search = this.resourceFilterCtrl.value;
-    if (!search) {
-      this.filteredResources.next(this.resources.slice());
-      return;
-    } else {
-      search = search.toLowerCase();
-    }
-    // filter the banks
-    this.filteredResources.next(
-      this.resources.filter(option => option.name.toLowerCase().indexOf(search) >=0)
-    );
-  }
+  nameFunction = (resource: Resource) => resource.name;
 }

--- a/libs/perun/components/src/lib/user-search-select/user-search-select.component.html
+++ b/libs/perun/components/src/lib/user-search-select/user-search-select.component.html
@@ -1,17 +1,9 @@
-<mat-form-field class="w-100">
-  <mat-select
-    placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.USER_SEARCH_SELECT.SELECT_USER' | translate}}"
-    [formControl]="userCtrl">
-    <mat-option>
-      <ngx-mat-select-search
-        placeholderLabel="{{'SHARED_LIB.PERUN.COMPONENTS.USER_SEARCH_SELECT.FIND_USER' | translate}}"
-        noEntriesFoundLabel="{{'SHARED_LIB.PERUN.COMPONENTS.USER_SEARCH_SELECT.NO_USER_FOUND' | translate}}"
-        [formControl]="userFilterCtrl">
-      </ngx-mat-select-search>
-    </mat-option>
-    <mat-option *ngFor="let user of filteredUsers | async" [value]="user">
-      {{user | userFullName}} <span class="text-muted muted">#{{user.id}}</span>
-    </mat-option>
-  </mat-select>
-</mat-form-field>
-
+<perun-web-apps-entity-search-select
+  [entities]="users"
+  (entitySelected)="this.userSelected.emit($event)"
+  [searchFunction]="userFullNameFunction"
+  [mainTextFunction]="userFullNameFunction"
+  [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.USER_SEARCH_SELECT.SELECT_USER' | translate"
+  [findPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.USER_SEARCH_SELECT.FIND_USER' | translate"
+  [noEntriesText]="'SHARED_LIB.PERUN.COMPONENTS.USER_SEARCH_SELECT.NO_USER_FOUND' | translate">
+</perun-web-apps-entity-search-select>

--- a/libs/perun/components/src/lib/user-search-select/user-search-select.component.ts
+++ b/libs/perun/components/src/lib/user-search-select/user-search-select.component.ts
@@ -1,8 +1,5 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { User } from '@perun-web-apps/perun/openapi';
-import { FormControl } from '@angular/forms';
-import { ReplaySubject, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { parseFullName } from '@perun-web-apps/perun/utils';
 
 @Component({
@@ -10,8 +7,7 @@ import { parseFullName } from '@perun-web-apps/perun/utils';
   templateUrl: './user-search-select.component.html',
   styleUrls: ['./user-search-select.component.css']
 })
-export class UserSearchSelectComponent implements OnInit, OnChanges, OnDestroy {
-
+export class UserSearchSelectComponent {
 
   constructor() { }
 
@@ -20,50 +16,5 @@ export class UserSearchSelectComponent implements OnInit, OnChanges, OnDestroy {
 
   @Output()
   userSelected = new EventEmitter<User>();
-
-  userCtrl: FormControl = new FormControl();
-  userFilterCtrl: FormControl = new FormControl();
-  filteredUsers = new ReplaySubject<User[]>(1);
-
-  protected _onDestroy = new Subject<void>();
-
-  ngOnInit(): void {
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    this.filteredUsers.next(this.users.slice());
-
-    this.userCtrl.setValue(this.users[0]);
-
-    this.userCtrl.valueChanges.subscribe(resource => this.userSelected.emit(resource));
-
-    this.userFilterCtrl.valueChanges
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe(() => {
-        this.filterUsers();
-      });
-  }
-
-  ngOnDestroy() {
-    this._onDestroy.next();
-    this._onDestroy.complete();
-  }
-
-  private filterUsers() {
-    if (!this.users) {
-      return;
-    }
-    // get the search keyword
-    let search = this.userFilterCtrl.value;
-    if (!search) {
-      this.filteredUsers.next(this.users.slice());
-      return;
-    } else {
-      search = search.toLowerCase();
-    }
-    // filter the banks
-    this.filteredUsers.next(
-      this.users.filter(option => parseFullName(option).toLowerCase().indexOf(search) >=0)
-    );
-  }
+  userFullNameFunction = parseFullName;
 }

--- a/libs/perun/components/src/lib/vo-search-select/vo-search-select.component.html
+++ b/libs/perun/components/src/lib/vo-search-select/vo-search-select.component.html
@@ -1,16 +1,10 @@
-<mat-form-field class="w-100">
-  <mat-select
-    placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.VO_SEARCH_SELECT.SELECT_VO' | translate}}"
-    [formControl]="voCtrl">
-    <mat-option>
-      <ngx-mat-select-search
-        placeholderLabel="{{'SHARED_LIB.PERUN.COMPONENTS.VO_SEARCH_SELECT.FIND_VO' | translate}}"
-        noEntriesFoundLabel="{{'SHARED_LIB.PERUN.COMPONENTS.VO_SEARCH_SELECT.NO_VO_FOUND' | translate}}"
-        [formControl]="voFilterCtrl">
-      </ngx-mat-select-search>
-    </mat-option>
-    <mat-option *ngFor="let vo of filteredVos | async" [value]="vo">
-      {{vo.name}} <span class="text-muted"> {{vo.shortName}} </span>
-    </mat-option>
-  </mat-select>
-</mat-form-field>
+<perun-web-apps-entity-search-select
+  [entities]="vos"
+  (entitySelected)="this.voSelected.emit($event)"
+  [searchFunction]="searchFunction"
+  [mainTextFunction]="nameFunction"
+  [secondaryTextFunction]="shortNameFunction"
+  [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.VO_SEARCH_SELECT.SELECT_VO' | translate"
+  [findPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.VO_SEARCH_SELECT.FIND_VO' | translate"
+  [noEntriesText]="'SHARED_LIB.PERUN.COMPONENTS.VO_SEARCH_SELECT.NO_VO_FOUND' | translate">
+</perun-web-apps-entity-search-select>

--- a/libs/perun/components/src/lib/vo-search-select/vo-search-select.component.ts
+++ b/libs/perun/components/src/lib/vo-search-select/vo-search-select.component.ts
@@ -1,15 +1,12 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
-import { FormControl } from '@angular/forms';
-import { ReplaySubject, Subject } from 'rxjs';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Vo } from '@perun-web-apps/perun/openapi';
-import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'perun-web-apps-vo-search-select',
   templateUrl: './vo-search-select.component.html',
   styleUrls: ['./vo-search-select.component.css']
 })
-export class VoSearchSelectComponent implements OnInit, OnChanges, OnDestroy {
+export class VoSearchSelectComponent {
 
   constructor() { }
 
@@ -19,48 +16,7 @@ export class VoSearchSelectComponent implements OnInit, OnChanges, OnDestroy {
   @Output()
   voSelected = new EventEmitter<Vo>();
 
-  voCtrl: FormControl = new FormControl();
-  voFilterCtrl: FormControl = new FormControl();
-  filteredVos = new ReplaySubject<Vo[]>(1);
-
-  protected _onDestroy = new Subject<void>();
-
-  ngOnInit(): void {
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    this.filteredVos.next(this.vos.slice());
-
-    this.voCtrl.valueChanges.subscribe(vo => this.voSelected.emit(vo));
-
-    this.voFilterCtrl.valueChanges
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe(() => {
-        this.filterVos();
-      });
-  }
-
-  ngOnDestroy() {
-    this._onDestroy.next();
-    this._onDestroy.complete();
-  }
-
-  private filterVos() {
-    if (!this.vos) {
-      return;
-    }
-    // get the search keyword
-    let search = this.voFilterCtrl.value;
-    if (!search) {
-      this.filteredVos.next(this.vos.slice());
-      return;
-    } else {
-      search = search.toLowerCase();
-    }
-    // filter the banks
-    this.filteredVos.next(
-      this.vos.filter(option => option.name.toLowerCase().indexOf(search) >=0
-        || option.shortName.toLowerCase().indexOf(search) >= 0)
-    );
-  }
+  nameFunction = (vo: Vo) => vo.name;
+  shortNameFunction = (vo: Vo) => vo.shortName;
+  searchFunction = (vo: Vo) => vo.name + vo.shortName + vo.id;
 }

--- a/libs/perun/urns/src/lib/perun-urns.ts
+++ b/libs/perun/urns/src/lib/perun-urns.ts
@@ -5,6 +5,7 @@ export class Urns {
   public static MEMBER_DEF_GROUP_EXPIRATION = 'urn:perun:member_group:attribute-def:def:groupMembershipExpiration';
   public static MEMBER_DEF_ORGANIZATION = 'urn:perun:member:attribute-def:def:organization';
   public static MEMBER_DEF_MAIL = 'urn:perun:member:attribute-def:def:mail';
+  public static MEMBER_CORE_ID = 'urn:perun:member:attribute-def:core:id';
 
   // Vo
   public static VO_DEF_EXPIRATION_RULES = 'urn:perun:vo:attribute-def:def:membershipExpirationRules';


### PR DESCRIPTION
* Search selects now use a virtual scroll so they can work well with a
large number of entities.
* The search select logic was duplicated so I have created a new general
component that is used by all specific searchSelect components.
* The attribute page with members was loading all attributes for members
which was unnecessary since these attributes were not used. I have
specified a single core attribute to be returned. If an empty list was
passed, all attributes were loaded.