### PR TITLE
AdminGui - sponsored user pwd error message

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.html
@@ -117,7 +117,7 @@
             <mat-icon
               *ngIf="this.namespaceControl.get('password').dirty && this.namespaceControl.get('password').errors !== null"
               color="warn" matSuffix
-              [matTooltip]="this.namespaceControl.get('password').getError('backendError')">
+              [matTooltip]="'DIALOGS.CREATE_SPONSORED_MEMBER.BACKEND_ERROR_LONG' | translate">
               error
             </mat-icon>
             <mat-error

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1687,6 +1687,7 @@
       "EMAIL_ERROR": "Email is not valid",
       "LENGTH_ERROR": "Empty value is not allowed",
       "BACKEND_ERROR": "Entered password doesn't meet the selected namespace's criteria",
+      "BACKEND_ERROR_LONG": "Entered password doesn't match criteria for strong password and it can't be accepted. Please, make sure that the entered password is at least 8 characters long, contains at least one of: A-z, 0-9, and special characters.",
       "SHOW_PASSWORD": "Show password",
       "NAMESPACE_ERROR": "Selection of namespace is required",
       "FUNCTIONALITY_NOT_SUPPORTED": "This functionality is not yet supported.",


### PR DESCRIPTION
* For now, the backend doesn't support sending english error messages.
Therefore, we have to use a custom predefined english message.