### PR TITLE
Allowed displaying short names instead of labels on preview

### DIFF
--- a/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.ts
@@ -123,7 +123,7 @@ export class ApplicationFormPreviewComponent implements OnInit {
   }
 
   getLocalizedLabel(applicationFormItem: ApplicationFormItem): string {
-    if (applicationFormItem.i18n[this.language]) {
+    if (applicationFormItem.i18n[this.language] && applicationFormItem.i18n[this.language].label) {
       return applicationFormItem.i18n[this.language].label;
     }
     return applicationFormItem.shortname;


### PR DESCRIPTION
* If is not set any label for application item, then is displayed its short name on the preview.