### PR TITLE
fix: align footer items

### DIFF
--- a/libs/perun/components/src/lib/perun-footer/perun-footer.component.html
+++ b/libs/perun/components/src/lib/perun-footer/perun-footer.component.html
@@ -1,6 +1,6 @@
-<footer [ngStyle]="{'background': bgColor}" class="wrap-content container-fluid text-center text-md-left pr-xl-5 pl-xl-5">
-  <div class="row">
-    <div *ngFor="let item of items" class="footer-col col-md-4 mx-auto">
+<footer [ngStyle]="{'background': bgColor}" class="footer-container">
+  <div class="footer-columns-container">
+    <div *ngFor="let item of items" class="footer-col mx-auto">
       <h6 [ngStyle]="{'color': headersTextColor}" class="font-weight-bold">
         {{item | localisedText: language:'title'}}
       </h6>

--- a/libs/perun/components/src/lib/perun-footer/perun-footer.component.scss
+++ b/libs/perun/components/src/lib/perun-footer/perun-footer.component.scss
@@ -13,6 +13,7 @@ a {
 .footer-col {
   padding-top: 35px;
   white-space: nowrap;
+  text-align: center;
 }
 
 .wrap-content {
@@ -21,4 +22,17 @@ a {
 
 #clickable {
   cursor: pointer;
+}
+
+.footer-columns-container {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  @media (min-width: 768px) {
+    flex-direction: row;
+  }
+}
+
+.footer-container {
+  height: fit-content;
 }


### PR DESCRIPTION
* Items in footer columns were not aligned properly and it looked weird. From now, the items are
centered.