### PR TITLE
fix(publications): fix header position with dialogs

### DIFF
--- a/apps/publications/src/app/app.component.scss
+++ b/apps/publications/src/app/app.component.scss
@@ -27,6 +27,7 @@
 }
 
 #nav-menu {
+  top: 0;
   background: #102027;
   position: fixed;
   width: 100%;


### PR DESCRIPTION
* From now, the header will be displayed properly when viewing a dialog on a scrolled page.