### PR TITLE
feat(admin): warn before disconnecting users from service accounts

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/disconnect-identity-dialog/disconnect-identity-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/disconnect-identity-dialog/disconnect-identity-dialog.component.html
@@ -13,6 +13,12 @@
       <tr mat-header-row *matHeaderRowDef="displayedColumns" class="font-weight-bolder"></tr>
       <tr mat-row *matRowDef="let identity; columns: displayedColumns;"></tr>
     </table>
+    <app-alert *ngIf="disconnectingSelf" alert_type="warn">
+      {{'DIALOGS.DISCONNECT_IDENTITY.WARNING_DISCONNECT_YOURSELF' | translate}}
+    </app-alert>
+    <app-alert *ngIf="disconnectingLastOwner" alert_type="warn">
+      {{'DIALOGS.DISCONNECT_IDENTITY.WARNING_LAST_USER' | translate}}
+    </app-alert>
   </div>
   <div mat-dialog-actions>
     <button

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1732,6 +1732,8 @@
       "REMOVE": "Disconnect",
       "CANCEL": "Cancel",
       "DESCRIPTION": "Following identities will be disconnected from user.",
+      "WARNING_DISCONNECT_YOURSELF": "You will be disconnected from the service account - you will immediately lose rights to access and manage the account. If you want to move rights to another user, you should do it before disconnecting yourself.",
+      "WARNING_LAST_USER": "You want to disconnect the last identity from the service account - the account will be unattended.",
       "ASK": "Do you want to proceed?",
       "SUCCESS": "Identity was disconnected."
     },


### PR DESCRIPTION
- Users are now warned when they are disconnecting themselves from
service accounts or when the last identity is about to be disconnected.