### PR TITLE
ci(GithubCI): Fix pull_request lints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
 


### PR DESCRIPTION
* The pull_request trigger works only for pr from the same repository (not forks). For forks, we need pull_request_target.