### PR TITLE
fix(admin): don't show non-existent objects on dashboard

### DIFF
--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-recently-viewed-button-field/dashboard-recently-viewed-button-field.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-recently-viewed-button-field/dashboard-recently-viewed-button-field.component.html
@@ -1,7 +1,12 @@
 <app-alert *ngIf="items.length === 0" alert_type="info">{{'USER_DETAIL.DASHBOARD.NO_RECENTLY_VIEWED' | translate}}</app-alert>
 <div *ngIf="items.length > 0" class="items-container">
   <div *ngFor="let item of items" class="item-itself-container" mat-ripple>
-    <a class="{{item.style}} item-itself" [routerLink]="item.url" queryParamsHandling="merge">
+    <a
+      class="{{item.style}} item-itself"
+      [routerLink]="item.url"
+      queryParamsHandling="merge"
+      matTooltip="{{item.tooltip}}"
+      [matTooltipDisabled]="item.label === item.tooltip">
       <span class="item-type">{{item.type}}</span>
       <mat-icon [svgIcon]="item.cssIcon" class="item-pic perun-icon"></mat-icon>
       {{item.label}}

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-recently-viewed-button-field/dashboard-recently-viewed-button-field.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-recently-viewed-button-field/dashboard-recently-viewed-button-field.component.ts
@@ -1,9 +1,15 @@
 import { Component, OnInit } from '@angular/core';
 import { getRecentlyVisitedIds } from '@perun-web-apps/perun/utils';
+import {
+  FacilitiesManagerService,
+  GroupsManagerService,
+  VosManagerService
+} from '@perun-web-apps/perun/openapi';
 
 export interface RecentItem {
   url: string;
   label: string;
+  tooltip?: string;
   style: string;
   cssIcon: string;
   type: string;
@@ -16,14 +22,63 @@ export interface RecentItem {
 })
 export class DashboardRecentlyViewedButtonFieldComponent implements OnInit {
 
-  constructor() { }
+  constructor(private vosManager: VosManagerService,
+              private groupsManager: GroupsManagerService,
+              private facilitiesManager: FacilitiesManagerService) { }
 
   items: RecentItem[] = [];
 
-  voId: number;
+  vosIds: number[] = [];
+  groupsIds: number[] = [];
+  facilitiesIds: number[] = [];
+  existingRecentIds: number[] = [];
 
   ngOnInit() {
-    const recent = getRecentlyVisitedIds('recent');
+    let recent = getRecentlyVisitedIds('recent');
+
+    for (const item of recent) {
+      switch (item.type) {
+        case 'Vo': {
+          this.vosIds.push(item.id);
+          break;
+        }
+        case 'Group': {
+          this.groupsIds.push(item.id);
+          break;
+        }
+        case 'Facility': {
+          this.facilitiesIds.push(item.id);
+          break;
+        }
+      }
+    }
+
+    // if no vos/groups/facilities are in recently viewed, post to the backend "-1" to get an empty array
+    if (this.vosIds.length === 0) {
+      this.vosIds.push(-1);
+    }
+    if (this.groupsIds.length === 0) {
+      this.groupsIds.push(-1);
+    }
+    if (this.facilitiesIds.length === 0) {
+      this.facilitiesIds.push(-1);
+    }
+
+    this.vosManager.getVosByIds(this.vosIds).subscribe(vos => {
+      this.existingRecentIds.push(...vos.map(vo => vo.id));
+      this.groupsManager.getGroupsByIds(this.groupsIds).subscribe(groups => {
+        this.existingRecentIds.push(...groups.map(group => group.id));
+        this.facilitiesManager.getFacilitiesByIds(this.facilitiesIds).subscribe(facilities => {
+          this.existingRecentIds.push(...facilities.map(facility => facility.id));
+          recent = recent.filter(rec => this.existingRecentIds.indexOf(rec.id) > -1);
+          this.addRecentlyViewedToDashboard(recent);
+        });
+      });
+    });
+
+  }
+
+  private addRecentlyViewedToDashboard(recent: any[]) {
     for (const item of recent) {
       switch (item.type) {
         case 'Vo': {
@@ -41,6 +96,7 @@ export class DashboardRecentlyViewedButtonFieldComponent implements OnInit {
             cssIcon: 'perun-group',
             url: `/organizations/${item.voId}/groups/${item.id}`,
             label: item.name,
+            tooltip: item.fullName,
             style: 'group-btn',
             type: 'Group'
           });

--- a/libs/perun/utils/src/lib/perun-utils.ts
+++ b/libs/perun/utils/src/lib/perun-utils.ts
@@ -287,7 +287,7 @@ export function addRecentlyVisitedObject(item: any) {
     const recent: any[] = JSON.parse(localStorage.getItem('recent'));
     let object;
     if (item.beanName === 'Group') {
-      object = {id: item.id, name: item.shortName, type: item.beanName, voId: item.voId};
+      object = {id: item.id, name: item.shortName, fullName: item.name, type: item.beanName, voId: item.voId};
     } else {
       object = {id: item.id, name: item.name, type: item.beanName, voId: item.voId};
     }


### PR DESCRIPTION
* Dashboard used to show also objects which were already deleted.
* In this PR was also added tootlip for subgroups on dashboard (tooltip shows whole fullname).