### PR TITLE
Searching by UUID hint

### DIFF
--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-users/admin-users.component.scss
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-users/admin-users.component.scss
@@ -1,3 +1,3 @@
 .search-field {
-  width: 300px;
+  width: 325px;
 }

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.scss
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.scss
@@ -1,5 +1,5 @@
 .search-field {
-    width: 300px;
+    width: 325px;
 }
 
 .align-elements{

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.scss
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.scss
@@ -1,5 +1,5 @@
 .search-field {
-  width: 300px;
+  width: 325px;
 }
 
 .align-elements{

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -286,7 +286,7 @@
       "ADD_MEMBER": "Add",
       "ADD_MEMBER_DISABLED": "You cannot add members manually into this Vo.",
       "REMOVE_MEMBERS": "Remove",
-      "SEARCH_DESCRIPTION": "Search by name, login or email",
+      "SEARCH_DESCRIPTION": "Search by name, login, email or UUID",
       "FILTER_STATUS": "Filter by Status",
       "INVITE": "Invite"
     },
@@ -566,7 +566,7 @@
       "ADD_MEMBER": "Add",
       "ADD_MEMBER_DISABLED": "You cannot add members manually into this group.",
       "REMOVE_MEMBERS": "Remove",
-      "SEARCH_DESCRIPTION": "Search by name, login or email",
+      "SEARCH_DESCRIPTION": "Search by name, login, email or UUID",
       "LIST_ALL": "List all members",
       "INVITE_MEMBER": "Invite",
       "SYNCHRONIZED": "Action is disabled on this group, group is filled with members from external source.",
@@ -1968,7 +1968,7 @@
     },
     "USERS": {
       "TITLE": "Users",
-      "SEARCH_PLACEHOLDER": "Search by name, email or login",
+      "SEARCH_PLACEHOLDER": "Search by name, email, login or UUID",
       "SEARCH_INFO": "You can search users by name, email or login or you can list all users without vo.",
       "NO_USERS_FOUND": "No users found.",
       "EMPTY_SEARCH": "Search field cannot be empty",


### PR DESCRIPTION
- Placeholder in search fields for searching users and members was
updated because it is now possible to search by user UUID as well.
- Width of search fields was increased so the new placeholder can fit
in.