### PR TITLE
fix(admin): Fix order of columns in groups list

### DIFF
--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
@@ -30,7 +30,7 @@
     [selection]="selected"
     [disableMembers]="false"
     [disableRouting]="!guiAuthResolver.isAuthorized('getGroupById_int_policy', [assignedGroups[0]])"
-    [displayedColumns]="['select', 'id', 'name', 'description', 'status']">
+    [displayedColumns]="['select', 'id', 'name', 'status', 'description']">
   </perun-web-apps-groups-list>
 </div>
 <app-alert *ngIf="assignedGroups.length === 0 && !loading" alert_type="warn">

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.html
@@ -34,6 +34,6 @@
     [disableRouting]="!routingAuth"
     [selection]="selected"
     [groupToResource]="group"
-    [displayedColumns]="['select', 'id', 'name', 'facility', 'status', 'tags', 'description']">
+    [displayedColumns]="['select', 'id', 'name', 'status', 'facility', 'tags', 'description']">
   </perun-web-apps-resources-list>
 </div>

--- a/apps/admin-gui/src/styles.scss
+++ b/apps/admin-gui/src/styles.scss
@@ -1295,6 +1295,14 @@ textarea.cdk-textarea-autosize-measuring {
   color: #1a87ff;
   vertical-align: bottom;
 }
+.material-icons.black {
+  color: #000000;
+  vertical-align: bottom;
+}
+.material-icons.grey {
+  color: #808080;
+  vertical-align: bottom;
+}
 
 //specific style for dialog without any border
 .noBorderDialog .mat-dialog-container {

--- a/libs/perun/components/src/lib/group-resource-status/group-resource-status.component.html
+++ b/libs/perun/components/src/lib/group-resource-status/group-resource-status.component.html
@@ -2,23 +2,23 @@
   *ngIf="status === 'ACTIVE'"
   matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_RESOURCE_STATUS.ACTIVE' | translate}}"
   matTooltipPosition="above">
-  <mat-icon>check_circle_outline</mat-icon>
+  <mat-icon class ="green">check_circle_outline</mat-icon>
 </span>
 <span
   *ngIf="status === 'INACTIVE'"
   matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_RESOURCE_STATUS.INACTIVE' | translate}}"
   matTooltipPosition="above">
-  <mat-icon>block</mat-icon>
+  <mat-icon class="grey">block</mat-icon>
 </span>
 <span
   *ngIf="status === 'FAILED'"
   matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_RESOURCE_STATUS.FAILED' | translate}}"
   matTooltipPosition="above">
-  <mat-icon>report</mat-icon>
+  <mat-icon class="red">report</mat-icon>
 </span>
 <span
   *ngIf="status === 'PROCESSING'"
   matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.GROUP_RESOURCE_STATUS.PROCESSING' | translate}}"
   matTooltipPosition="above">
-  <mat-icon>autorenew</mat-icon>
+  <mat-icon class="black">autorenew</mat-icon>
 </span>

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.html
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.html
@@ -63,11 +63,6 @@
               mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.TABLE_GROUP_NAME' | translate}}</th>
           <td *matCellDef="let group" mat-cell>{{group.name}}</td>
         </ng-container>
-        <ng-container matColumnDef="description">
-          <th *matHeaderCellDef mat-header-cell
-              mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.TABLE_GROUP_DESCRIPTION' | translate}}</th>
-          <td *matCellDef="let group" class="wrap-content" mat-cell>{{group.description}}</td>
-        </ng-container>
         <ng-container matColumnDef="status">
           <th *matHeaderCellDef mat-header-cell
               mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.TABLE_GROUP_STATUS' | translate}}</th>
@@ -76,6 +71,11 @@
               [status]="group.status">
             </perun-web-apps-group-resource-status>
           </td>
+        </ng-container>
+        <ng-container matColumnDef="description">
+          <th *matHeaderCellDef mat-header-cell
+              mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.TABLE_GROUP_DESCRIPTION' | translate}}</th>
+          <td *matCellDef="let group" class="wrap-content" mat-cell>{{group.description}}</td>
         </ng-container>
         <ng-container matColumnDef="expiration">
           <th *matHeaderCellDef mat-header-cell

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.ts
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.ts
@@ -73,7 +73,7 @@ export class GroupsListComponent implements OnInit, AfterViewInit, OnChanges {
   private hasMembersGroup = false;
 
   @Input()
-  displayedColumns: string[] = ['select', 'id', 'recent', 'vo', 'name', 'description', 'status', 'expiration', 'menu'];
+  displayedColumns: string[] = ['select', 'id', 'recent', 'vo', 'name', 'status', 'description', 'expiration', 'menu'];
 
   @Input()
   disableMembers: boolean;

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.html
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.html
@@ -60,12 +60,6 @@
               mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_VO_NAME' | translate}}</th>
           <td mat-cell *matCellDef="let resource">{{resource.vo.name}}</td>
         </ng-container>
-        <ng-container matColumnDef="facility">
-          <th mat-header-cell
-              *matHeaderCellDef
-              mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_FACILITY_NAME' | translate}}</th>
-          <td mat-cell *matCellDef="let resource">{{resource.facility.name}}</td>
-        </ng-container>
         <ng-container matColumnDef="status">
           <th mat-header-cell
               *matHeaderCellDef
@@ -75,6 +69,12 @@
               [status]="resource.status">
             </perun-web-apps-group-resource-status>
           </td>
+        </ng-container>
+        <ng-container matColumnDef="facility">
+          <th mat-header-cell
+              *matHeaderCellDef
+              mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_FACILITY_NAME' | translate}}</th>
+          <td mat-cell *matCellDef="let resource">{{resource.facility.name}}</td>
         </ng-container>
         <ng-container matColumnDef="tags">
           <th mat-header-cell

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.ts
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.ts
@@ -54,7 +54,7 @@ export class ResourcesListComponent implements AfterViewInit, OnChanges {
   @Input()
   routingVo = false;
   @Input()
-  displayedColumns: string[] = ['select', 'id', 'recent', 'name', 'vo', 'facility', 'status', 'tags', 'description'];
+  displayedColumns: string[] = ['select', 'id', 'recent', 'name', 'vo', 'status', 'facility', 'tags', 'description'];
   @Input()
   groupToResource: Group;
   @Input()


### PR DESCRIPTION
- The group-resource status in table in group-list component was placed
after description column. Now, it is placed after name column like in
other tables, e.g. in members-list.
- Each status icon has now different color.