### PR TITLE
fix: fix Principal Load with code flow

### DIFF
--- a/libs/perun/services/src/lib/ApiInterceptor.ts
+++ b/libs/perun/services/src/lib/ApiInterceptor.ts
@@ -63,7 +63,9 @@ export class ApiInterceptor implements HttpInterceptor {
     // Also handle errors globally, if not disabled
     const shouldHandleError = this.apiRequestConfiguration.shouldHandleError();
 
-    const shouldReloadPrincipal = req.method === "POST" && !this.store.skipOidc();
+    const shouldReloadPrincipal = req.method === "POST" &&
+                                  !this.store.skipOidc() &&
+                                  this.isCallToPerunApi(req.url);
 
     return next.handle(req).pipe(
       tap(x => {
@@ -83,6 +85,10 @@ export class ApiInterceptor implements HttpInterceptor {
         }
       })
     );
+  }
+
+  private isCallToPerunApi(url: string): boolean {
+    return url.startsWith(this.store.get("api_url"));
   }
 
   private formatErrors(error: any, req: HttpRequest<any>) {


### PR DESCRIPTION
* When the code flow was enabled, the ApiInterceptor tried to reload the principal, when the code
was exchanged for the access token. This was done, because the check in the interceptor didn't check
the url. We want to reload the principal only when a POST call is made to the Perun API.