### PR TITLE
add branding

### DIFF
--- a/libs/config/src/lib/app-config.service.ts
+++ b/libs/config/src/lib/app-config.service.ts
@@ -94,8 +94,8 @@ export class AppConfigService {
       this.http.get('/assets/config/instanceConfig.json', { headers: this.getNoCacheHeaders() })
         .subscribe(config => {
           this.storeService.setInstanceConfig(config);
-          const branding = document.location.hostname + '_branding';
-          if (this.storeService.get(branding) !== undefined) {
+          const branding = document.location.hostname;
+          if (this.storeService.get('brandings', branding) !== undefined) {
             this.storeService.setBanding(branding);
           }
           resolve();

--- a/libs/config/src/lib/app-config.service.ts
+++ b/libs/config/src/lib/app-config.service.ts
@@ -95,7 +95,7 @@ export class AppConfigService {
         .subscribe(config => {
           this.storeService.setInstanceConfig(config);
           const branding = document.location.hostname;
-          if (this.storeService.get('brandings', branding) !== undefined) {
+          if (config['brandings'] !== undefined && config['brandings'][branding] !== undefined) {
             this.storeService.setBanding(branding);
           }
           resolve();

--- a/libs/config/src/lib/app-config.service.ts
+++ b/libs/config/src/lib/app-config.service.ts
@@ -49,7 +49,6 @@ export class AppConfigService {
         // update theme for given entity
         this.setEntityTheme(ecc.entity, color);
       });
-
       resolve();
     }));
   }
@@ -95,6 +94,10 @@ export class AppConfigService {
       this.http.get('/assets/config/instanceConfig.json', { headers: this.getNoCacheHeaders() })
         .subscribe(config => {
           this.storeService.setInstanceConfig(config);
+          const branding = document.location.hostname + '_branding';
+          if (this.storeService.get(branding) !== undefined) {
+            this.storeService.setBanding(branding);
+          }
           resolve();
         }, () => {
           console.log('instance config not detected');

--- a/libs/perun/services/src/lib/store.service.ts
+++ b/libs/perun/services/src/lib/store.service.ts
@@ -102,7 +102,6 @@ export class StoreService {
           currentValue = this.defaultConfig[keys[i]];
         } else {
           if (currentValue === undefined) {
-            console.error('Missing value in default config: ' + keys);
             break;
           }
           currentValue = currentValue[keys[i]];

--- a/libs/perun/services/src/lib/store.service.ts
+++ b/libs/perun/services/src/lib/store.service.ts
@@ -102,6 +102,7 @@ export class StoreService {
           currentValue = this.defaultConfig[keys[i]];
         } else {
           if (currentValue === undefined) {
+            console.error('Missing value in default config: ' + keys);
             break;
           }
           currentValue = currentValue[keys[i]];

--- a/libs/perun/services/src/lib/store.service.ts
+++ b/libs/perun/services/src/lib/store.service.ts
@@ -67,7 +67,7 @@ export class StoreService {
     let currentValue: string;
 
     if (this.branding !== '') {
-      const brandingConfig = this.instanceConfig[this.branding];
+      const brandingConfig = this.instanceConfig['brandings'][this.branding];
       for (let i = 0; i < keys.length; ++i) {
         if (i === 0) {
           currentValue = brandingConfig[keys[i]];

--- a/libs/perun/services/src/lib/store.service.ts
+++ b/libs/perun/services/src/lib/store.service.ts
@@ -14,6 +14,7 @@ export class StoreService {
   private defaultConfig;
   private principal: PerunPrincipal;
   private initialPageId: number;
+  private branding = '';
 
   constructor() { }
 
@@ -49,6 +50,10 @@ export class StoreService {
     return this.get("member_profile_attributes_friendly_names");
   }
 
+  setBanding(branding: string) {
+    this.branding = branding;
+  }
+
   skipOidc(): boolean {
     return this.get('skip_oidc');
   }
@@ -61,7 +66,21 @@ export class StoreService {
   get(...keys: string[]) : any {
     let currentValue: string;
 
-    if (this.instanceConfig !== undefined) {
+    if (this.branding !== '') {
+      const brandingConfig = this.instanceConfig[this.branding];
+      for (let i = 0; i < keys.length; ++i) {
+        if (i === 0) {
+          currentValue = brandingConfig[keys[i]];
+        } else {
+          if (currentValue === undefined) {
+            break;
+          }
+          currentValue = currentValue[keys[i]];
+        }
+      }
+    }
+
+    if (this.instanceConfig !== undefined && currentValue === undefined) {
       for (let i = 0; i < keys.length; ++i) {
         if (i === 0) {
           currentValue = this.instanceConfig[keys[i]];


### PR DESCRIPTION
* instance config now can have property <domainName>_branding and inside this can be any property that is able to be configured
* method "get" now looks for properties in branding(if the branding exist) then it looks on the instanceConfig and then it looks on the defaultConfig
TESTING: the testing domain is gui-dev.org and gui-dev2.org, you can test the branding on these two domain, you need to change settings in apache2, allowed hosts, and also default config(oidc) 
eg. how the instance config can look: `"gui-dev2.org_branding": {
    "footer_support_mail": "gui2 mail test"
  },
  "gui-dev.org_branding": {
    "footer_support_mail": "idm@mail.muni.cz",
  },`