### PR TITLE
fix(profile): fix header menu for mobile view

### DIFF
--- a/apps/user-profile/src/app/app.component.ts
+++ b/apps/user-profile/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, HostListener, OnInit } from '@angular/core';
 import { InitAuthService, StoreService } from '@perun-web-apps/perun/services';
 import { AttributesManagerService } from '@perun-web-apps/perun/openapi';
 import { TranslateService } from '@ngx-translate/core';
@@ -16,7 +16,8 @@ export class AppComponent implements OnInit {
   constructor(private store:StoreService,
               private attributesManagerService: AttributesManagerService,
               private translateService:TranslateService,
-              private initAuth: InitAuthService) {
+              private initAuth: InitAuthService,
+              private changeDetector: ChangeDetectorRef) {
     this.getScreenSize();
   }
 
@@ -49,6 +50,7 @@ export class AppComponent implements OnInit {
   }
 
   setContentHeight(height: number) {
-    this.contentHeight =  'calc(100vh - 84px - '+height+'px)'
+    this.contentHeight =  'calc(100vh - 84px - '+height+'px)';
+    this.changeDetector.detectChanges();
   }
 }

--- a/apps/user-profile/src/app/components/header/header.component.html
+++ b/apps/user-profile/src/app/components/header/header.component.html
@@ -6,7 +6,7 @@
 
   <a class="ml-3" [innerHTML]="logo" [routerLink]="disableLogo ? [] : ['/']" queryParamsHandling="merge"></a>
 
-  <p [ngStyle]="{'color': textColor}" class="ml-3 mt-auto mb-auto">{{label}}</p>
+  <p [ngStyle]="{'color': textColor}" class="ml-3 mt-auto mb-auto hide-label">{{label}}</p>
 
   <perun-web-apps-header-menu
     id="nav-menu-user-info"

--- a/apps/user-profile/src/app/components/header/header.component.scss
+++ b/apps/user-profile/src/app/components/header/header.component.scss
@@ -12,3 +12,9 @@
   margin-left: auto;
   margin-right: 0;
 }
+
+@media (max-width: 570px) {
+  .hide-label {
+    display: none;
+  }
+}


### PR DESCRIPTION
* The header menu used to be placed out of the screen on mobile view.
* In this PR has been also fixed error 'ExpressionChangedAfterItHasBeenCheckedError', which was visible only in development mode.