### PR TITLE
ci(githubci): add maintanance branches for semantic releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 on:
   push:
-    branches:
-      - production
+    branches-ignore:
+      - master
+    tags-ignore:
+      - v*
 jobs:
   release:
     name: Release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": [ "production" ],
+  "branches": [ "production", "+([0-9])?(.{+([0-9]),x}).x"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
* Change the Github workflow so it is run also on maintanance branches.
* Updated semantic release configuration to perform releasing on maintanance branches.