### PR TITLE
feat(admin): change label of submit button in Change group resource assignment dialog

### DIFF
--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2645,7 +2645,8 @@
         "CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG": {
           "TITLE": "Change group resource assigment status",
           "CANCEL": "Cancel",
-          "SUBMIT": "Submit",
+          "ACTIVATE": "Activate",
+          "DEACTIVATE": "Deactivate",
           "ACTIVE": "Active",
           "INACTIVE": "Inactive",
           "CURRENT": "Current status",

--- a/libs/perun/dialogs/src/lib/change-group-resource-assigment-dialog/change-group-resource-assigment-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-group-resource-assigment-dialog/change-group-resource-assigment-dialog.component.html
@@ -54,7 +54,7 @@
       color="accent"
       [disabled]="loading"
       (click)="onSubmit()">
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.SUBMIT' | translate}}
+      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.'+(status === 'ACTIVE' ? 'DEACTIVATE' : 'ACTIVATE') | translate}}
     </button>
   </div>
 </div>


### PR DESCRIPTION
* Label on submit button has been changed from 'Submit' to 'Activate'/'Deactivate' depending on the current status