### PR TITLE
Embedded application settings conditional

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/update-application-form-dialog/update-application-form-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/update-application-form-dialog/update-application-form-dialog.component.html
@@ -30,7 +30,7 @@
       </mat-select>
     </mat-form-field>
 
-    <div *ngIf="entity === 'group'">
+    <div *ngIf="entity === 'group' && autoRegistrationEnabled">
       {{'DIALOGS.UPDATE_APPLICATION_FORM.EMBEDDED' | translate}}:
     <mat-form-field class="w-100">
       <mat-select [(value)]="embeddedState" disableOptionCentering>

--- a/apps/admin-gui/src/app/shared/components/dialogs/update-application-form-dialog/update-application-form-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/update-application-form-dialog/update-application-form-dialog.component.ts
@@ -6,6 +6,7 @@ export interface UpdateApplicationFormDialogData {
   entity: string;
   applicationForm: ApplicationForm;
   theme: string;
+  autoRegistrationEnabled: boolean;
 }
 
 @Component({
@@ -27,6 +28,7 @@ export class UpdateApplicationFormDialogComponent implements OnInit {
   embeddedState: string;
   loading = false;
   theme: string;
+  autoRegistrationEnabled: boolean;
 
   ngOnInit() {
     this.theme = this.data.theme;
@@ -36,6 +38,7 @@ export class UpdateApplicationFormDialogComponent implements OnInit {
     this.extensionState = this.applicationForm.automaticApprovalExtension ? 'auto' : 'manual';
     this.embeddedState = this.applicationForm.automaticApprovalEmbedded ? 'auto' : 'manual';
     this.entity = this.data.entity;
+    this.autoRegistrationEnabled = this.data.autoRegistrationEnabled;
   }
 
   onCancel() {

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
@@ -5,24 +5,27 @@
 </mat-spinner>
 <div *ngIf="!loading && !noApplicationForm">
   <div class="d-flex w-50">
-    <div class="w-75">
+    <div [ngClass]="autoRegistrationEnabled ? 'w-75' : 'w-50'">
       <div class="font-weight-bold">{{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MODULE_NAME' | translate}}:
         {{applicationForm.moduleClassName}}
       </div>
       <div>
         <span class="font-weight-bold">{{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.APPLICATION_TYPE' | translate}}</span>:
 
-        <mat-icon class="align-text-top" matTooltip="Initial">arrow_right_alt</mat-icon>
+        <mat-icon class="align-text-bottom" matTooltip="Initial">arrow_right_alt</mat-icon>
         {{applicationForm.automaticApproval ?
         ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.AUTOMATIC'| translate) : ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MANUAL'| translate)}},
 
-        <mat-icon class="align-text-top" matTooltip="Extension">restore</mat-icon>
+        <mat-icon class="align-text-bottom" matTooltip="Extension">restore</mat-icon>
         {{applicationForm.automaticApprovalExtension ?
-        ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.AUTOMATIC'| translate) : ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MANUAL'| translate)}},
-
-        <mat-icon class="align-text-top" matTooltip="Embedded">nat</mat-icon>
-        {{applicationForm.automaticApprovalEmbedded ?
         ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.AUTOMATIC'| translate) : ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MANUAL'| translate)}}
+
+        <span *ngIf='autoRegistrationEnabled'>
+          ,
+          <mat-icon class="align-text-bottom" matTooltip="Embedded">nat</mat-icon>
+          {{applicationForm.automaticApprovalEmbedded ?
+          ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.AUTOMATIC'| translate) : ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MANUAL'| translate)}}
+        </span>
       </div>
       <div *ngIf="voHasEmbeddedGroupApplication">
         <mat-slide-toggle (change)="updateAutoRegistration()"

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.ts
@@ -162,7 +162,8 @@ export class GroupSettingsApplicationFormComponent implements OnInit {
     config.data = {
       entity: "group",
       applicationForm: this.applicationForm,
-      theme: 'group-theme'
+      theme: 'group-theme',
+      autoRegistrationEnabled: this.autoRegistrationEnabled
     };
 
     const dialog = this.dialog.open(UpdateApplicationFormDialogComponent, config);


### PR DESCRIPTION
- Changing embedded group application approval is now possible only when
  autoregistration is enabled.
- Also visibility of approval is now relying on the same condition.
- Fixed icons allignment.