### PR TITLE
fix(admin-gui): fix of selection/combo box of edit application form item

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.html
@@ -179,7 +179,7 @@
             <app-edit-application-form-item-line [label]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.LABEL' | translate"
                                                  [description]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.LABEL_BUTTON_DESCRIPTION' | translate">
               <mat-form-field class="w-100">
-                <textarea [(ngModel)]="applicationFormItem.i18n[''].label" matInput></textarea>
+                <textarea [(ngModel)]="applicationFormItem.i18n[lang].label" matInput></textarea>
               </mat-form-field>
             </app-edit-application-form-item-line>
           </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.ts
@@ -286,7 +286,9 @@ export class EditApplicationFormItemDialogComponent implements OnInit {
   }
 
   private getOptions() {
+    this.options = {};
     for (const lang of this.languages) {
+      this.options[lang] = [];
       if (this.applicationFormItem.i18n[lang].options) {
         const temp = this.applicationFormItem.i18n[lang].options.split('|');
         for (const item of temp) {


### PR DESCRIPTION
* when user wanted to edit some of 'RADIO', 'COMBOBOX', 'CHECKBOX', 'SELECTIONBOX' types of application form item the gui was displaying blank page and throwing errors on console