### PR TITLE
fix(publications): fix bug on create single publication page

### DIFF
--- a/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.html
+++ b/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.html
@@ -57,11 +57,11 @@
           </mat-form-field>
 
           <mat-form-field>
-            <input matInput formControlName="ISBN"
+            <input matInput formControlName="isbn"
                    placeholder="{{'CREATE_SINGLE_PUBLICATION.ISBN' | translate}}">
           </mat-form-field>
           <mat-form-field>
-            <input matInput formControlName="DOI"
+            <input matInput formControlName="doi"
                    placeholder="{{'CREATE_SINGLE_PUBLICATION.DOI' | translate}}">
           </mat-form-field>
 

--- a/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.ts
+++ b/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.ts
@@ -119,8 +119,8 @@ export class CreateSinglePublicationPageComponent implements OnInit {
         title: this.publicationControl.get("title").value,
         categoryId: this.publicationControl.get("category").value.id,
         year: this.publicationControl.get("year").value.year(),
-        isbn: this.publicationControl.get("ISBN").value,
-        doi: this.publicationControl.get("DOI").value,
+        isbn: this.publicationControl.get("isbn").value,
+        doi: this.publicationControl.get("doi").value,
         main: this.publicationControl.get("cite").value
       }
     };
@@ -149,8 +149,8 @@ export class CreateSinglePublicationPageComponent implements OnInit {
   similarCheck(){
     this.innerLoading = true;
     const title: string = this.publicationControl.get('title').value ? this.publicationControl.get('title').value : null;
-    const doi: string = this.publicationControl.get('DOI').value ? this.publicationControl.get('DOI').value : null;
-    const isbn: string = this.publicationControl.get('ISBN').value ? this.publicationControl.get('ISBN').value : null;
+    const doi: string = this.publicationControl.get('doi').value ? this.publicationControl.get('doi').value : null;
+    const isbn: string = this.publicationControl.get('isbn').value ? this.publicationControl.get('isbn').value : null;
     this.cabinetService.findSimilarPublications(title, doi, isbn).subscribe(similarPubs => {
       this.similarPublications = similarPubs;
       this.filteredPublications = similarPubs;


### PR DESCRIPTION
* Create single publication page used to throw an error and it wasn't possible to create some publication (in form group control definition are properties in lower case, but in code were called these properties with upper case).