### PR TITLE
feat(admin-gui): show automatically assigned subgroups/resources

### DIFF
--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-groups/facility-allowed-groups.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-groups/facility-allowed-groups.component.html
@@ -21,7 +21,7 @@
     *ngIf="!loading && groupsToShow.length !== 0"
     [displayedColumns]="['id', 'vo', 'name', 'description']"
     [groups] = "groupsToShow"
-    [groupsToDisable]="groupsWithoutRouteAuth"
+    [groupsToDisableRouting]="groupsWithoutRouteAuth"
     [filter]="filterValue"
     [disableMembers]="false">
   </perun-web-apps-groups-list>

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
@@ -23,6 +23,8 @@
 <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
 <div class="mt-3" *ngIf="!loading && assignedGroups.length !== 0">
   <perun-web-apps-groups-list
+    [disableGroups]="true"
+    [groupsToDisableCheckbox]="groupsToDisable"
     (page)="pageChanged($event)"
     (refreshTable)="loadAllGroups()"
     [pageSize]="pageSize"
@@ -32,7 +34,7 @@
     [disableMembers]="false"
     [resourceId]="resourceId"
     [disableRouting]="!guiAuthResolver.isAuthorized('getGroupById_int_policy', [assignedGroups[0]])"
-    [displayedColumns]="['select', 'id', 'name', 'status', 'description']">
+    [displayedColumns]="['select', 'id', 'indirectGroupAssigment', 'name', 'status', 'description']">
   </perun-web-apps-groups-list>
 </div>
 <app-alert *ngIf="assignedGroups.length === 0 && !loading" alert_type="warn">

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.ts
@@ -35,6 +35,7 @@ export class ResourceGroupsComponent implements OnInit {
   selected = new SelectionModel<GroupWithStatus>(true, []);
   loading: boolean;
   filteredValue = '';
+  groupsToDisable: Set<number>;
 
   tableId = TABLE_RESOURCE_ALLOWED_GROUPS;
   pageSize: number;
@@ -66,8 +67,10 @@ export class ResourceGroupsComponent implements OnInit {
         const gws: GroupWithStatus = g.enrichedGroup.group;
         gws.status = g.status;
         gws.failureCause = g.failureCause;
+        gws.sourceGroupId = g.sourceGroupId;
         return gws;
       });
+      this.groupsToDisable = new Set(this.assignedGroups.filter(group => !!group.sourceGroupId).map(group => group.id));
       this.selected.clear();
       this.loading = false;
     });

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-member-group-dialog/add-member-group-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-member-group-dialog/add-member-group-dialog.component.html
@@ -13,7 +13,7 @@
       [selection]="selection"
       [displayedColumns]="['select', 'id', 'name', 'description']"
       [filter]="filterValue"
-      [groupsToDisable]="membersGroups"
+      [groupsToDisableCheckbox]="membersGroups"
       [disableGroups]="true"
       [disableRouting]="true"
       [disableMembers]="true">

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-member-to-resource-dialog/add-member-to-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-member-to-resource-dialog/add-member-to-resource-dialog.component.html
@@ -66,7 +66,7 @@
             [disableGroups]="true"
             [disableHeadCheckbox]="true"
             [disableRouting]="true"
-            [groupsToDisable]="membersGroupsId"
+            [groupsToDisableCheckbox]="membersGroupsId"
             [groups]="groups"
             [displayedColumns]="['select', 'id', 'name', 'description']"
             [selection]="selectedGroups">

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-relation-dialog/create-relation-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-relation-dialog/create-relation-dialog.component.html
@@ -7,7 +7,7 @@
   <div mat-dialog-content class="dialog-container">
     <perun-web-apps-groups-list
         (page)="pageChanged($event)"
-        [groupsToDisable]="groupsToDisable"
+        [groupsToDisableCheckbox]="groupsToDisable"
         [disableGroups]="true"
         [pageSize]="pageSize"
         [groups]="groups"

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.html
@@ -36,6 +36,7 @@
     [selection]="selected"
     [groupToResource]="group"
     [groupId]="groupId"
-    [displayedColumns]="['select', 'id', 'name', 'status', 'facility', 'tags', 'description']">
+    [resourcesToDisableCheckbox]="resourcesToDisable"
+    [displayedColumns]="['select', 'id', 'indirectResourceAssigment', 'name', 'status', 'facility', 'tags', 'description']">
   </perun-web-apps-resources-list>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.ts
@@ -39,6 +39,7 @@ export class GroupResourcesComponent implements OnInit {
   group: Group;
   resources: ResourceWithStatus[] = null;
   selected = new SelectionModel<ResourceWithStatus>(true, []);
+  resourcesToDisable: Set<number>;
 
   loading: boolean;
   filterValue = '';
@@ -87,9 +88,11 @@ export class GroupResourcesComponent implements OnInit {
         resWithStatus.status = r.status;
         resWithStatus.resourceTags = r.resourceTags;
         resWithStatus.failureCause = r.failureCause;
+        resWithStatus.sourceGroupId = r.sourceGroupId;
         return resWithStatus;
       });
       this.selected.clear();
+      this.resourcesToDisable = new Set(this.resources.filter(resource => resource.sourceGroupId !== null).map(resource => resource.id));
       this.setAuthorization();
       this.loading = false;
     });

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2381,7 +2381,8 @@
           "DISABLED_HINT": "You cannot add members to this group or user is already member.",
           "ALREADY_MEMBER_TOOLTIP": "User is already member of group",
           "CREATE_RELATION_AUTH_TOOLTIP": "You don't have permission to create relation with this group.",
-          "SYNCHRONIZED_GROUP": "Group is filled with members from external source"
+          "SYNCHRONIZED_GROUP": "Group is filled with members from external source",
+          "INDIRECT_GROUP": "This group is assigned as a part of groups tree."
         },
         "GROUP_MENU": {
           "MOVE": "Move group",
@@ -2419,7 +2420,8 @@
           "TABLE_SEARCH": "Filter",
           "TABLE_RESOURCE_DESCRIPTION": "Description",
           "TABLE_GROUP_RESOURCE_STATUS": "Status",
-          "NO_RESOURCES_WARNING": "No resources assigned."
+          "NO_RESOURCES_WARNING": "No resources assigned.",
+          "INDIRECT_RESOURCE": "This resource is assigned indirectly."
         },
         "RESOURCE_SEARCH_SELECT": {
           "SELECT_RESOURCE": "Select resource",

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.html
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.html
@@ -56,10 +56,20 @@
               mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.TABLE_VO_NAME' | translate}}</th>
           <td *matCellDef="let group" class="static-column-size" mat-cell>{{voNames.get(group.voId)}}</td>
         </ng-container>
+        <ng-container matColumnDef="indirectGroupAssigment">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let group" mat-cell>
+            <mat-icon *ngIf="group.sourceGroupId"
+                      matTooltipPosition="above"
+                      [matTooltip]="'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.INDIRECT_GROUP' | translate">account_tree</mat-icon>
+          </td>
+        </ng-container>
         <ng-container matColumnDef="name">
           <th *matHeaderCellDef mat-header-cell
               mat-sort-header>{{'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.TABLE_GROUP_NAME' | translate}}</th>
-          <td *matCellDef="let group" mat-cell>{{group.name}}</td>
+          <td *matCellDef="let group" mat-cell>
+            {{group.name}}
+          </td>
         </ng-container>
         <ng-container matColumnDef="status">
           <th *matHeaderCellDef mat-header-cell
@@ -129,10 +139,10 @@
       <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
       <tr
         *matRowDef="let group; columns: displayedColumns;"
-        [class.cursor-pointer]="!disableRouting && !groupsToDisable.has(group.id)"
-        [class.disable-outline]="disabledRouting || groupsToDisable.has(group.id)"
-        [perunWebAppsMiddleClickRouterLink]="(disabledRouting || groupsToDisable.has(group.id)) ? null : ['/organizations', group.voId, 'groups', group.id]"
-        [routerLink]="(disabledRouting || groupsToDisable.has(group.id)) ? null : ['/organizations', group.voId, 'groups', group.id]"
+        [class.cursor-pointer]="!disableRouting && !groupsToDisableRouting.has(group.id)"
+        [class.disable-outline]="disabledRouting || groupsToDisableRouting.has(group.id)"
+        [perunWebAppsMiddleClickRouterLink]="(disabledRouting || groupsToDisableRouting.has(group.id)) ? null : ['/organizations', group.voId, 'groups', group.id]"
+        [routerLink]="(disabledRouting || groupsToDisableRouting.has(group.id)) ? null : ['/organizations', group.voId, 'groups', group.id]"
         class="dark-hover-list-item"
         mat-row>
       </tr>

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.ts
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.ts
@@ -68,7 +68,7 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
   private hasMembersGroup = false;
 
   @Input()
-  displayedColumns: string[] = ['select', 'id', 'recent', 'vo', 'name', 'status', 'groupStatus', 'description', 'expiration', 'menu'];
+  displayedColumns: string[] = ['select', 'id', 'recent', 'vo', 'indirectGroupAssigment', 'name', 'status', 'groupStatus', 'description', 'expiration', 'menu'];
 
   @Input()
   disableMembers: boolean;
@@ -77,7 +77,10 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
   disableGroups: boolean;
 
   @Input()
-  groupsToDisable: Set<number> = new Set<number>();
+  groupsToDisableCheckbox: Set<number> = new Set<number>();
+
+  @Input()
+  groupsToDisableRouting: Set<number> = new Set<number>();
 
   @Input()
   pageSize = 10;
@@ -250,7 +253,7 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
   }
 
   disableSelect(grp: GroupWithStatus): boolean {
-    return this.disableGroups && (this.groupsToDisable.has(grp.id) || this.isSynchronized(grp));
+    return this.disableGroups && (this.groupsToDisableCheckbox.has(grp.id) || this.isSynchronized(grp));
   }
 
   ngAfterViewInit(): void {
@@ -332,6 +335,8 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
       return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.CREATE_RELATION_AUTH_TOOLTIP';
     } else if (this.isSynchronized(row)){
       return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.SYNCHRONIZED_GROUP';
+    } else if (row.sourceGroupId) {
+      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.INDIRECT_GROUP';
     } else {
       return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.ALREADY_MEMBER_TOOLTIP';
     }

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.html
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.html
@@ -25,12 +25,18 @@
           </mat-checkbox>
         </th>
         <td *matCellDef="let resource" class="static-column-size" mat-cell>
-          <mat-checkbox (change)="$event ? itemSelectionToggle(resource) : null"
-                        (click)="$event.stopPropagation()"
-                        [aria-label]="checkboxLabel(resource)"
-                        [checked]="selection.isSelected(resource)"
-                        color="primary">
-          </mat-checkbox>
+          <span
+            matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.INDIRECT_RESOURCE' | translate}}"
+            [matTooltipPosition]="'above'"
+            [matTooltipDisabled]="!disableSelect(resource)">
+              <mat-checkbox (change)="$event ? itemSelectionToggle(resource) : null"
+                            (click)="$event.stopPropagation()"
+                            [aria-label]="checkboxLabel(resource)"
+                            [checked]="selection.isSelected(resource)"
+                            [disabled]="disableSelect(resource)"
+                            color="primary">
+              </mat-checkbox>
+            </span>
         </td>
       </ng-container>
 
@@ -47,6 +53,14 @@
               [recentIds]="recentIds"
               [id]="resource.id">
             </perun-web-apps-recently-viewed-icon>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="indirectResourceAssigment">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let resource" mat-cell>
+            <mat-icon *ngIf="resource.sourceGroupId"
+                      matTooltipPosition="above"
+                      [matTooltip]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.INDIRECT_RESOURCE' | translate">account_tree</mat-icon>
           </td>
         </ng-container>
         <ng-container matColumnDef="name">

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.ts
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.ts
@@ -47,7 +47,7 @@ export class ResourcesListComponent implements OnInit, OnChanges {
   @Input()
   routingVo = false;
   @Input()
-  displayedColumns: string[] = ['select', 'id', 'recent', 'name', 'vo', 'status', 'facility', 'tags', 'description'];
+  displayedColumns: string[] = ['select', 'id', 'recent', 'indirectResourceAssigment', 'name', 'vo', 'status', 'facility', 'tags', 'description'];
   @Input()
   groupToResource: Group;
   @Input()
@@ -56,6 +56,8 @@ export class ResourcesListComponent implements OnInit, OnChanges {
   recentIds: number[];
   @Input()
   groupId: number = null;
+  @Input()
+  resourcesToDisableCheckbox: Set<number> = new Set<number>();
 
   @Output()
   page: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
@@ -144,16 +146,18 @@ export class ResourcesListComponent implements OnInit, OnChanges {
     this.dataSource.data = this.resources;
   }
 
+  canBeSelected = (group: ResourceWithStatus): boolean => !this.disableSelect(group)
+
   /** Whether the number of selected elements matches the total number of rows. */
   isAllSelected() {
-    const isAllSelected = this.tableCheckbox.isAllSelected(this.selection.selected.length, this.filterValue, this.pageSize, this.child.paginator.hasNextPage(), this.dataSource);
+    const isAllSelected = this.tableCheckbox.isAllSelectedWithDisabledCheckbox(this.selection.selected.length, this.filterValue, this.pageSize, this.child.paginator.hasNextPage(), this.child.paginator.pageIndex, this.dataSource, this.sort, this.canBeSelected);
     this.allSelected.emit(isAllSelected)
     return isAllSelected;
   }
 
   /** Selects all rows if they are not all selected; otherwise clear selection. */
   masterToggle() {
-    this.tableCheckbox.masterToggle(this.isAllSelected(), this.selection, this.filterValue, this.dataSource, this.sort, this.pageSize, this.child.paginator.pageIndex, false);
+    this.tableCheckbox.masterToggle(this.isAllSelected(), this.selection, this.filterValue, this.dataSource, this.sort, this.pageSize, this.child.paginator.pageIndex, true, this.canBeSelected);
     this.setAuth();
   }
 
@@ -176,5 +180,9 @@ export class ResourcesListComponent implements OnInit, OnChanges {
   itemSelectionToggle(item: ResourceWithStatus) {
     this.selection.toggle(item);
     this.setAuth();
+  }
+
+  disableSelect(resource: ResourceWithStatus) {
+    return this.resourcesToDisableCheckbox.has(resource.id);
   }
 }

--- a/libs/perun/models/src/lib/GroupWithStatus.ts
+++ b/libs/perun/models/src/lib/GroupWithStatus.ts
@@ -1,6 +1,8 @@
 import { GroupResourceStatus, RichGroup } from '@perun-web-apps/perun/openapi';
 
 export interface GroupWithStatus extends RichGroup {
+  autoAssignSubgroups?: boolean;
   status?: GroupResourceStatus;
   failureCause?: string;
+  sourceGroupId?: number;
 }

--- a/libs/perun/models/src/lib/ResourceWithStatus.ts
+++ b/libs/perun/models/src/lib/ResourceWithStatus.ts
@@ -3,4 +3,5 @@ import { GroupResourceStatus, RichResource } from '@perun-web-apps/perun/openapi
 export interface ResourceWithStatus extends RichResource {
   status?: GroupResourceStatus;
   failureCause?: string;
+  sourceGroupId?: number;
 }


### PR DESCRIPTION
* on page assigned groups and assigned resources we are now showing an
indicator if the group/resource was assigned automatically
* the remove
action is disabled for these groups/resources