### PR TITLE
style: unify info/warn/error alerts

### DIFF
--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-users/admin-users.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-users/admin-users.component.html
@@ -33,10 +33,10 @@
       *ngIf="users !== undefined && users.length > 0"
       [users]="users">
     </app-users-list>
-    <app-alert *ngIf="!firstSearchDone" [alert_type]="'info'">
+    <app-alert *ngIf="!firstSearchDone" alert_type="info">
       {{'ADMIN.USERS.SEARCH_INFO' | translate}}
     </app-alert>
-    <app-alert *ngIf="firstSearchDone && users.length === 0" [alert_type]="'warn'">
+    <app-alert *ngIf="firstSearchDone && users.length === 0" alert_type="warn">
       {{'ADMIN.USERS.NO_USERS_FOUND' | translate}}
     </app-alert>
   </div>

--- a/apps/admin-gui/src/app/shared/components/create-service-member-dialog/create-service-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/create-service-member-dialog/create-service-member-dialog.component.html
@@ -172,7 +172,7 @@
             [members]="members"
             [pageSize]="pageSize"
             [selection]="selection"></perun-web-apps-members-list>
-          <app-alert *ngIf="!firstSearchDone" [alert_type]="'info'">
+          <app-alert *ngIf="!firstSearchDone" alert_type="info">
             {{'DIALOGS.CREATE_SERVICE_MEMBER.SEARCH_INFO' | translate}}
           </app-alert>
         </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/connect-identity-dialog/connect-identity-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/connect-identity-dialog/connect-identity-dialog.component.html
@@ -31,7 +31,7 @@
         [selection]="selection">
       </app-users-list>
     </div>
-    <app-alert *ngIf="!firstSearchDone" [alert_type]="'info'">
+    <app-alert *ngIf="!firstSearchDone" alert_type="info">
       {{'DIALOGS.CONNECT_IDENTITY.SEARCH_HINT' | translate}}
     </app-alert>
     <app-alert *ngIf="!loading && firstSearchDone && identities.length === 0" alert_type="warn">

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-definition-dialog/delete-attribute-definition-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-definition-dialog/delete-attribute-definition-dialog.component.html
@@ -20,7 +20,7 @@
       <tr mat-row *matRowDef="let group; columns: displayedColumns;"></tr>
     </table>
 
-    <app-alert class="mt-3" alert_type="error">
+    <app-alert class="mt-3" alert_type="warn">
       {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.WARNING' | translate}}
     </app-alert>
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-destination-dialog/remove-destination-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-destination-dialog/remove-destination-dialog.component.html
@@ -2,7 +2,7 @@
 <div class="{{theme}}">
   <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
   <div *ngIf="!loading" mat-dialog-content>
-    <app-alert [alert_type]="'warn'">{{'DIALOGS.REMOVE_DESTINATIONS.WARNING' | translate}}</app-alert>
+    <app-alert alert_type="warn">{{'DIALOGS.REMOVE_DESTINATIONS.WARNING' | translate}}</app-alert>
     <p>{{'DIALOGS.REMOVE_DESTINATIONS.DESCRIPTION' | translate}}</p>
     <div class="font-weight-bold">
       {{'DIALOGS.REMOVE_DESTINATIONS.ASK' | translate}}

--- a/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.html
@@ -35,7 +35,7 @@
       [disableRouting]="true">
     </perun-web-apps-members-list>
 
-    <app-alert *ngIf="!firstSearchDone" alert_type="warn">
+    <app-alert *ngIf="!firstSearchDone" alert_type="info">
       {{'DIALOGS.SPONSOR_EXISTING_MEMBER.BEGIN_SEARCH' | translate}}
     </app-alert>
 

--- a/apps/admin-gui/src/app/shared/components/entityless-attribute-keys-list/entityless-attribute-keys-list.component.html
+++ b/apps/admin-gui/src/app/shared/components/entityless-attribute-keys-list/entityless-attribute-keys-list.component.html
@@ -104,7 +104,7 @@
 <!--  <div *ngIf="records.length === 0" class="perun-alert warn-alert mt-3">-->
 <!--    {{'SHARED.COMPONENTS.ENTITYLESS_ATTRIBUTES_LIST.NO_KEYS_WARNING' | translate}}-->
 <!--  </div>-->
-    <app-alert *ngIf="records.length === 0" alert_type="info" class="mt-3">
+    <app-alert *ngIf="records.length === 0" alert_type="warn" class="mt-3">
       {{'SHARED.COMPONENTS.ENTITYLESS_ATTRIBUTES_LIST.NO_KEYS_WARNING' | translate}}
     </app-alert>
 </div>

--- a/apps/admin-gui/src/app/shared/components/member-overview-groups/member-overview-groups.component.html
+++ b/apps/admin-gui/src/app/shared/components/member-overview-groups/member-overview-groups.component.html
@@ -11,7 +11,7 @@
                                         [firstSelectedGroup]="selectedGroup">
     </perun-web-apps-group-search-select>
     <mat-spinner *ngIf="(loading || initLoading) && !noGroups" class="mr-auto ml-auto"></mat-spinner>
-    <app-alert alert_type="info" *ngIf="noGroups">{{'MEMBER_DETAIL.OVERVIEW.NO_GROUPS_FOUND' | translate}}</app-alert>
+    <app-alert alert_type="warn" *ngIf="noGroups">{{'MEMBER_DETAIL.OVERVIEW.NO_GROUPS_FOUND' | translate}}</app-alert>
     <div *ngIf="!loading">
       <table mat-table [dataSource]="groupMembershipDataSource" class="ml-auto mr-auto">
         <ng-container matColumnDef="attName">

--- a/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.html
+++ b/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.html
@@ -1,7 +1,7 @@
 <h1 class="page-subtitle">
   {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.TITLE' | translate}} - {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.MANAGE_GROUPS_PAGE.TITLE' | translate}}
 </h1>
-<app-alert [alert_type]="'info'">
+<app-alert alert_type="info">
   {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.MANAGE_GROUPS_PAGE.HELP' | translate}}
 </app-alert>
 

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-resources/vo-resources-states/vo-resources-states.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-resources/vo-resources-states/vo-resources-states.component.html
@@ -12,7 +12,7 @@
         <span class="badge badge-danger ml-1">{{errorPropagation.length}}</span>
       </ng-template>
       <ng-template matTabContent>
-        <app-alert *ngIf="errorPropagation.length === 0" [alert_type]="'warn'">
+        <app-alert *ngIf="errorPropagation.length === 0" alert_type="warn">
           {{'VO_DETAIL.RESOURCES.STATES.NO_RESOURCES_IN_ERROR' | translate}}
         </app-alert>
 

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.html
@@ -87,7 +87,7 @@
 
   <app-alert
     *ngIf="editAuth"
-    [alert_type]="'info'">
+    alert_type="info">
     {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.DRAG_AND_DROP_INFO' | translate}}
   </app-alert>
 

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-notifications/vo-settings-notifications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-notifications/vo-settings-notifications.component.html
@@ -55,6 +55,6 @@
     [theme]="'vo-theme'"
     (selectionChange)="changeSelection($event)"></app-notification-list>
 </div>
-<app-alert *ngIf="this.applicationMails.length === 0 && !loading" [alert_type]="'warn'">
+<app-alert *ngIf="this.applicationMails.length === 0 && !loading" alert_type="warn">
   {{'VO_DETAIL.SETTINGS.NOTIFICATIONS.NO_EMAILS' | translate}}
 </app-alert>

--- a/apps/publications/src/app/components/authors-list/authors-list.component.html
+++ b/apps/publications/src/app/components/authors-list/authors-list.component.html
@@ -83,12 +83,12 @@
 
 <app-alert
   *ngIf="authors.length !== 0 && dataSource.filteredData.length === 0"
-  [alert_type]="'warn'">
+  alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_FILTER_RESULTS_ALERT' | translate}}
 </app-alert>
 
 <app-alert
   *ngIf="authors.length === 0"
-  [alert_type]="'warn'">
+  alert_type="warn">
   {{'AUTHORS_LIST.NO_AUTHORS' | translate}}
 </app-alert>

--- a/apps/publications/src/app/components/publication-systems-list/publication-systems-list.component.html
+++ b/apps/publications/src/app/components/publication-systems-list/publication-systems-list.component.html
@@ -52,5 +52,5 @@
 </div>
 
 <app-alert *ngIf="dataSource.filteredData.length === 0 && publicationSystems.length !== 0" alert_type="warn">
-  {{'NO_FILTER_RESULTS' | translate}}
+  {{'SHARED_LIB.UI.ALERTS.NO_FILTER_RESULTS_ALERT' | translate}}
 </app-alert>

--- a/apps/publications/src/app/components/thanks-list/thanks-list.component.html
+++ b/apps/publications/src/app/components/thanks-list/thanks-list.component.html
@@ -56,12 +56,12 @@
 
 <app-alert
   *ngIf="thanks.length !== 0 && dataSource.filteredData.length === 0"
-  [alert_type]="'warn'">
+  alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_FILTER_RESULTS_ALERT' | translate}}
 </app-alert>
 
 <app-alert
   *ngIf="thanks.length === 0"
-  [alert_type]="'warn'">
+  alert_type="warn">
   {{'THANKS_LIST.NO_THANKS' | translate}}
 </app-alert>

--- a/apps/publications/src/app/dialogs/add-authors-dialog/add-authors-dialog.component.html
+++ b/apps/publications/src/app/dialogs/add-authors-dialog/add-authors-dialog.component.html
@@ -31,7 +31,7 @@
           [displayedColumns]="['id', 'name', 'organization', 'email', 'add']"
           (page)="pageChangedAuthors($event)">
         </perun-web-apps-authors-list>
-        <app-alert *ngIf="!firstSearchDone" [alert_type]="'info'">
+        <app-alert *ngIf="!firstSearchDone" alert_type="info">
           {{'DIALOGS.ADD_AUTHORS.SEARCH_INFO' | translate}}
         </app-alert>
       </div>
@@ -49,7 +49,7 @@
           (page)="pageChangedAuthorsToAdd($event)">
         </perun-web-apps-authors-list>
       </div>
-      <app-alert *ngIf="authorsToAdd.length === 0" [alert_type]="'warn'">
+      <app-alert *ngIf="authorsToAdd.length === 0" alert_type="warn">
         {{'DIALOGS.ADD_AUTHORS.NO_AUTHORS_TO_ADD' | translate}}
       </app-alert>
     </div>

--- a/apps/publications/src/app/pages/create-publication-page/import-publications-page/import-publications-page.component.html
+++ b/apps/publications/src/app/pages/create-publication-page/import-publications-page/import-publications-page.component.html
@@ -42,7 +42,7 @@
     </div>
     <app-alert
       *ngIf="!firstSearchDone"
-      [alert_type]="'info'">
+      alert_type="info">
       {{'IMPORT_PUBLICATIONS.INFO' | translate}}
     </app-alert>
     <perun-web-apps-publications-list
@@ -60,7 +60,7 @@
 
   <div *ngIf="importDone">
     <app-alert
-      [alert_type]="'info'">
+      alert_type="info">
       {{'IMPORT_PUBLICATIONS.IMPORTED_INFO' | translate}}
     </app-alert>
     <mat-accordion>

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
@@ -12,7 +12,7 @@
 <button (click)="addTOTP()" class="mr-2" color="accent" mat-flat-button>{{'AUTHENTICATION.ADD_TOTP' | customTranslate | translate}}</button>
 <button (click)="addWebAuthn()" class="mb-3" color="accent" mat-flat-button>{{'AUTHENTICATION.ADD_WEBAUTHN' | customTranslate | translate}}</button>
 
-<app-alert *ngIf="!tokens.length" alert_type="info">{{'AUTHENTICATION.NO_TOKENS' | customTranslate | translate}}</app-alert>
+<app-alert *ngIf="!tokens.length" alert_type="warn">{{'AUTHENTICATION.NO_TOKENS' | customTranslate | translate}}</app-alert>
 <div [hidden]="!tokens.length">
 <!--  <mat-slide-toggle #toggle color="primary">{{'AUTHENTICATION.MFA_TOGGLE' | customTranslate | translate}}</mat-slide-toggle>-->
   <div class="card mt-2">

--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
@@ -109,6 +109,6 @@
 
 <app-alert
   *ngIf="this.dataSource.allMemberCount === 0 && (dataSource.loading$ | async) === false"
-  [alert_type]="'warn'">
+  alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_MEMBERS' | translate}}
 </app-alert>

--- a/libs/perun/components/src/lib/members-list/members-list.component.html
+++ b/libs/perun/components/src/lib/members-list/members-list.component.html
@@ -116,12 +116,12 @@
 
 <app-alert
   *ngIf="!!dataSource && members.length !== 0 && dataSource.filteredData.length === 0"
-  [alert_type]="'warn'">
+  alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_FILTER_RESULTS_ALERT' | translate}}
 </app-alert>
 
 <app-alert
   *ngIf="members.length === 0"
-  [alert_type]="'warn'">
+  alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_MEMBERS' | translate}}
 </app-alert>

--- a/libs/ui/alerts/src/lib/alert/alert.component.css
+++ b/libs/ui/alerts/src/lib/alert/alert.component.css
@@ -6,7 +6,8 @@
 }
 
 .perun-alert.info-alert {
-  font-weight: bold;
+  font-style: italic;
+  color: grey;
   text-align: left;
   border: 1px #b3b3b3 solid;
   border-radius: 10px;
@@ -15,17 +16,18 @@
 .perun-alert.warn-alert {
   font-weight: bold;
   text-align: left;
-  border: 1px #b3b3b3 solid;
+  border: 1px #ececec solid;
   border-radius: 10px;
+  background-color: #ececec;
 }
 
-.perun-warn-alert-icon {
+.perun-alert-icon {
   padding-right: 2rem;
 }
 
 .perun-alert.error-alert {
-  border-left: 4px solid;
-  color: #000000;
-  background-color: #fae2e2;
-  border-color: #d32f2f;
+  text-align: left;
+  border: 1px #fedcda solid;
+  border-radius: 10px;
+  background-color: #fedcda;
 }

--- a/libs/ui/alerts/src/lib/alert/alert.component.html
+++ b/libs/ui/alerts/src/lib/alert/alert.component.html
@@ -3,8 +3,14 @@
   [class.warn-alert]="alert_type === 'warn'"
   [class.error-alert]="alert_type === 'error'"
   [class.info-alert]="alert_type === 'info'">
-  <mat-icon *ngIf="alert_type !== 'error'" class="perun-warn-alert-icon">
-    error
+  <mat-icon *ngIf="alert_type === 'info'" class="perun-alert-icon">
+    info
+  </mat-icon>
+  <mat-icon *ngIf="alert_type === 'warn'" class="perun-alert-icon">
+    warning
+  </mat-icon>
+  <mat-icon *ngIf="alert_type === 'error'" class="perun-alert-icon">
+    dangerous
   </mat-icon>
   <ng-content></ng-content>
 </div>


### PR DESCRIPTION
* Design of our ui alerts was unified.
* Fixed wrong usage of info/warn/error alerts in some html files.
* Fixed alert text in publication-systems-list.
* Unified definition of alert type in html files - we mainly use definition alert_type="string", but in some files was definition [alert_type]="'string'" - it was unified to definition alert_type="string".