### PR TITLE
Displayed item properties hidden/disabled on the form configuration and form preview

### DIFF
--- a/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.html
+++ b/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.html
@@ -28,6 +28,26 @@
           <th *matHeaderCellDef mat-header-cell>{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.TYPE' | translate}}</th>
           <td *matCellDef="let applicationFormItem" mat-cell>{{applicationFormItem.type | applicationFormItemType}}</td>
         </ng-container>
+        <ng-container matColumnDef="disabled">
+          <th class="center" *matHeaderCellDef mat-header-cell>{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HEADER' | translate}}</th>
+          <td class="center" *matCellDef="let applicationFormItem" mat-cell>
+            <div *ngIf="applicationFormItem.disabled !== 'NEVER'">
+              <mat-icon class="pointer" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+              <br>
+              {{disabledHiddenDependency(applicationFormItem, applicationFormItem.disabled, applicationFormItem.disabledDependencyItemId)}}
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="hidden">
+          <th class="center" *matHeaderCellDef mat-header-cell>{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.HIDDEN_HEADER' | translate}}</th>
+          <td class="center" *matCellDef="let applicationFormItem" mat-cell>
+            <div *ngIf="applicationFormItem.hidden !== 'NEVER'">
+              <mat-icon class="pointer" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
+              <br>
+              {{disabledHiddenDependency(applicationFormItem, applicationFormItem.hidden, applicationFormItem.hiddenDependencyItemId)}}
+            </div>
+          </td>
+        </ng-container>
         <ng-container matColumnDef="preview">
           <th *matHeaderCellDef mat-header-cell>{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW' | translate}}</th>
           <td *matCellDef="let applicationFormItem" mat-cell>

--- a/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.scss
+++ b/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.scss
@@ -33,3 +33,11 @@
 .make-yellow {
   background-color: #FFF9C4;
 }
+
+.center {
+  text-align: center;
+}
+
+.pointer {
+  cursor: pointer;
+}

--- a/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, SimpleChanges, ViewChild, Output, EventEmitter} from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ViewChild, Output, EventEmitter, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTable } from '@angular/material/table';
 import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
@@ -19,7 +19,7 @@ import { Router } from '@angular/router';
   templateUrl: './application-form-list.component.html',
   styleUrls: ['./application-form-list.component.scss']
 })
-export class ApplicationFormListComponent implements OnChanges {
+export class ApplicationFormListComponent implements OnInit, OnChanges {
 
   constructor(private dialog: MatDialog,
               private notificator: NotificatorService,
@@ -39,7 +39,7 @@ export class ApplicationFormListComponent implements OnChanges {
   theme: string;
 
   @Input()
-  displayedColumns: string[] = ['drag', 'shortname', 'type', 'preview', 'managegroups', 'edit', 'delete'];
+  displayedColumns: string[] = ['drag', 'shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups', 'edit', 'delete'];
 
   @Output()
   applicationFormItemsChange = new EventEmitter<ApplicationFormItem[]>();
@@ -52,9 +52,70 @@ export class ApplicationFormListComponent implements OnChanges {
   mapForCombobox: Map<number, string> = new Map();
   dragDisabled = true;
 
+  // labels and tooltips
+  ifEmpty: string;
+  ifPrefilled: string;
+  alwaysDisabled: string;
+  alwaysHidden: string;
+  isDisabledIf: string;
+  isHiddenIf: string;
+  isEmpty: string;
+  isPrefilled: string;
+
+  ngOnInit() {
+    // labels for hidden and disabled icons
+    this.ifEmpty = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.IF_EMPTY');
+    this.ifPrefilled = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.IF_PREFILLED');
+
+    // tooltips for hidden and disabled icons
+    this.alwaysDisabled = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.ALWAYS_DISABLED_HINT');
+    this.alwaysHidden = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.ALWAYS_HIDDEN_HINT')
+    this.isDisabledIf = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.DISABLED_IF_HINT');
+    this.isHiddenIf = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.HIDDEN_IF_HINT');
+    this.isEmpty = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.IS_EMPTY_HINT');
+    this.isPrefilled = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.IS_PREFILLED_HINT');
+  }
+
   ngOnChanges(changes: SimpleChanges) {
     this.dataSource = this.applicationFormItems;
 
+  }
+
+  disabledHiddenDependency(item: ApplicationFormItem, dependency: string, dependencyItemId: number): string {
+    let message = "";
+    if (dependency === "IF_EMPTY" || dependency === "IF_PREFILLED") {
+      const dep = dependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === dependencyItemId).shortname;
+      message = dependency === "IF_EMPTY" ? `(${this.ifEmpty} ${dep})` : `(${this.ifPrefilled} ${dep})`;
+    }
+    return message;
+  }
+
+  disabledTooltip(item: ApplicationFormItem): string {
+    let dep: string;
+    switch (item.disabled) {
+      case 'ALWAYS':
+        return this.alwaysDisabled;
+      case 'IF_EMPTY':
+        dep = item.disabledDependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === item.disabledDependencyItemId).shortname;
+        return `${this.isDisabledIf} ${dep} ${this.isEmpty}`;
+      case 'IF_PREFILLED':
+        dep = item.disabledDependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === item.disabledDependencyItemId).shortname;
+        return `${this.isDisabledIf} ${dep} ${this.isPrefilled}`;
+    }
+  }
+
+  hiddenTooltip(item: ApplicationFormItem): string {
+    let dep: string;
+    switch (item.hidden) {
+      case 'ALWAYS':
+        return this.alwaysHidden;
+      case 'IF_EMPTY':
+        dep = item.hiddenDependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === item.hiddenDependencyItemId).shortname;
+        return `${this.isHiddenIf} ${dep} ${this.isEmpty}`;
+      case 'IF_PREFILLED':
+        dep = item.hiddenDependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === item.hiddenDependencyItemId).shortname;
+        return `${this.isHiddenIf} ${dep} ${this.isPrefilled}`;
+    }
   }
 
   edit(applicationFormItem: ApplicationFormItem) {

--- a/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.html
+++ b/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.html
@@ -44,101 +44,121 @@
     <div *ngFor="let applicationFormItem of applicationFormItems">
       <div *ngIf="isValid(applicationFormItem)" class="mb-2">
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'TEXTFIELD' ||
+        <div class="d-flex" *ngIf="(applicationFormItem.type === 'TEXTFIELD' ||
                                    applicationFormItem.type === 'VALIDATED_EMAIL' ||
-                                   applicationFormItem.type === 'USERNAME'">
+                                   applicationFormItem.type === 'USERNAME') &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <div class="w-50">
-              <input type="text" class="w-100">
+              <input type="text" class="w-100" [disabled]="applicationFormItem.disabled === 'ALWAYS'">
             </div>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'FROM_FEDERATION_SHOW'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'FROM_FEDERATION_SHOW' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <div class="w-50">
               <input type="text" class="w-100" disabled>
             </div>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'PASSWORD'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'PASSWORD' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <div class="w-50">
-              <input class="mb-1 w-100" type="text"><br/>
-              <input class="w-100" type="text">
+              <input class="mb-1 w-100" type="text" [disabled]="applicationFormItem.disabled === 'ALWAYS'"><br/>
+              <input class="w-100" type="text" [disabled]="applicationFormItem.disabled === 'ALWAYS'">
             </div>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'RADIO'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'RADIO' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <form class="w-50">
               <div *ngFor="let item of getLocalizedOptions(applicationFormItem)">
-                <input type="radio" name="temp"> {{item}}<br>
+                <input type="radio" [disabled]="applicationFormItem.disabled === 'ALWAYS'" name="temp"> {{item}}<br>
               </div>
-              <input type="reset" value="{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.CLEAR_SELECTION' | translate}}"><!--tlacitko-->
+              <input type="reset" [disabled]="applicationFormItem.disabled === 'ALWAYS'" value="{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.CLEAR_SELECTION' | translate}}"><!--tlacitko-->
             </form>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
 
-        <div *ngIf="applicationFormItem.type ==='HEADING' ||
-                    applicationFormItem.type === 'HTML_COMMENT'">
+        <div *ngIf="(applicationFormItem.type ==='HEADING' ||
+                    applicationFormItem.type === 'HTML_COMMENT') &&
+                    applicationFormItem.hidden !== 'ALWAYS'">
           <span [innerHTML]="getLocalizedLabel(applicationFormItem)"></span>
         </div>
 
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'SELECTIONBOX'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'SELECTIONBOX' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <div class="w-50">
-              <select class="w-100">
+              <select class="w-100" [disabled]="applicationFormItem.disabled === 'ALWAYS'">
                 <option *ngFor="let item of getLocalizedOptions(applicationFormItem)">{{item}}</option>
               </select>
             </div>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'TEXTAREA'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'TEXTAREA' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
-            <textarea class="w-50"></textarea>
+            <textarea class="w-50" [disabled]="applicationFormItem.disabled === 'ALWAYS'"></textarea>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'COMBOBOX'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'COMBOBOX' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <div class="w-50">
-              <select [(ngModel)]="mapForCombobox[applicationFormItem.id]" class="w-100">
+              <select [(ngModel)]="mapForCombobox[applicationFormItem.id]" class="w-100"  [disabled]="applicationFormItem.disabled === 'ALWAYS'">
                 <option value="true" selected>{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.OTHER_VALUE' | translate}}</option>
                 <option value="false" *ngFor="let item of getLocalizedOptions(applicationFormItem)">{{item}}</option>
               </select>
@@ -149,59 +169,74 @@
               </div>
             </div>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'CHECKBOX'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'CHECKBOX' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <div class="w-50">
               <form class="w-100">
                 <div *ngFor="let item of getLocalizedOptions(applicationFormItem)">
-                  <input type="checkbox"> {{item}}
+                  <input type="checkbox" [disabled]="applicationFormItem.disabled === 'ALWAYS'"> {{item}}
                 </div>
               </form>
             </div>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'EMBEDDED_GROUP_APPLICATION'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'EMBEDDED_GROUP_APPLICATION' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <div class="w-50">
-              <form class="w-100">
-                <input type="checkbox"> example group1 <br/>
-                <input type="checkbox"> example group2 <br/>
-                <input type="checkbox"> example group3
+              <form class="w-100" >
+                <input type="checkbox" [disabled]="applicationFormItem.disabled === 'ALWAYS'"> example group1 <br/>
+                <input type="checkbox" [disabled]="applicationFormItem.disabled === 'ALWAYS'"> example group2 <br/>
+                <input type="checkbox" [disabled]="applicationFormItem.disabled === 'ALWAYS'"> example group3
               </form>
             </div>
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'SUBMIT_BUTTON'">
-          <button mat-flat-button color="accent">{{getLocalizedLabel(applicationFormItem)}}</button>
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'SUBMIT_BUTTON' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
+          <button mat-flat-button color="accent" [disabled]="applicationFormItem.disabled === 'ALWAYS'">{{getLocalizedLabel(applicationFormItem)}}</button>
+          <mat-icon class="pointer left" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+          <mat-icon class="pointer left" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
         </div>
 
 
-        <div *ngIf="applicationFormItem.type === 'AUTO_SUBMIT_BUTTON'">
-          <button mat-flat-button color="accent">{{getLocalizedLabel(applicationFormItem)}}</button>
+        <div *ngIf="applicationFormItem.type === 'AUTO_SUBMIT_BUTTON' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
+          <button mat-flat-button color="accent" [disabled]="applicationFormItem.disabled === 'ALWAYS'">{{getLocalizedLabel(applicationFormItem)}}</button>
+          <mat-icon class="pointer left" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+          <mat-icon class="pointer left" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
         </div>
 
 
-        <div class="d-flex" *ngIf="applicationFormItem.type === 'TIMEZONE'">
+        <div class="d-flex" *ngIf="applicationFormItem.type === 'TIMEZONE' &&
+                                   applicationFormItem.hidden !== 'ALWAYS'">
           <div class="w-50 d-flex">
             <span class="w-50">{{getLocalizedLabel(applicationFormItem)}}</span>
             <div class="w-50">
-              <select name="timezone_offset" id="timezone-offset" class="w-100">
+              <select name="timezone_offset" id="timezone-offset" class="w-100" [disabled]="applicationFormItem.disabled === 'ALWAYS'">
                 <option value="-12:00" selected="selected">
                   {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.NOT_SELECTED' | translate}}
                 </option>
@@ -249,7 +284,9 @@
             </div>
 
           </div>
-          <div class="w-50 d-flex">
+          <div class="w-50 d-flex left">
+            <mat-icon class="pointer" *ngIf="applicationFormItem.disabled !== 'NEVER'" [matTooltip]="disabledTooltip(applicationFormItem)">lock</mat-icon>
+            <mat-icon class="pointer" *ngIf="applicationFormItem.hidden !== 'NEVER'" [matTooltip]="hiddenTooltip(applicationFormItem)">visibility_off</mat-icon>
             <span class="ml-2">{{getLocalizedHint(applicationFormItem)}}</span>
           </div>
         </div>

--- a/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.scss
+++ b/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.scss
@@ -1,0 +1,7 @@
+.left {
+  margin-left: 10px;
+}
+
+.pointer {
+  cursor: pointer;
+}

--- a/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.ts
@@ -1,6 +1,7 @@
 import {Component, HostBinding, OnInit} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import { ApplicationFormItem } from '@perun-web-apps/perun/openapi';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-application-form-preview',
@@ -11,7 +12,8 @@ export class ApplicationFormPreviewComponent implements OnInit {
 
   @HostBinding('class.router-component') true;
 
-  constructor(protected route: ActivatedRoute) { }
+  constructor(protected route: ActivatedRoute,
+              private translate: TranslateService) { }
 
   loading = true;
   applicationFormItems: ApplicationFormItem[] = [];
@@ -69,6 +71,50 @@ export class ApplicationFormPreviewComponent implements OnInit {
       }
     }
     return false;
+  }
+
+  disabledTooltip(item: ApplicationFormItem): string {
+    let messStart: string;
+    let dep: string;
+    let messEnd: string;
+    switch (item.disabled) {
+      case 'ALWAYS':
+        return this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.ALWAYS_DISABLED');
+      case 'IF_PREFILLED':
+        messStart = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.DISABLED_WHEN');
+        dep =  item.hiddenDependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === item.disabledDependencyItemId).shortname;
+        messEnd = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.IS_PREFILLED');
+        return `${messStart} ${dep} ${messEnd}`;
+      case 'IF_EMPTY':
+        messStart = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.DISABLED_WHEN');
+        dep =  item.hiddenDependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === item.disabledDependencyItemId).shortname;
+        messEnd = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.IS_EMPTY');
+        return `${messStart} ${dep} ${messEnd}`;
+      default:
+        return "";
+    }
+  }
+
+  hiddenTooltip(item: ApplicationFormItem): string {
+    let messStart: string;
+    let dep: string;
+    let messEnd: string;
+    switch (item.hidden) {
+      case 'ALWAYS':
+        return this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.ALWAYS_HIDDEN');
+      case 'IF_PREFILLED':
+        messStart = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.HIDDEN_WHEN');
+        dep = item.hiddenDependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === item.hiddenDependencyItemId).shortname;
+        messEnd = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.IS_PREFILLED');
+        return `${messStart} ${dep} ${messEnd}`;
+      case 'IF_EMPTY':
+        messStart = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.HIDDEN_WHEN');
+        dep = item.hiddenDependencyItemId === null ? "" : this.applicationFormItems.find(i => i.id === item.hiddenDependencyItemId).shortname;
+        messEnd = this.translate.instant('VO_DETAIL.SETTINGS.APPLICATION_FORM.PREVIEW_PAGE.DISABLED_HIDDEN_ICON.IS_EMPTY');
+        return `${messStart} ${dep} ${messEnd}`;
+      default:
+        return "";
+    }
   }
 
   getLocalizedLabel(applicationFormItem: ApplicationFormItem): string {

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
@@ -112,7 +112,7 @@
     [applicationForm]="applicationForm"
     [applicationFormItems]="applicationFormItems"
     [theme]="'group-theme'"
-    [displayedColumns]="editAuth ? ['drag', 'shortname', 'type', 'preview', 'managegroups', 'edit', 'delete'] : ['shortname', 'type', 'preview', 'managegroups']"
+    [displayedColumns]="editAuth ? ['drag', 'shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups', 'edit', 'delete'] : ['shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups']"
     (applicationFormItemsChange)="changeItems()">
   </app-application-form-list>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.ts
@@ -81,8 +81,8 @@ export class VoSettingsApplicationFormComponent implements OnInit {
 
   setAuthRights(){
     this.editAuth = this.authResolver.isAuthorized('vo-updateFormItems_ApplicationForm_List<ApplicationFormItem>_policy', [this.vo]);
-    this.displayedColumns = this.editAuth ? ['drag', 'shortname', 'type', 'preview', 'managegroups', 'edit', 'delete']
-                                          : ['shortname', 'type', 'preview', 'managegroups'];
+    this.displayedColumns = this.editAuth ? ['drag', 'shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups', 'edit', 'delete']
+                                          : ['shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups'];
   }
 
   add() {

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -312,6 +312,8 @@
         "NO_APPLICATION_FORM": "Application form have no items.",
         "SHORTNAME": "Short name",
         "TYPE": "Type",
+        "DISABLED_HEADER": "Disabled",
+        "HIDDEN_HEADER": "Hidden",
         "PREVIEW": "Preview",
         "EDIT": "Edit",
         "MANAGE_GROUPS": "Manage groups",
@@ -381,12 +383,30 @@
           "AUTO_SUBMIT_BUTTON": "Button used to auto-submit the form with custom label. All other form items are checked on valid input before submission. If validation fail (at least once) user must submit form manually. If it's OK, then form is automatically submitted.",
           "EMBEDDED_GROUP_APPLICATION": "Checkbox of real organization groups which the user can check and thus submit an application to these groups"
         },
+        "DISABLED_HIDDEN_ICON": {
+          "IF_EMPTY": "If empty",
+          "IF_PREFILLED": "If prefilled",
+          "ALWAYS_DISABLED_HINT": "This item is always disabled",
+          "ALWAYS_HIDDEN_HINT": "This item is always hidden",
+          "DISABLED_IF_HINT": "This item is disabled if",
+          "HIDDEN_IF_HINT": "This item is hidden if",
+          "IS_EMPTY_HINT": "is empty",
+          "IS_PREFILLED_HINT": "is prefilled"
+        },
         "PREVIEW_PAGE": {
           "TITLE": "Application form preview",
           "SWITCH_ENGLISH": "Switch to English",
           "SWITCH_CZECH": "Switch to Czech",
           "SWITCH_EXTENSION": "Switch to Extension",
-          "SWITCH_INITIAL": "Switch to Initial"
+          "SWITCH_INITIAL": "Switch to Initial",
+          "DISABLED_HIDDEN_ICON": {
+            "ALWAYS_DISABLED": "Always disabled",
+            "ALWAYS_HIDDEN": "Always hidden",
+            "DISABLED_WHEN": "Disabled when",
+            "HIDDEN_WHEN": "Hidden when",
+            "IS_EMPTY": "is empty",
+            "IS_PREFILLED": "is prefilled"
+          }
         },
         "MANAGE_GROUPS_PAGE": {
           "TITLE": "Manage groups for registration",


### PR DESCRIPTION
* To the form configuration were added two columns which display hidden and disabled item properties. In columns are also displayed hidden and disabled dependencies.
* To the form preview were added icons which refer to hidden and disabled item properties. In the icon tooltip is dependency info.
* If some item has property disabled='ALWAYS', then is shown as disabled on the form preview.