### PR TITLE
dynamic paginating in vo-members page implemented

### DIFF
--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.html
@@ -66,9 +66,17 @@
   </div>
   <mat-spinner *ngIf="loading" class="ml-auto mr-auto">
   </mat-spinner>
-  <app-alert [alert_type]="'info'" *ngIf="!firstSearchDone && !loading">
-    {{'VO_DETAIL.MEMBERS.SEARCH_ALERT_PART_1' | translate}} {{count}} {{'VO_DETAIL.MEMBERS.SEARCH_ALERT_PART_2' | translate}}
-  </app-alert>
+  <perun-web-apps-members-dynamic-list
+    *ngIf="!firstSearchDone && !loading"
+    [voId]="vo.id"
+    [pageSize]="pageSize"
+    (page)="pageChanged($event)"
+    [selection]="selection"
+    [hideColumns]="hideColumns"
+    [attrNames]="attrNames"
+    (updateTable)="refreshTable()"
+  ></perun-web-apps-members-dynamic-list>
+
   <div class="mt-3" *ngIf="members !== null && !loading">
     <perun-web-apps-members-list
       [pageSize]="pageSize"

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.ts
@@ -62,7 +62,7 @@ export class VoMembersComponent implements OnInit {
 
   loading = false;
 
-  private attrNames = [
+  attrNames = [
     Urns.MEMBER_DEF_ORGANIZATION,
     Urns.MEMBER_DEF_MAIL,
     Urns.USER_DEF_ORGANIZATION,
@@ -81,7 +81,6 @@ export class VoMembersComponent implements OnInit {
   removeAuth: boolean;
   inviteAuth: boolean;
   routeAuth: boolean;
-  count: number;
   blockManualMemberAdding: boolean;
 
   ngOnInit() {
@@ -97,13 +96,7 @@ export class VoMembersComponent implements OnInit {
         this.voService.getVoById(voId).subscribe(vo => {
           this.vo = vo;
           this.setAuthRights();
-          this.membersService.getMembersCount(this.vo.id).subscribe(count => {
-            this.count = count;
-            if (count < 400) {
-              this.onListAll();
-            }
-            this.loading = false;
-          });
+          this.loading = false;
         });
       });
     });

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -296,8 +296,6 @@
       "REMOVE_MEMBERS": "Remove",
       "SEARCH_DESCRIPTION": "Search by name, login or email",
       "LIST_MEMBERS": "List all members",
-      "SEARCH_ALERT_PART_1": "In this VO are",
-      "SEARCH_ALERT_PART_2": "members and load all of them would take a long time. You can search particular member by name, login or email. Also, you can list all valid members.",
       "NO_MEMBERS_ALERT": "No members found.",
       "FILTER_STATUS": "Select Status",
       "INVITE": "Invite",

--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.css
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.css
@@ -1,0 +1,16 @@
+.spinner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 56px;
+  right: 0;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.table-container {
+  position: relative;
+  overflow: auto;
+}

--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
@@ -1,0 +1,102 @@
+<div class="card mt-2" [hidden]="this.dataSource.allMemberCount === 0 && (dataSource.loading$ | async) === false">
+  <div class="card-body position-relative">
+    <div class="spinner-container" *ngIf="dataSource.loading$ | async">
+      <mat-spinner class="ml-auto mr-auto"></mat-spinner>
+    </div>
+    <div class="overflow-auto table-container">
+      <table
+        [dataSource]="dataSource"
+        class="w-100"
+        mat-table
+        matSort
+        matSortActive="fullName"
+        matSortDirection="asc"
+        matSortDisableClear>
+        <ng-container matColumnDef="checkbox">
+          <th *matHeaderCellDef mat-header-cell>
+            <mat-checkbox (change)="$event ? masterToggle() : null"
+                          [aria-label]="checkboxLabel()"
+                          [checked]="selection.hasValue() && isAllSelected()"
+                          [indeterminate]="selection.hasValue() && !isAllSelected()"
+                          color="primary">
+            </mat-checkbox>
+          </th>
+          <td *matCellDef="let member" class="static-column-size" mat-cell>
+            <mat-checkbox (change)="$event ? selection.toggle(member) : null"
+                          (click)="$event.stopPropagation()"
+                          [aria-label]="checkboxLabel(member)"
+                          [checked]="selection.isSelected(member)"
+                          color="primary">
+            </mat-checkbox>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="id">
+          <th *matHeaderCellDef mat-header-cell mat-sort-header>{{'MEMBERS_LIST.ID' | translate}}</th>
+          <td *matCellDef="let member" class="static-column-size" mat-cell>{{member.id}}</td>
+        </ng-container>
+        <ng-container matColumnDef="fullName">
+          <th *matHeaderCellDef mat-header-cell mat-sort-header>{{'MEMBERS_LIST.NAME' | translate}}</th>
+          <td *matCellDef="let member" mat-cell>{{member.user | userFullName}}</td>
+        </ng-container>
+        <ng-container matColumnDef="status">
+          <div *ngIf="showGroupStatuses then thenHeader else elseHeader"></div>
+          <ng-template #thenHeader>
+            <th *matHeaderCellDef mat-header-cell>{{'MEMBERS_LIST.GROUP_STATUS' | translate}}</th>
+          </ng-template>
+          <ng-template #elseHeader>
+            <th *matHeaderCellDef mat-header-cell>{{'MEMBERS_LIST.STATUS' | translate}}</th>
+          </ng-template>
+          <td *matCellDef="let member" mat-cell>
+            <i (click)="changeStatus($event, member)"
+               class="material-icons {{showGroupStatuses ? (member.groupStatus | memberStatusIconColor) : (member.status | memberStatusIconColor)}}"
+               matTooltip="{{member | memberStatusTooltip: showGroupStatuses}}"
+               matTooltipClass="status-tooltip"
+               matTooltipPosition="left">
+              <span *ngIf="!showGroupStatuses">
+                {{member.status | memberStatusIcon}}
+              </span>
+              <span *ngIf="showGroupStatuses">
+                {{member.groupStatus | memberStatusIcon}}
+              </span>
+            </i>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="organization">
+          <th *matHeaderCellDef mat-header-cell>{{'MEMBERS_LIST.ORGANIZATION' | translate}}</th>
+          <td *matCellDef="let member" mat-cell>{{member | memberOrganization}}</td>
+        </ng-container>
+        <ng-container matColumnDef="email">
+          <th *matHeaderCellDef mat-header-cell>{{'MEMBERS_LIST.EMAIL' | translate}}</th>
+          <td *matCellDef="let member" mat-cell>{{member | memberEmail}}</td>
+        </ng-container>
+        <ng-container matColumnDef="logins">
+          <th *matHeaderCellDef mat-header-cell>{{'MEMBERS_LIST.LOGINS' | translate}}</th>
+          <td *matCellDef="let member" mat-cell>{{member | memberLogins}}</td>
+        </ng-container>
+        <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
+        <tr
+          *matRowDef="let member; columns: displayedColumns;"
+          [class.disable-outline]="!this.dataSource.routeAuth"
+          [class.cursor-pointer]="this.dataSource.routeAuth"
+          [routerLink]="!this.dataSource.routeAuth ? null : ['/organizations', member.voId, 'members', member.id]"
+          [perunWebAppsMiddleClickRouterLink]="!this.dataSource.routeAuth ? null : ['/organizations', member.voId, 'members', member.id]"
+          class="dark-hover-list-item"
+          mat-row>
+        </tr>
+      </table>
+    </div>
+
+    <mat-paginator
+      [length]="this.dataSource.allMemberCount"
+      (page)="pageChanged($event)"
+      [pageSize]="pageSize"
+      [pageSizeOptions]="pageSizeOptions">
+    </mat-paginator>
+  </div>
+</div>
+
+<app-alert
+  *ngIf="this.dataSource.allMemberCount === 0 && (dataSource.loading$ | async) === false"
+  [alert_type]="'warn'">
+  {{'SHARED_LIB.UI.ALERTS.NO_MEMBERS' | translate}}
+</app-alert>

--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.ts
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.ts
@@ -1,0 +1,138 @@
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
+import {MatSort} from '@angular/material/sort';
+import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
+import {SelectionModel} from '@angular/cdk/collections';
+import { RichMember} from '@perun-web-apps/perun/openapi';
+import {
+  getDefaultDialogConfig,
+  TABLE_ITEMS_COUNT_OPTIONS
+} from '@perun-web-apps/perun/utils';
+import { ChangeMemberStatusDialogComponent } from '@perun-web-apps/perun/dialogs';
+import {
+  DynamicPaginatingService,
+  GuiAuthResolver,
+  MembersDataSource,
+  TableCheckbox
+} from '@perun-web-apps/perun/services';
+import { merge } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Component({
+  selector: 'perun-web-apps-members-dynamic-list',
+  templateUrl: './members-dynamic-list.component.html',
+  styleUrls: ['./members-dynamic-list.component.css']
+})
+export class MembersDynamicListComponent implements AfterViewInit, OnInit {
+
+  constructor(private dialog: MatDialog,
+              private authResolver: GuiAuthResolver,
+              private tableCheckbox: TableCheckbox,
+              private dynamicPaginatingService: DynamicPaginatingService) { }
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+
+  @Input()
+  showGroupStatuses: boolean;
+
+  @Input()
+  selection: SelectionModel<RichMember>;
+
+  @Input()
+  hideColumns: string[] = [];
+
+  @Input()
+  pageSize = 10;
+
+  @Input()
+  voId: number;
+
+  @Input()
+  attrNames: string[];
+
+  @Output()
+  page: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
+
+  @Output()
+  updateTable = new EventEmitter<boolean>();
+
+  exporting = false;
+
+  displayedColumns: string[] = ['checkbox', 'id', 'fullName', 'status', 'organization', 'email', 'logins'];
+  dataSource: MembersDataSource;
+  pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
+
+  ngAfterViewInit(): void {
+    this.sort.sortChange.subscribe(() => this.paginator.pageIndex = 0);
+
+    merge(this.sort.sortChange, this.paginator.page)
+      .pipe(
+        tap(() => this.loadMembersPage())
+      )
+      .subscribe();
+  }
+
+  ngOnInit() {
+    if (!this.authResolver.isPerunAdmin()){
+      this.displayedColumns = this.displayedColumns.filter(column => column !== 'id');
+    }
+    this.displayedColumns = this.displayedColumns.filter(x => !this.hideColumns.includes(x));
+
+    this.dataSource = new MembersDataSource(this.dynamicPaginatingService, this.authResolver);
+    this.dataSource.loadMembers(this.voId, this.attrNames,'ASCENDING', 0, this.pageSize, 'NAME');
+  }
+
+  isAllSelected() {
+    const numSelected = this.selection.selected.length;
+    const numRows = this.pageSize;
+    return numSelected === numRows;
+  }
+
+  masterToggle() {
+    this.isAllSelected() ?
+      this.selection.clear() :
+      this.dataSource.getData().forEach(row => this.selection.select(row));
+  }
+
+  checkboxLabel(row?: RichMember): string {
+    if (!row) {
+      return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
+    }
+    return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.id + 1}`;
+  }
+
+  changeStatus(event: any, member: RichMember) {
+    event.stopPropagation();
+    if (member.status === 'INVALID') {
+      const config = getDefaultDialogConfig();
+      config.width = '500px';
+      config.data = {member: member};
+
+      const dialogRef = this.dialog.open(ChangeMemberStatusDialogComponent, config);
+      dialogRef.afterClosed().subscribe( success => {
+        if (success) {
+          this.updateTable.emit(true);
+        }
+      });
+    }
+  }
+
+  pageChanged(event: PageEvent) {
+    this.page.emit(event);
+  }
+
+  loadMembersPage() {
+    const sortDirection = this.sort.direction === 'asc' ? 'ASCENDING' : 'DESCENDING';
+    const sortColumn = this.sort.active === 'fullName' ? 'NAME' : 'ID';
+    this.dataSource.loadMembers(this.voId, this.attrNames, sortDirection, this.paginator.pageIndex, this.paginator.pageSize, sortColumn);
+  }
+}

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -77,6 +77,7 @@ import { ReportIssueDialogComponent } from './report-issue-dialog/report-issue-d
 import { MatDialogModule } from '@angular/material/dialog';
 import { CreateGroupFormComponent } from './create-group-form/create-group-form.component';
 import { DebounceFilterComponent } from './debounce-filter/debounce-filter.component';
+import { MembersDynamicListComponent } from './members-dynamic-list/members-dynamic-list.component';
 
 @Injectable()
 export class AppDateAdapter extends NativeDateAdapter {
@@ -184,7 +185,8 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     PerunFooterComponent,
     ReportIssueDialogComponent,
     CreateGroupFormComponent,
-    DebounceFilterComponent
+    DebounceFilterComponent,
+    MembersDynamicListComponent
   ],
   exports: [
     VoSelectTableComponent,
@@ -227,7 +229,8 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     PerunFooterComponent,
     ReportIssueDialogComponent,
     CreateGroupFormComponent,
-    DebounceFilterComponent
+    DebounceFilterComponent,
+    MembersDynamicListComponent
   ],
   providers: [
     { provide: DateAdapter, useClass: AppDateAdapter },

--- a/libs/perun/services/src/index.ts
+++ b/libs/perun/services/src/index.ts
@@ -11,4 +11,6 @@ export { NotificationStorageService } from './lib/notification-storage.service';
 export {ApiService} from './lib/api.service';
 export {ForceRouterService} from './lib/force-router.service';
 export {TableCheckbox} from './lib/table-checkbox.service';
+export { DynamicPaginatingService } from './lib/dynamic-paginating.service'
+export { MembersDataSource } from './lib/members.datasource'
 

--- a/libs/perun/services/src/lib/dynamic-paginating.service.ts
+++ b/libs/perun/services/src/lib/dynamic-paginating.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import {
+  MembersManagerService,
+  MembersOrderColumn,
+  PaginatedRichMembers,
+  SortingOrder
+} from '@perun-web-apps/perun/openapi';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DynamicPaginatingService {
+
+  constructor(private membersService: MembersManagerService) { }
+
+  getMembers(voId: number,
+             attrNames: string[],
+             sortOrder: SortingOrder,
+             pageNumber: number,
+             pageSize : number,
+             sortColumn: MembersOrderColumn): Observable<PaginatedRichMembers> {
+    return this.membersService.getMembersPage({
+      vo: voId,
+      attrNames: attrNames,
+      query: {pageSize: pageSize, offset: pageNumber*pageSize, order: sortOrder, sortColumn: sortColumn}})
+
+  }
+}

--- a/libs/perun/services/src/lib/members.datasource.ts
+++ b/libs/perun/services/src/lib/members.datasource.ts
@@ -1,0 +1,60 @@
+import {CollectionViewer, DataSource} from "@angular/cdk/collections";
+import {Observable, BehaviorSubject, of} from "rxjs";
+import {catchError, finalize} from "rxjs/operators";
+import { MembersOrderColumn, PaginatedRichMembers, RichMember, SortingOrder } from '@perun-web-apps/perun/openapi';
+import { DynamicPaginatingService } from './dynamic-paginating.service';
+import { GuiAuthResolver } from '@perun-web-apps/perun/services';
+
+
+
+export class MembersDataSource implements DataSource<RichMember> {
+
+  private membersSubject = new BehaviorSubject<RichMember[]>([]);
+
+  private loadingSubject = new BehaviorSubject<boolean>(false);
+
+  public loading$ = this.loadingSubject.asObservable();
+
+  public allMemberCount = 0;
+
+  public routeAuth = true;
+
+  constructor(private dynamicPaginatingService: DynamicPaginatingService,
+              private authzService: GuiAuthResolver) {}
+
+  loadMembers(voId: number,
+              attrNames: string[],
+              sortOrder: SortingOrder,
+              pageIndex: number,
+              pageSize: number,
+              sortColumn: MembersOrderColumn) {
+
+    this.loadingSubject.next(true);
+
+    this.dynamicPaginatingService.getMembers(voId, attrNames, sortOrder, pageIndex, pageSize, sortColumn).pipe(
+      catchError(() => of([])),
+      finalize(() => this.loadingSubject.next(false))
+    ).subscribe(paginatedRichMembers => {
+      const data: RichMember[] = (<PaginatedRichMembers>paginatedRichMembers).data;
+      if(data !== null && data.length !== 0){
+        this.routeAuth = this.authzService.isAuthorized('getMemberById_int_policy', [{beanName: 'Vo', id: voId}, data[0]]);
+      }
+      this.allMemberCount = (<PaginatedRichMembers>paginatedRichMembers).totalCount;
+      this.membersSubject.next((<PaginatedRichMembers>paginatedRichMembers).data);
+    });
+
+  }
+
+  connect(collectionViewer: CollectionViewer): Observable<RichMember[]> {
+    return this.membersSubject.asObservable();
+  }
+
+  disconnect(collectionViewer: CollectionViewer): void {
+    this.membersSubject.complete();
+    this.loadingSubject.complete();
+  }
+
+  getData(): RichMember[] {
+    return this.membersSubject.value;
+  }
+}


### PR DESCRIPTION
* initially members of vo in vo-members page are dynamically acquired from database
* now backend is supporting options for sorting according to id and names
* buttons "list all" and "search" do not support this because the backend does not support this yet
* implemented according to https://blog.angular-university.io/angular-material-data-table/