### PR TITLE
refactor(admin-gui): refactor of group table and getting vos

### DIFF
--- a/libs/perun/components/src/lib/groups-list/groups-list.component.ts
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.ts
@@ -350,10 +350,12 @@ export class GroupsListComponent implements OnInit, AfterViewInit, OnChanges {
         this.groups.forEach(grp => {
           if(!this.voIds.has(grp.voId)){
             this.voIds.add(grp.voId);
-            this.voService.getVoById(grp.voId).subscribe(vo => {
-              this.voNames.set(grp.voId, vo.name);
-            });
           }
+        });
+        this.voService.getVosByIds([...this.voIds]).subscribe(vos => {
+          vos.forEach(vo => {
+            this.voNames.set(vo.id, vo.name);
+          });
         });
       }
   }


### PR DESCRIPTION
* table of groups now uses only one call to rpc for getting vos names if
VO column is present