### PR TITLE
feat(admin): add all assignment statuses to group/resource attribute settings

### DIFF
--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.ts
@@ -17,8 +17,8 @@ import {
 import { PageEvent } from '@angular/material/paginator';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { GuiAuthResolver } from '@perun-web-apps/perun/services';
-import { GroupWithStatus } from '@perun-web-apps/perun/components';
 import { Urns } from '@perun-web-apps/perun/urns';
+import { GroupWithStatus } from '@perun-web-apps/perun/models';
 
 @Component({
   selector: 'app-perun-web-apps-resource-groups',

--- a/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.html
@@ -8,6 +8,7 @@
         *ngIf="secondEntity === 'group'"
         [groups]="entityValues"
         [firstSelectedGroup]="specificSecondEntity"
+        [displayStatus]="true"
         (groupSelected)="specifySecondEntity($event)">
       </perun-web-apps-group-search-select>
 

--- a/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.ts
+++ b/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.ts
@@ -14,6 +14,8 @@ import { getDefaultDialogConfig, getRecentlyVisitedIds } from '@perun-web-apps/p
 import { EditAttributeDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { CreateAttributeDialogComponent } from '../dialogs/create-attribute-dialog/create-attribute-dialog.component';
 import { Urns } from '@perun-web-apps/perun/urns';
+import { ResourceWithStatus } from '@perun-web-apps/perun/models';
+import { GroupWithStatus } from '@perun-web-apps/perun/models';
 
 @Component({
   selector: 'app-two-entity-attribute-page',
@@ -81,8 +83,12 @@ export class TwoEntityAttributePageComponent implements OnInit {
       case 'group':
         switch (this.secondEntity){
           case 'resource':
-            this.resourcesManagerService.getAssignedResourcesWithGroup(this.firstEntityId).subscribe(resources => {
-              this.entityValues = resources;
+            this.resourcesManagerService.getResourceAssignments(this.firstEntityId).subscribe(resources => {
+              this.entityValues = <ResourceWithStatus[]>resources.map(r =>{
+                const resWithStatus: ResourceWithStatus = r.enrichedResource.resource;
+                resWithStatus.status = r.status;
+                return resWithStatus;
+              });
               this.preselectEntity();
               this.loading = false;
             });
@@ -114,11 +120,15 @@ export class TwoEntityAttributePageComponent implements OnInit {
             })
             break;
           case 'group':
-            this.resourcesManagerService.getAssignedGroups(this.firstEntityId).subscribe(groups => {
-              this.entityValues = groups;
+            this.resourcesManagerService.getGroupAssignments(this.firstEntityId).subscribe(groups => {
+              this.entityValues = <GroupWithStatus[]>groups.map(g =>{
+                const resWithStatus: GroupWithStatus = g.enrichedGroup.group;
+                resWithStatus.status = g.status;
+                return resWithStatus;
+              });
               this.preselectEntity();
               this.loading = false;
-            })
+            });
             break;
         }
         break;

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.ts
@@ -13,7 +13,8 @@ import { AddGroupResourceDialogComponent } from '../../../../shared/components/d
 import { RemoveGroupResourceDialogComponent } from '../../../../shared/components/dialogs/remove-group-resource-dialog/remove-group-resource-dialog.component';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { GuiAuthResolver } from '@perun-web-apps/perun/services';
-import { ResourcesListComponent, ResourceWithStatus } from '@perun-web-apps/perun/components';
+import { ResourcesListComponent } from '@perun-web-apps/perun/components';
+import { ResourceWithStatus } from '@perun-web-apps/perun/models';
 
 @Component({
   selector: 'app-group-resources',

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.css
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.css
@@ -2,3 +2,19 @@
   visibility: hidden;
   position: absolute;
 }
+
+.green {
+  color: green;
+}
+
+.grey {
+  color: grey;
+}
+
+.red {
+  color: red;
+}
+
+.black {
+  color: black;
+}

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.html
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.html
@@ -13,6 +13,9 @@
     </mat-option>
     <mat-option class="selected-options-bottom" *ngIf="entitiesCtrl?.value" [value]="entitiesCtrl?.value">
       {{mainTextFunction(entitiesCtrl?.value)}} <span class="text-muted muted">{{secondaryTextFunction(entitiesCtrl?.value)}}</span>
+      <span *ngIf="displayStatus" class="{{colorByStatus(entitiesCtrl?.value)}}">
+        ({{statusTextFunction(entitiesCtrl?.value)}})
+      </span>
     </mat-option>
     <cdk-virtual-scroll-viewport
       itemSize="48"
@@ -22,6 +25,9 @@
       [maxBufferPx]="10 * 48">
       <mat-option *cdkVirtualFor="let entity of filteredEntities | async" [value]="entity">
         {{mainTextFunction(entity)}} <span class="text-muted muted">{{secondaryTextFunction(entity)}}</span>
+        <span *ngIf="displayStatus" class="{{colorByStatus(entity)}}">
+          ({{statusTextFunction(entity)}})
+        </span>
       </mat-option>
     </cdk-virtual-scroll-viewport>
   </mat-select>

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.ts
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.ts
@@ -46,6 +46,9 @@ export class EntitySearchSelectComponent<T extends PerunBean> implements OnInit,
   @Input()
   entity: T = null;
 
+  @Input()
+  displayStatus = false;
+
   @Output()
   entitySelected = new EventEmitter<T>();
 
@@ -69,6 +72,7 @@ export class EntitySearchSelectComponent<T extends PerunBean> implements OnInit,
   @Input()
   secondaryTextFunction: (entity: T) => string = entity => '#' + entity.id;
 
+  statusTextFunction: (entity) => string = entity => entity.status;
 
   ngOnInit(): void {
     this.entitiesCtrl.valueChanges.subscribe(entity => this.entitySelected.emit(entity));
@@ -87,6 +91,21 @@ export class EntitySearchSelectComponent<T extends PerunBean> implements OnInit,
 
     if (this.entity !== null) {
       this.entitiesCtrl.setValue(this.entity);
+    }
+  }
+
+  colorByStatus(entity): string {
+    switch (entity.status) {
+      case "ACTIVE":
+        return "green";
+      case "INACTIVE":
+        return "grey";
+      case "FAILED":
+        return "red";
+      case "PROCESSING":
+        return "black";
+      default:
+        break;
     }
   }
 

--- a/libs/perun/components/src/lib/group-search-select/group-search-select.component.html
+++ b/libs/perun/components/src/lib/group-search-select/group-search-select.component.html
@@ -3,6 +3,7 @@
   [entities]="groups"
   [entity]="firstSelectedGroup ?? null"
   (entitySelected)="this.groupSelected.emit($event)"
+  [displayStatus]="displayStatus"
   [disableAutoSelect]="disableAutoSelect"
   [mainTextFunction]="nameFunction"
   [searchFunction]="nameFunction"

--- a/libs/perun/components/src/lib/group-search-select/group-search-select.component.ts
+++ b/libs/perun/components/src/lib/group-search-select/group-search-select.component.ts
@@ -21,6 +21,9 @@ export class GroupSearchSelectComponent implements OnInit{
   @Input()
   firstSelectedGroup: Group;
 
+  @Input()
+  displayStatus = false;
+
   nameFunction = (group: Group) => group.name;
 
   ngOnInit(): void {

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.ts
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.ts
@@ -32,11 +32,7 @@ import {
 } from '@perun-web-apps/perun/dialogs';
 import { GuiAuthResolver, TableCheckbox } from '@perun-web-apps/perun/services';
 import { formatDate } from '@angular/common';
-
-export interface GroupWithStatus extends RichGroup {
-  status?: GroupResourceStatus;
-  failureCause?: string;
-}
+import { GroupWithStatus } from '@perun-web-apps/perun/models';
 
 @Component({
   selector: 'perun-web-apps-groups-list',

--- a/libs/perun/components/src/lib/resource-search-select/resource-search-select.component.html
+++ b/libs/perun/components/src/lib/resource-search-select/resource-search-select.component.html
@@ -1,6 +1,7 @@
 <perun-web-apps-entity-search-select
   [entities]="resources"
   (entitySelected)="this.resourceSelected.emit($event)"
+  [displayStatus]="true"
   [searchFunction]="nameFunction"
   [mainTextFunction]="nameFunction"
   [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCE_SEARCH_SELECT.SELECT_RESOURCE' | translate"

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.ts
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   Component,
   EventEmitter,
   Input,
@@ -10,7 +9,7 @@ import {
 import { PageEvent } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-import { Group, GroupResourceStatus, ResourceTag, RichResource } from '@perun-web-apps/perun/openapi';
+import { Group, ResourceTag, RichResource } from '@perun-web-apps/perun/openapi';
 import { SelectionModel } from '@angular/cdk/collections';
 import {
   customDataSourceFilterPredicate,
@@ -19,12 +18,7 @@ import {
 } from '@perun-web-apps/perun/utils';
 import { GuiAuthResolver, TableCheckbox } from '@perun-web-apps/perun/services';
 import { TableWrapperComponent } from '@perun-web-apps/perun/utils';
-
-
-export interface ResourceWithStatus extends RichResource {
-  status?: GroupResourceStatus;
-  failureCause?: string;
-}
+import { ResourceWithStatus } from '@perun-web-apps/perun/models';
 
 @Component({
   selector: 'perun-web-apps-resources-list',

--- a/libs/perun/models/src/index.ts
+++ b/libs/perun/models/src/index.ts
@@ -8,4 +8,6 @@ export * from './lib/TreeGroup';
 export * from './lib/GroupFlatNode';
 export * from './lib/MenuItem'
 export * from './lib/NotificationData'
+export * from './lib/GroupWithStatus'
+export * from './lib/ResourceWithStatus'
 

--- a/libs/perun/models/src/lib/GroupWithStatus.ts
+++ b/libs/perun/models/src/lib/GroupWithStatus.ts
@@ -1,0 +1,6 @@
+import { GroupResourceStatus, RichGroup } from '@perun-web-apps/perun/openapi';
+
+export interface GroupWithStatus extends RichGroup {
+  status?: GroupResourceStatus;
+  failureCause?: string;
+}

--- a/libs/perun/models/src/lib/ResourceWithStatus.ts
+++ b/libs/perun/models/src/lib/ResourceWithStatus.ts
@@ -1,0 +1,6 @@
+import { GroupResourceStatus, RichResource } from '@perun-web-apps/perun/openapi';
+
+export interface ResourceWithStatus extends RichResource {
+  status?: GroupResourceStatus;
+  failureCause?: string;
+}


### PR DESCRIPTION
* On group-resource and resource-group attributes page used to be only groups/resources with active
assignment status. Now there are groups/resources with all statuses (type of assignment status is
visible in search select component).