### PR TITLE
fix(admin-gui): Show disabled config for username app item

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.ts
@@ -53,7 +53,7 @@ export class EditApplicationFormItemDialogComponent implements OnInit {
   possibleDependencyItems: ApplicationFormItem[] = [];
 
   typesWithUpdatable: Type[] = ['VALIDATED_EMAIL', 'TEXTFIELD', 'TEXTAREA', 'CHECKBOX', 'RADIO', 'SELECTIONBOX', 'COMBOBOX', 'TIMEZONE'];
-  typesWithDisabled: Type[] = ['PASSWORD', 'VALIDATED_EMAIL', 'TEXTFIELD', 'TEXTAREA', 'CHECKBOX', 'RADIO', 'SELECTIONBOX', 'COMBOBOX'];
+  typesWithDisabled: Type[] = ['USERNAME', 'PASSWORD', 'VALIDATED_EMAIL', 'TEXTFIELD', 'TEXTAREA', 'CHECKBOX', 'RADIO', 'SELECTIONBOX', 'COMBOBOX'];
 
   hiddenDependencyItem: ApplicationFormItem = null;
   disabledDependencyItem: ApplicationFormItem = null;


### PR DESCRIPTION
* The username item type can use the disabled property, however it was not possible to set these properties in admin gui.