### PR TITLE
minor changes to sponsored members logic

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
@@ -16,7 +16,6 @@ import {
   FormControl,
   FormGroupDirective,
   NgForm,
-  ValidationErrors,
   ValidatorFn,
   Validators,
   AbstractControl,
@@ -93,7 +92,7 @@ export class CreateSponsoredMemberDialogComponent implements OnInit {
   voSponsors: RichUser[] = [];
 
   selectedSponsor: User = null;
-  sponsorType: string = null;
+  sponsorType = 'self';
   isSponsor = false;
   isPerunAdmin = false;
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.html
@@ -73,7 +73,12 @@
         <ng-template matStepLabel>{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.PASSWORD_LABEL' | translate}}</ng-template>
         <div class="mt-2">
           <h5 class="mb-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.PASSWORD_MANAGEMENT' | translate}}</h5>
-          <mat-radio-group [(ngModel)]="passwordReset">
+          <app-alert alert_type="info" *ngIf="getSelectedNamespaceRules().namespaceName === 'No namespace'">
+            {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NO_NAMESPACE_PASSWORD_INFO' | translate}}
+          </app-alert>
+          <mat-radio-group
+            *ngIf="getSelectedNamespaceRules().namespaceName !== 'No namespace'"
+            [(ngModel)]="passwordReset">
             <mat-radio-button value="generate">
               {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GENERATE_PASSWORD' | translate}}
             </mat-radio-button>

--- a/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.ts
@@ -48,9 +48,9 @@ export class GenerateSponsoredMembersDialogComponent implements OnInit, AfterVie
   namespaceRules: NamespaceRules[] = [];
   usersInfoFormGroup: FormGroup;
 
-  passwordReset = null;
+  passwordReset = 'generate';
   groupAssignment = null;
-  expiration = null;
+  expiration = 'never';
 
   createGroupAuth: boolean;
   assignableGroups: Group[] = [];

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1780,7 +1780,8 @@
       "GROUPS_LABEL": "Group",
       "CREATE_NEW_GROUP": "Create new group",
       "SELECT_EXISTING_GROUPS": "Select from existing groups",
-      "DONT_ASSIGN_INFO": "Created users will become members of this organization, but won't be assigned to any additional groups. You will be able to change this manually later."
+      "DONT_ASSIGN_INFO": "Created users will become members of this organization, but won't be assigned to any additional groups. You will be able to change this manually later.",
+      "NO_NAMESPACE_PASSWORD_INFO": "Generated members will not have password."
     },
     "EDIT_MEMBER_SPONSORS": {
       "TITLE": "Edit sponsored member",

--- a/libs/perun/components/src/lib/expiration-select/expiration-select.component.html
+++ b/libs/perun/components/src/lib/expiration-select/expiration-select.component.html
@@ -1,13 +1,13 @@
-<mat-radio-group [(ngModel)]="expiration" (change)="emitDate()">
+<mat-radio-group [(ngModel)]="expiration" (change)="emitDate()" class="d-flex flex-column">
+  <mat-radio-button value="never">
+    {{'DIALOGS.CHANGE_EXPIRATION.EXPIRATION_NEVER'|translate}}
+  </mat-radio-button>
   <mat-radio-button value="{{expirationControl.value}}">
-    <mat-form-field appearance="fill" color="primary" class="cursor-pointer mr-3" (click)="picker.open()">
+    <mat-form-field color="primary" class="cursor-pointer mr-3" (click)="picker.open()">
       <mat-label>{{'DIALOGS.CHANGE_EXPIRATION.DATE_LABEL'|translate}}</mat-label>
       <input (dateChange)="setExpiration()" [min]="minDate" [formControl]="expirationControl" [matDatepicker]="picker" class="disable" readonly matInput>
       <mat-datepicker-toggle [for]="picker" [disabled]="false" matSuffix></mat-datepicker-toggle>
       <mat-datepicker #picker [disabled]="false"></mat-datepicker>
     </mat-form-field>
-  </mat-radio-button>
-  <mat-radio-button value="never">
-    {{'DIALOGS.CHANGE_EXPIRATION.EXPIRATION_NEVER'|translate}}
   </mat-radio-button>
 </mat-radio-group>


### PR DESCRIPTION
* when no namespace is selected in generate-sponsored-members-dialog.component on password tab is showed only info that created members will have no password
* in dialogs create-sponsored-member-dialog.component.ts and generate-sponsored-members-dialog.component.ts the radio buttons are now prefilled with the first option so user dont have to click on first option if its what fits him
* changed visuals for expiration-select.component.html