### PR TITLE
feat: 🎸 Add possiblity to hide security image block

### DIFF
--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
@@ -1,6 +1,6 @@
-<h1 class="page-subtitle">{{'AUTHENTICATION.TITLE' | customTranslate | translate}}</h1>
-<p>{{'AUTHENTICATION.ANTI_PHISHING_INFO' | customTranslate | translate}}</p>
-<ng-container *ngIf='displayImageBlock'>
+<div class="mb-5" *ngIf='displayImageBlock'>
+  <h1 class="page-subtitle">{{'AUTHENTICATION.TITLE' | customTranslate | translate}}</h1>
+  <p>{{'AUTHENTICATION.ANTI_PHISHING_INFO' | customTranslate | translate}}</p>
   <div *ngIf="imageSrc && imageSrc.length">
     <img [src]="imageSrc" alt="" class="img-size"/>
   </div>
@@ -8,9 +8,9 @@
           mat-flat-button>{{'AUTHENTICATION.NEW_IMG' | customTranslate | translate}}</button>
   <button (click)="onDeleteImg()" class="m-1" color="warn" [disabled]="!imgAtt || !imgAtt.value"
           mat-flat-button>{{'AUTHENTICATION.DELETE_IMG' | customTranslate | translate}}</button>
-</ng-container>
+</div>
 
-<h1 class="page-subtitle mt-5">{{'AUTHENTICATION.MFA' | customTranslate | translate}}</h1>
+<h1 class="page-subtitle">{{'AUTHENTICATION.MFA' | customTranslate | translate}}</h1>
 <button (click)="addTOTP()" class="mr-2" color="accent" mat-flat-button>{{'AUTHENTICATION.ADD_TOTP' | customTranslate | translate}}</button>
 <button (click)="addWebAuthn()" class="mb-3" color="accent" mat-flat-button>{{'AUTHENTICATION.ADD_WEBAUTHN' | customTranslate | translate}}</button>
 

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
@@ -1,12 +1,14 @@
 <h1 class="page-subtitle">{{'AUTHENTICATION.TITLE' | customTranslate | translate}}</h1>
 <p>{{'AUTHENTICATION.ANTI_PHISHING_INFO' | customTranslate | translate}}</p>
-<div *ngIf="imageSrc && imageSrc.length">
-  <img [src]="imageSrc" alt="" class="img-size"/>
-</div>
-<button (click)="onAddImg()" class="m-1" color="accent"
-        mat-flat-button>{{'AUTHENTICATION.NEW_IMG' | customTranslate | translate}}</button>
-<button (click)="onDeleteImg()" class="m-1" color="warn" [disabled]="!imgAtt || !imgAtt.value"
-        mat-flat-button>{{'AUTHENTICATION.DELETE_IMG' | customTranslate | translate}}</button>
+<ng-container *ngIf='displayImageBlock'>
+  <div *ngIf="imageSrc && imageSrc.length">
+    <img [src]="imageSrc" alt="" class="img-size"/>
+  </div>
+  <button (click)="onAddImg()" class="m-1" color="accent"
+          mat-flat-button>{{'AUTHENTICATION.NEW_IMG' | customTranslate | translate}}</button>
+  <button (click)="onDeleteImg()" class="m-1" color="warn" [disabled]="!imgAtt || !imgAtt.value"
+          mat-flat-button>{{'AUTHENTICATION.DELETE_IMG' | customTranslate | translate}}</button>
+</ng-container>
 
 <h1 class="page-subtitle mt-5">{{'AUTHENTICATION.MFA' | customTranslate | translate}}</h1>
 <button (click)="addTOTP()" class="mr-2" color="accent" mat-flat-button>{{'AUTHENTICATION.ADD_TOTP' | customTranslate | translate}}</button>

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.ts
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.ts
@@ -41,6 +41,7 @@ export class SettingsAuthenticationComponent implements OnInit, AfterViewInit {
   mfaAtt: Attribute;
   accessToken: string;
   idToken: string;
+  displayImageBlock: boolean;
 
   constructor(private dialog: MatDialog,
               private attributesManagerService: AttributesManagerService,
@@ -152,6 +153,7 @@ export class SettingsAuthenticationComponent implements OnInit, AfterViewInit {
 
   private loadImage() {
     const imgAttributeName = this.store.get('mfa', 'security_image_attribute');
+    this.displayImageBlock = this.store.get('mfa', 'enable_security_image');
     this.attributesManagerService.getUserAttributeByName(this.store.getPerunPrincipal().userId, imgAttributeName).subscribe(attr => {
       if (!attr) {
         this.attributesManagerService.getAttributeDefinitionByName(imgAttributeName).subscribe(att => {

--- a/apps/user-profile/src/assets/config/defaultConfig.json
+++ b/apps/user-profile/src/assets/config/defaultConfig.json
@@ -68,6 +68,7 @@
   ],
   "mfa": {
     "api_url": "https://id.muni.cz/mfaapi/",
+    "enable_security_image": true,
     "security_image_attribute": "urn:perun:user:attribute-def:def:securityImage:mu",
     "enforce_mfa_attribute": "urn:perun:user:attribute-def:def:mfaEnforced:mu",
     "tokens_attribute": "urn:perun:user:attribute-def:def:mfaTokens:mu",


### PR DESCRIPTION
By setting the property "enable_security_image" under the block "mfa" in
the instanceConfig.json (defaultConfig.json), the block with security
image in the authentication settings can be displayed or hidden. Value
of the option is boolean, defaults to true (security image block
enabled).

✅ Closes: #893