### PR TITLE
Fix applications list for many applications

### DIFF
--- a/apps/admin-gui/src/app/vos/components/applications-list/applications-list.component.html
+++ b/apps/admin-gui/src/app/vos/components/applications-list/applications-list.component.html
@@ -1,6 +1,6 @@
 <div
   [class.hide-table]="exporting"
-  [hidden]="this.applications.length === 0 || dataSource.filteredData.length === 0"
+  [hidden]="this.applications.length === 0 || !dataSource || dataSource.filteredData.length === 0"
   class="card mt-2">
   <div class="card-body table-theme">
     <perun-web-apps-table-options (exportEnd)="exporting = false" (exportStart)="exporting = true" [exporter]="exporter"></perun-web-apps-table-options>
@@ -79,6 +79,7 @@
     </div>
 
     <mat-paginator
+      #paginator
       [length]="this.applications.length"
       [pageSize]="pageSize"
       (page)="pageChanged($event)"
@@ -93,6 +94,6 @@
   {{'VO_DETAIL.APPLICATION.NO_APPLICATION_FOUND' | translate}}
 </app-alert>
 
-<app-alert *ngIf="dataSource.filteredData.length === 0 && applications.length !== 0" alert_type="warn">
+<app-alert *ngIf="!!dataSource && dataSource.filteredData.length === 0 && applications.length !== 0" alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_FILTER_RESULTS_ALERT' | translate}}
 </app-alert>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-applications/group-applications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-applications/group-applications.component.html
@@ -18,7 +18,7 @@
       <mat-option value="rejected">{{'VO_DETAIL.APPLICATION.SELECTION_REJECTED' | translate}}</mat-option>
     </mat-select>
   </mat-form-field>
-  <perun-web-apps-immediate-filter (filter)="applyFilter($event)" [placeholder]="'VO_DETAIL.APPLICATION.FILTER'"></perun-web-apps-immediate-filter>
+  <app-debounce-filter (filter)="applyFilter($event)" [placeholder]="'VO_DETAIL.APPLICATION.FILTER'"></app-debounce-filter>
 </div>
 <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
 <div *ngIf="!loading">

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-applications/vo-applications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-applications/vo-applications.component.html
@@ -18,7 +18,10 @@
       <mat-option value="rejected">{{'VO_DETAIL.APPLICATION.SELECTION_REJECTED' | translate}}</mat-option>
     </mat-select>
   </mat-form-field>
-  <perun-web-apps-immediate-filter (filter)="applyFilter($event)" [placeholder]="'VO_DETAIL.APPLICATION.FILTER'"></perun-web-apps-immediate-filter>
+  <app-debounce-filter
+    [placeholder]="'VO_DETAIL.APPLICATION.FILTER'"
+    (filter)="applyFilter($event)">
+  </app-debounce-filter>
 </div>
 <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
 <div *ngIf="!loading">


### PR DESCRIPTION
* The paginator on the application list was implemented so it was not
actually used for the first view. The paginator was undefined during the
time it was set to the datasource. This caused the first view to render
all of the applications.
* On vo applications and group applications I have also replaces the
filter by a debounce filter, which is better to use with such large
number of applications. The filtration takes a long time by default.