### PR TITLE
fix(admin-gui): fixed workflow of creating sponsored member

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
@@ -109,7 +109,7 @@ export class CreateSponsoredMemberDialogComponent implements OnInit {
     this.voSponsors = this.data.sponsors;
     this.isSponsor = this.guiAuthResolver.principalHasRole(Role.SPONSOR, 'Vo', this.data.voId);
     this.isPerunAdmin = this.guiAuthResolver.isPerunAdmin();
-
+    this.sponsorType = this.isSponsor ? 'self' : 'other';
     this.userControl = this.formBuilder.group({
       firstName: ['', Validators.required],
       lastName: ['', Validators.required],
@@ -262,6 +262,7 @@ export class CreateSponsoredMemberDialogComponent implements OnInit {
       this.enableFormControl(password, validators, [loginAsyncValidator(namespc, this.usersService, this.apiRequestConfiguration)]);
       this.enableFormControl(passwordReset, []);
       this.enableFormControl(showPassword, []);
+      this.namespaceControl.get('passwordReset').setValue(false);
     } else {
       password.disable();
       password.setValue('');


### PR DESCRIPTION
* Fixed workflow bug where user wasn't shown why he/she couldn't continue from 2nd to 3rd steps in process of creation sponsored member
* Fixed bug where in the last step, first option in radio button group was always checked by default, even if it was disabled