### PR TITLE
Fix - matTooltip didn't vanish after routing

### DIFF
--- a/apps/admin-gui/src/app/core/services/common/cache-route-reuse-strategy.ts
+++ b/apps/admin-gui/src/app/core/services/common/cache-route-reuse-strategy.ts
@@ -233,6 +233,9 @@ export class CacheRouteReuseStrategy implements RouteReuseStrategy {
    */
   store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {
     if (route.component) {
+      while(document.getElementsByTagName('mat-tooltip-component').length > 0) {
+        document.getElementsByTagName('mat-tooltip-component')[0].remove();
+      }
       const type = this.getComponentType(route);
       this.typeToComponentToHandlers
         .get(type)


### PR DESCRIPTION
* In cache-route-reuse-strategy is new check, which is cleaning old matTooltips during the routing.