### PR TITLE
fix: when session expires the url is not saved

### DIFF
--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -114,6 +114,8 @@ export class AuthService {
           const dialogRef = this.dialog.open(SessionExpirationDialogComponent, c);
 
           dialogRef.afterClosed().subscribe(() => {
+            sessionStorage.setItem('auth:redirect', location.pathname);
+            sessionStorage.setItem('auth:queryParams', location.search.substr(1));
             this.startAuthentication();
           });
         }


### PR DESCRIPTION
* when the session expires and the dialog is open and then user click on
log in the url he was looking at was not stored anywhere
* added
redirect url to session storage before reloading session