### PR TITLE
feat(profile): disable delete Other identities

### DIFF
--- a/apps/user-profile/src/app/pages/identities-page/identities-page.component.html
+++ b/apps/user-profile/src/app/pages/identities-page/identities-page.component.html
@@ -32,7 +32,6 @@
         info_outline
       </mat-icon>
     </h1>
-    <button (click)="removeIdentity(otherSelection)" [disabled]="otherSelection.selected.length === 0" class="ml-2" color="warn" mat-flat-button>{{'IDENTITIES.REMOVE' | customTranslate | translate}}</button>
     <perun-web-apps-user-ext-sources-list
       [userExtSources]="otherExtSources"
       [selection]="otherSelection"

--- a/apps/user-profile/src/app/pages/identities-page/identities-page.component.ts
+++ b/apps/user-profile/src/app/pages/identities-page/identities-page.component.ts
@@ -43,7 +43,7 @@ export class IdentitiesPageComponent implements OnInit {
 
   displayedColumnsIdp = ['select', 'extSourceName', 'login', 'lastAccess']
   displayedColumnsCert= ['select', 'extSourceName', 'login', 'lastAccess']
-  displayedColumnsOther = ['select', 'extSourceName', 'login', 'lastAccess']
+  displayedColumnsOther = ['extSourceName', 'login', 'lastAccess']
 
   ngOnInit() {
     this.userId = this.storage.getPerunPrincipal().userId;

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -57,7 +57,7 @@
     "EXT_SOURCE_NAME_OTHER": "Jméno externího zdroje",
     "LOGIN_CERT": "DN",
     "LOGIN_IDP": "Připojená identita",
-    "OTHER_TOOLTIP": "Identity, které nebyly získány cez Konsolidátor identit"
+    "OTHER_TOOLTIP": "Identity, které nebyly získány přes Konsolidátor identit"
   },
   "PRIVACY": {
     "TITLE": "Soukromí",


### PR DESCRIPTION
* Other identities in section Linked identities cannot be deleted now.
* Fixed text in info tooltip.

BREAKING CHANGE: Other identities cannot be deleted any longer.