### PR TITLE
fix: Show all resources in member-attributes page

### DIFF
--- a/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.ts
+++ b/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.ts
@@ -64,8 +64,8 @@ export class TwoEntityAttributePageComponent implements OnInit {
       case 'member':
         switch (this.secondEntity) {
           case 'resource':
-            this.resourcesManagerService.getAllowedResources(this.firstEntityId).subscribe(resources => {
-              this.entityValues = resources;
+            this.resourcesManagerService.getAssignedResourcesWithStatus(this.firstEntityId).subscribe(resources => {
+              this.entityValues = resources.map(resource => resource.enrichedResource.resource);
               this.preselectEntity();
               this.loading = false;
             })

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-attributes/member-attributes.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-attributes/member-attributes.component.ts
@@ -35,7 +35,7 @@ export class MemberAttributesComponent implements OnInit {
        this.member = member;
 
        this.memberGroupAttAuth = this.authResolver.isAuthorized('getMemberGroups_Member_policy', [this.member]);
-       this.memberResourceAttAuth = this.authResolver.isAuthorized('getAllowedResources_Member_policy', [this.member]);
+       this.memberResourceAttAuth = this.authResolver.isAuthorized('getAssignedResourcesWithStatus_Member_policy', [this.member]);
        this.userFacilityAttAuth = this.authResolver.isAuthorized('getAssignedFacilities_User_policy', [{beanName: 'User', id: member.userId}]);
      });
     });

--- a/libs/perun/openapi/src/lib/api/attributesManager.service.ts
+++ b/libs/perun/openapi/src/lib/api/attributesManager.service.ts
@@ -651,13 +651,22 @@ export class AttributesManagerService {
 
     /**
      * Returns all AttributeDefinitions in a namespace.
+     * @param namespace name of namespace to obtain attribute definitions from
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getAttributeDefinitionsByNamespace(observe?: 'body', reportProgress?: boolean): Observable<Array<AttributeDefinition>>;
-    public getAttributeDefinitionsByNamespace(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<AttributeDefinition>>>;
-    public getAttributeDefinitionsByNamespace(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<AttributeDefinition>>>;
-    public getAttributeDefinitionsByNamespace(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getAttributeDefinitionsByNamespace(namespace: string, observe?: 'body', reportProgress?: boolean): Observable<Array<AttributeDefinition>>;
+    public getAttributeDefinitionsByNamespace(namespace: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<AttributeDefinition>>>;
+    public getAttributeDefinitionsByNamespace(namespace: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<AttributeDefinition>>>;
+    public getAttributeDefinitionsByNamespace(namespace: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+        if (namespace === null || namespace === undefined) {
+            throw new Error('Required parameter namespace was null or undefined when calling getAttributeDefinitionsByNamespace.');
+        }
+
+        let queryParameters = new HttpParams({encoder: this.encoder});
+        if (namespace !== undefined && namespace !== null) {
+            queryParameters = queryParameters.set('namespace', <any>namespace);
+        }
 
         let headers = this.defaultHeaders;
 
@@ -689,6 +698,7 @@ export class AttributesManagerService {
 
         return this.httpClient.get<Array<AttributeDefinition>>(`${this.configuration.basePath}/json/attributesManager/getAttributesDefinitionByNamespace`,
             {
+                params: queryParameters,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
                 observe: observe,

--- a/libs/perun/openapi/src/lib/api/groupsManager.service.ts
+++ b/libs/perun/openapi/src/lib/api/groupsManager.service.ts
@@ -1846,19 +1846,16 @@ export class GroupsManagerService {
      * Returns RichGroup selected by id containing selected attributes
      * Throws GroupNotExistsException when the group doesn\&#39;t exist.
      * @param groupId id of Group
-     * @param attrNames list of attribute names List&lt;String&gt;
+     * @param attrNames list of attribute names List&lt;String&gt; or null
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getRichGroupByIdWithAttributesByNames(groupId: number, attrNames: Array<string>, observe?: 'body', reportProgress?: boolean): Observable<RichGroup>;
-    public getRichGroupByIdWithAttributesByNames(groupId: number, attrNames: Array<string>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<RichGroup>>;
-    public getRichGroupByIdWithAttributesByNames(groupId: number, attrNames: Array<string>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<RichGroup>>;
-    public getRichGroupByIdWithAttributesByNames(groupId: number, attrNames: Array<string>, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getRichGroupByIdWithAttributesByNames(groupId: number, attrNames?: Array<string>, observe?: 'body', reportProgress?: boolean): Observable<RichGroup>;
+    public getRichGroupByIdWithAttributesByNames(groupId: number, attrNames?: Array<string>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<RichGroup>>;
+    public getRichGroupByIdWithAttributesByNames(groupId: number, attrNames?: Array<string>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<RichGroup>>;
+    public getRichGroupByIdWithAttributesByNames(groupId: number, attrNames?: Array<string>, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (groupId === null || groupId === undefined) {
             throw new Error('Required parameter groupId was null or undefined when calling getRichGroupByIdWithAttributesByNames.');
-        }
-        if (attrNames === null || attrNames === undefined) {
-            throw new Error('Required parameter attrNames was null or undefined when calling getRichGroupByIdWithAttributesByNames.');
         }
 
         let queryParameters = new HttpParams({encoder: this.encoder});

--- a/libs/perun/openapi/src/lib/api/resourcesManager.service.ts
+++ b/libs/perun/openapi/src/lib/api/resourcesManager.service.ts
@@ -18,6 +18,7 @@ import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { AssignedGroup } from '../model/assignedGroup';
+import { AssignedMember } from '../model/assignedMember';
 import { AssignedResource } from '../model/assignedResource';
 import { BanOnResource } from '../model/banOnResource';
 import { EnrichedResource } from '../model/enrichedResource';
@@ -2185,6 +2186,64 @@ export class ResourcesManagerService {
     }
 
     /**
+     * Returns members of groups assigned to resource with status of group-resource assignment.
+     * @param resource id of Resource
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public getAssignedMembersWithStatus(resource: number, observe?: 'body', reportProgress?: boolean): Observable<Array<AssignedMember>>;
+    public getAssignedMembersWithStatus(resource: number, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<AssignedMember>>>;
+    public getAssignedMembersWithStatus(resource: number, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<AssignedMember>>>;
+    public getAssignedMembersWithStatus(resource: number, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+        if (resource === null || resource === undefined) {
+            throw new Error('Required parameter resource was null or undefined when calling getAssignedMembersWithStatus.');
+        }
+
+        let queryParameters = new HttpParams({encoder: this.encoder});
+        if (resource !== undefined && resource !== null) {
+            queryParameters = queryParameters.set('resource', <any>resource);
+        }
+
+        let headers = this.defaultHeaders;
+
+        // authentication (ApiKeyAuth) required
+        if (this.configuration.apiKeys && this.configuration.apiKeys["Authorization"]) {
+            headers = headers.set('Authorization', this.configuration.apiKeys["Authorization"]);
+        }
+
+        // authentication (BasicAuth) required
+        if (this.configuration.username || this.configuration.password) {
+            headers = headers.set('Authorization', 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password));
+        }
+        // authentication (BearerAuth) required
+        if (this.configuration.accessToken) {
+            const accessToken = typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken()
+                : this.configuration.accessToken;
+            headers = headers.set('Authorization', 'Bearer ' + accessToken);
+        }
+        // to determine the Accept header
+        const httpHeaderAccepts: string[] = [
+            'application/json'
+        ];
+        const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        if (httpHeaderAcceptSelected !== undefined) {
+            headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+
+
+        return this.httpClient.get<Array<AssignedMember>>(`${this.configuration.basePath}/json/resourcesManager/getAssignedMembersWithStatus`,
+            {
+                params: queryParameters,
+                withCredentials: this.configuration.withCredentials,
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
      * List all resources associated with a group.
      * @param group id of Group
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -2290,6 +2349,64 @@ export class ResourcesManagerService {
 
 
         return this.httpClient.get<Array<Resource>>(`${this.configuration.basePath}/json/resourcesManager/getAssignedResources/m`,
+            {
+                params: queryParameters,
+                withCredentials: this.configuration.withCredentials,
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Returns all assigned resources with statuses where member is assigned through the groups.
+     * @param member id of Member
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public getAssignedResourcesWithStatus(member: number, observe?: 'body', reportProgress?: boolean): Observable<Array<AssignedResource>>;
+    public getAssignedResourcesWithStatus(member: number, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<AssignedResource>>>;
+    public getAssignedResourcesWithStatus(member: number, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<AssignedResource>>>;
+    public getAssignedResourcesWithStatus(member: number, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+        if (member === null || member === undefined) {
+            throw new Error('Required parameter member was null or undefined when calling getAssignedResourcesWithStatus.');
+        }
+
+        let queryParameters = new HttpParams({encoder: this.encoder});
+        if (member !== undefined && member !== null) {
+            queryParameters = queryParameters.set('member', <any>member);
+        }
+
+        let headers = this.defaultHeaders;
+
+        // authentication (ApiKeyAuth) required
+        if (this.configuration.apiKeys && this.configuration.apiKeys["Authorization"]) {
+            headers = headers.set('Authorization', this.configuration.apiKeys["Authorization"]);
+        }
+
+        // authentication (BasicAuth) required
+        if (this.configuration.username || this.configuration.password) {
+            headers = headers.set('Authorization', 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password));
+        }
+        // authentication (BearerAuth) required
+        if (this.configuration.accessToken) {
+            const accessToken = typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken()
+                : this.configuration.accessToken;
+            headers = headers.set('Authorization', 'Bearer ' + accessToken);
+        }
+        // to determine the Accept header
+        const httpHeaderAccepts: string[] = [
+            'application/json'
+        ];
+        const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        if (httpHeaderAcceptSelected !== undefined) {
+            headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+
+
+        return this.httpClient.get<Array<AssignedResource>>(`${this.configuration.basePath}/json/resourcesManager/getAssignedResourcesWithStatus`,
             {
                 params: queryParameters,
                 withCredentials: this.configuration.withCredentials,

--- a/libs/perun/openapi/src/lib/api/usersManager.service.ts
+++ b/libs/perun/openapi/src/lib/api/usersManager.service.ts
@@ -189,6 +189,65 @@ export class UsersManagerService {
     }
 
     /**
+     * Anonymizes user - according to configuration, each of user\&#39;s attributes is either anonymized, kept untouched or deleted. Also deletes other user\&#39;s related data, e.g. authorships of users publications, mail change and password reset requests, bans...
+     * @param user id of User
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public anonymizeUser(user: number, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public anonymizeUser(user: number, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public anonymizeUser(user: number, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public anonymizeUser(user: number, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+        if (user === null || user === undefined) {
+            throw new Error('Required parameter user was null or undefined when calling anonymizeUser.');
+        }
+
+        let queryParameters = new HttpParams({encoder: this.encoder});
+        if (user !== undefined && user !== null) {
+            queryParameters = queryParameters.set('user', <any>user);
+        }
+
+        let headers = this.defaultHeaders;
+
+        // authentication (ApiKeyAuth) required
+        if (this.configuration.apiKeys && this.configuration.apiKeys["Authorization"]) {
+            headers = headers.set('Authorization', this.configuration.apiKeys["Authorization"]);
+        }
+
+        // authentication (BasicAuth) required
+        if (this.configuration.username || this.configuration.password) {
+            headers = headers.set('Authorization', 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password));
+        }
+        // authentication (BearerAuth) required
+        if (this.configuration.accessToken) {
+            const accessToken = typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken()
+                : this.configuration.accessToken;
+            headers = headers.set('Authorization', 'Bearer ' + accessToken);
+        }
+        // to determine the Accept header
+        const httpHeaderAccepts: string[] = [
+            'application/json'
+        ];
+        const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        if (httpHeaderAcceptSelected !== undefined) {
+            headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+
+
+        return this.httpClient.post<any>(`${this.configuration.basePath}/urlinjsonout/usersManager/anonymizeUser`,
+            null,
+            {
+                params: queryParameters,
+                withCredentials: this.configuration.withCredentials,
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
      * Changes user password in defined login-namespace based on token parameter.
      * This method throws PasswordResetLinkExpiredException when the password reset request expired. This method throws PasswordResetLinkNotValidException when the password reset request was already used or has never existed. 
      * @param token token for the password reset request
@@ -1127,6 +1186,65 @@ export class UsersManagerService {
 
 
         return this.httpClient.get<Array<User>>(`${this.configuration.basePath}/json/usersManager/findUsers`,
+            {
+                params: queryParameters,
+                withCredentials: this.configuration.withCredentials,
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Returns users with attributes
+     * Returns list of objects representing the User with attributes
+     * @param includedSpecificUsers if you want to or don\&#39;t want to get specificUsers too
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public getAllRichUsersWithAttributes(includedSpecificUsers: boolean, observe?: 'body', reportProgress?: boolean): Observable<Array<RichUser>>;
+    public getAllRichUsersWithAttributes(includedSpecificUsers: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<RichUser>>>;
+    public getAllRichUsersWithAttributes(includedSpecificUsers: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<RichUser>>>;
+    public getAllRichUsersWithAttributes(includedSpecificUsers: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+        if (includedSpecificUsers === null || includedSpecificUsers === undefined) {
+            throw new Error('Required parameter includedSpecificUsers was null or undefined when calling getAllRichUsersWithAttributes.');
+        }
+
+        let queryParameters = new HttpParams({encoder: this.encoder});
+        if (includedSpecificUsers !== undefined && includedSpecificUsers !== null) {
+            queryParameters = queryParameters.set('includedSpecificUsers', <any>includedSpecificUsers);
+        }
+
+        let headers = this.defaultHeaders;
+
+        // authentication (ApiKeyAuth) required
+        if (this.configuration.apiKeys && this.configuration.apiKeys["Authorization"]) {
+            headers = headers.set('Authorization', this.configuration.apiKeys["Authorization"]);
+        }
+
+        // authentication (BasicAuth) required
+        if (this.configuration.username || this.configuration.password) {
+            headers = headers.set('Authorization', 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password));
+        }
+        // authentication (BearerAuth) required
+        if (this.configuration.accessToken) {
+            const accessToken = typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken()
+                : this.configuration.accessToken;
+            headers = headers.set('Authorization', 'Bearer ' + accessToken);
+        }
+        // to determine the Accept header
+        const httpHeaderAccepts: string[] = [
+            'application/json'
+        ];
+        const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        if (httpHeaderAcceptSelected !== undefined) {
+            headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+
+
+        return this.httpClient.get<Array<RichUser>>(`${this.configuration.basePath}/json/usersManager/getAllRichUsersWithAttributes`,
             {
                 params: queryParameters,
                 withCredentials: this.configuration.withCredentials,
@@ -2295,6 +2413,55 @@ export class UsersManagerService {
         return this.httpClient.get<Array<UserExtSource>>(`${this.configuration.basePath}/json/usersManager/getUserExtSourcesByIds`,
             {
                 params: queryParameters,
+                withCredentials: this.configuration.withCredentials,
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Returns all users
+     * Returns list of objects representing the User
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public getUsers(observe?: 'body', reportProgress?: boolean): Observable<Array<User>>;
+    public getUsers(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<User>>>;
+    public getUsers(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<User>>>;
+    public getUsers(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+
+        let headers = this.defaultHeaders;
+
+        // authentication (ApiKeyAuth) required
+        if (this.configuration.apiKeys && this.configuration.apiKeys["Authorization"]) {
+            headers = headers.set('Authorization', this.configuration.apiKeys["Authorization"]);
+        }
+
+        // authentication (BasicAuth) required
+        if (this.configuration.username || this.configuration.password) {
+            headers = headers.set('Authorization', 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password));
+        }
+        // authentication (BearerAuth) required
+        if (this.configuration.accessToken) {
+            const accessToken = typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken()
+                : this.configuration.accessToken;
+            headers = headers.set('Authorization', 'Bearer ' + accessToken);
+        }
+        // to determine the Accept header
+        const httpHeaderAccepts: string[] = [
+            'application/json'
+        ];
+        const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        if (httpHeaderAcceptSelected !== undefined) {
+            headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+
+
+        return this.httpClient.get<Array<User>>(`${this.configuration.basePath}/json/usersManager/getUsers`,
+            {
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
                 observe: observe,

--- a/libs/perun/openapi/src/lib/model/assignedGroup.ts
+++ b/libs/perun/openapi/src/lib/model/assignedGroup.ts
@@ -16,6 +16,7 @@ import { GroupResourceStatus } from './groupResourceStatus';
 export interface AssignedGroup { 
     enrichedGroup?: EnrichedGroup;
     status?: GroupResourceStatus;
+    sourceGroupId?: number;
     failureCause?: string;
 }
 

--- a/libs/perun/openapi/src/lib/model/assignedMember.ts
+++ b/libs/perun/openapi/src/lib/model/assignedMember.ts
@@ -9,18 +9,12 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-import { EnrichedResource } from './enrichedResource';
-import { ResourceTag } from './resourceTag';
-import { Facility } from './facility';
+import { Member } from './member';
 import { GroupResourceStatus } from './groupResourceStatus';
 
 
-export interface AssignedResource { 
-    enrichedResource?: EnrichedResource;
+export interface AssignedMember { 
+    member?: Member;
     status?: GroupResourceStatus;
-    sourceGroupId?: number;
-    failureCause?: string;
-    facility?: Facility;
-    resourceTags?: Array<ResourceTag>;
 }
 

--- a/libs/perun/openapi/src/lib/model/models.ts
+++ b/libs/perun/openapi/src/lib/model/models.ts
@@ -8,6 +8,7 @@ export * from './applicationFormItem';
 export * from './applicationFormItemData';
 export * from './applicationMail';
 export * from './assignedGroup';
+export * from './assignedMember';
 export * from './assignedResource';
 export * from './attribute';
 export * from './attributeDefinition';


### PR DESCRIPTION
* All resources are now shown in member-attribute drop-down menu,
not just those with ACTIVE GroupResourceStatus.
* Regenerated openapi to access new method.