### PR TITLE
fix: don't send acr_values=null if no filter should be used

### DIFF
--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -46,7 +46,7 @@ export class AuthService {
 
   getClientSettings(): UserManagerSettings {
     const filterValue = this.setIdpFilter();
-    return {
+    const data: any = {
       authority: this.store.get('oidc_client', 'oauth_authority'),
       client_id: this.store.get('oidc_client', 'oauth_client_id'),
       redirect_uri: this.store.get('oidc_client', 'oauth_redirect_uri'),
@@ -56,9 +56,12 @@ export class AuthService {
       filterProtocolClaims: true,
       loadUserInfo: this.store.get('oidc_client', 'oauth_load_user_info'),
       automaticSilentRenew: true,
-      silent_redirect_uri: this.store.get('oidc_client', 'oauth_silent_redirect_uri'),
-      extraQueryParams: { 'acr_values': filterValue }
+      silent_redirect_uri: this.store.get('oidc_client', 'oauth_silent_redirect_uri')
     };
+    if (filterValue) {
+      data.extraQueryParams = { 'acr_values': filterValue };
+    }
+    return data
   }
 
   setIdpFilter(): string {


### PR DESCRIPTION
* When no default filter was defined or when there were no filters, the application would send
acr_values=null to the oidc server, which caused it to fail the authentication.We need to set this
property only if there is some filter values.