### PR TITLE
fix(perun-web-apps): fix of resource dialog

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/create-resource-dialog/create-resource-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-resource-dialog/create-resource-dialog.component.ts
@@ -46,8 +46,6 @@ export class CreateResourceDialogComponent implements OnInit {
 
     this.nameCtrl = new FormControl(null, [Validators.required, Validators.pattern('.*[\\S]+.*')]);
     this.descriptionCtrl = new FormControl(null, [Validators.required, Validators.pattern('.*[\\S]+.*')]);
-    this.nameCtrl.markAllAsTouched();
-    this.descriptionCtrl.markAllAsTouched();
   }
 
 


### PR DESCRIPTION
* the dialog form items when creating resource are no longer marked as touched and so the items are validated after touching and not right away