### PR TITLE
remove unused and useless core from generate-sponsored-members

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.html
@@ -215,40 +215,4 @@
       </mat-step>
     </mat-horizontal-stepper>
   </div>
-
-  <table
-    [hidden]="true"
-    class="w-100"
-    mat-table>
-    <ng-container matColumnDef="name">
-      <th *matHeaderCellDef mat-header-cell>name</th>
-      <td *matCellDef="let sponsoredMember" mat-cell>{{sponsoredMember.name}}</td>
-    </ng-container>
-    <ng-container matColumnDef="status">
-      <th *matHeaderCellDef mat-header-cell>status</th>
-      <td *matCellDef="let sponsoredMember" mat-cell>{{sponsoredMember.status}}</td>
-    </ng-container>
-    <ng-container matColumnDef="login">
-      <th *matHeaderCellDef mat-header-cell>login</th>
-      <td *matCellDef="let sponsoredMember" mat-cell>{{sponsoredMember.login}}</td>
-    </ng-container>
-    <ng-container matColumnDef="password">
-      <th *matHeaderCellDef mat-header-cell>password</th>
-      <td *matCellDef="let sponsoredMember" mat-cell>{{sponsoredMember.password}}</td>
-    </ng-container>
-    <tr *matHeaderRowDef="outputColumns" mat-header-row></tr>
-    <tr
-      *matRowDef="let sponsoredMember; columns: outputColumns;"
-      class="dark-hover-list-item"
-      mat-row
-    >
-    </tr>
-  </table>
-
-  <mat-paginator
-    [hidden]="true"
-    [length]="this.dataSource.data.length"
-    (page)="pageChanged($event)"
-    [pageSize]="100">
-  </mat-paginator>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, EventEmitter, Inject, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import {
   Attribute,
@@ -10,8 +10,7 @@ import {
 import { GuiAuthResolver, NotificatorService, StoreService } from '@perun-web-apps/perun/services';
 import { TranslateService } from '@ngx-translate/core';
 import { AbstractControl, FormBuilder, FormGroup, ValidatorFn, Validators } from '@angular/forms';
-import { MatTableDataSource } from '@angular/material/table';
-import { MatPaginator, PageEvent } from '@angular/material/paginator';
+import { PageEvent } from '@angular/material/paginator';
 import { formatDate } from '@angular/common';
 import { SelectionModel } from '@angular/cdk/collections';
 import { Urns } from '@perun-web-apps/perun/urns';
@@ -28,18 +27,10 @@ export interface GenerateSponsoredMembersDialogData {
   templateUrl: './generate-sponsored-members-dialog.component.html',
   styleUrls: ['./generate-sponsored-members-dialog.component.scss']
 })
-export class GenerateSponsoredMembersDialogComponent implements OnInit, AfterViewInit {
-
-  @Output()
-  page = new EventEmitter<PageEvent>();
-
-  @ViewChild(MatPaginator) paginator: MatPaginator;
+export class GenerateSponsoredMembersDialogComponent implements OnInit {
 
   theme: string;
   loading = false;
-  dataSource: MatTableDataSource<{name: string, status: string, login: string, passwd: string}> =
-    new MatTableDataSource<{name: string; status: string; login: string; passwd: string}>();
-  outputColumns = ['name', 'status', 'login', 'password'];
   functionalityNotSupported = false;
 
   emailRegx = /^(([^<>+()\[\]\\.,;:\s@"-#$%&=]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,3}))$/;
@@ -189,11 +180,6 @@ export class GenerateSponsoredMembersDialogComponent implements OnInit, AfterVie
     return output;
   }
 
-  exportData(data) {
-    this.dataSource.data = this.createOutputObjects(data);
-    downloadData(this.dataSource.data, 'csv', 'member-logins')
-  }
-
   onGenerate(){
     this.loading = true;
     const listOfMembers = this.usersInfoFormGroup.get('sponsoredMembers').value.split("\n");
@@ -233,7 +219,7 @@ export class GenerateSponsoredMembersDialogComponent implements OnInit, AfterVie
     }
 
     this.membersService.createSponsoredMembersFromCSV(inputSponsoredMembersFromCSV).subscribe(logins => {
-      this.exportData(logins);
+      downloadData(this.createOutputObjects(logins), 'csv', 'member-logins')
       this.notificator.showSuccess(this.translate.instant('DIALOGS.GENERATE_SPONSORED_MEMBERS.SUCCESS'));
       this.dialogRef.close(true);
     }, () => this.loading = false);
@@ -290,14 +276,6 @@ export class GenerateSponsoredMembersDialogComponent implements OnInit, AfterVie
 
       return null;
     };
-  }
-
-  ngAfterViewInit() {
-    this.dataSource.paginator = this.paginator;
-  }
-
-  pageChanged(event: PageEvent) {
-    this.page.emit(event);
   }
 
   setExpiration(newExpiration) {


### PR DESCRIPTION
* remove hidden table and all methods that were needed to support it
* the table was needed here for exporting the logins and passwords because the exporter library needed actual table to export it
* new export method doesnt need an actual table, just data, thus the table is useless