### PR TITLE
remove unused config property sponsor_namespace_attributes

### DIFF
--- a/apps/admin-gui/src/assets/config/defaultConfig.json
+++ b/apps/admin-gui/src/assets/config/defaultConfig.json
@@ -27,7 +27,6 @@
     "urn:perun:user:attribute-def:def:login-namespace:cesnet",
     "urn:perun:user:attribute-def:def:login-namespace:mu"
   ],
-  "sponsor_namespace_attributes": [],
   "password_namespace_attributes": [
     "urn:perun:user:attribute-def:def:login-namespace:einfra",
     "urn:perun:user:attribute-def:def:login-namespace:einfra-services",


### PR DESCRIPTION
* the configuration for sponsor namespace attributes is now loaded from backend