### PR TITLE
fix: urls to other applications based on brand configuration

### DIFF
--- a/apps/admin-gui/src/app/core/services/common/admin-gui-config.service.ts
+++ b/apps/admin-gui/src/app/core/services/common/admin-gui-config.service.ts
@@ -112,6 +112,7 @@ export class AdminGuiConfigService {
           return this.initAuthService.loadPrincipal()
             .catch(err => this.handleErr(err))
             .then(() => this.loadPolicies())
+            .then(() => this.appConfigService.loadAppsConfig())
             .then(() => this.guiAuthResolver.loadRolesManagementRules());
         } else {
           return this.initAuthService.handleAuthStart();

--- a/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.ts
+++ b/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit} from '@angular/core';
 import { MatSidenav } from '@angular/material/sidenav';
-import { AuthzResolverService, PerunPrincipal, UtilsService } from '@perun-web-apps/perun/openapi';
-import { StoreService } from '@perun-web-apps/perun/services';
+import { AuthzResolverService, PerunPrincipal } from '@perun-web-apps/perun/openapi';
+import { OtherApplicationsService, StoreService } from '@perun-web-apps/perun/services';
 import { AuthService } from '@perun-web-apps/perun/services';
 import { MatDialog } from '@angular/material/dialog';
 import { ShowNotificationHistoryDialogComponent } from '../components/dialogs/show-notification-history-dialog/show-notification-history-dialog.component';
@@ -27,7 +27,7 @@ export class PerunNavComponent implements OnInit {
               private store: StoreService,
               private sanitizer: DomSanitizer,
               private notificationStorageService: NotificationStorageService,
-              private utilsService: UtilsService) {
+              private otherApplicationService: OtherApplicationsService) {
   }
 
   logoutEnabled = true;
@@ -50,9 +50,7 @@ export class PerunNavComponent implements OnInit {
     this.logo = this.sanitizer.bypassSecurityTrustHtml(this.store.get('logo'));
     this.logoutEnabled = this.storeService.get('log_out_enabled');
     this.profileLabel = this.storeService.get('profile_label_en');
-    this.utilsService.getAppsConfig().subscribe(config => {
-      this.profileUrl = config.brands[0].newApps.profile ? config.brands[0].newApps.profile : null;
-    });
+    this.profileUrl = this.otherApplicationService.getUrlForOtherApplication("profile");
   }
 
   showNotificationHistory() {

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/user-dashboard.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/user-dashboard.component.ts
@@ -1,10 +1,11 @@
 import { Component, HostBinding, OnInit } from '@angular/core';
 import {
   User,
-  UsersManagerService, UtilsService
+  UsersManagerService
 } from '@perun-web-apps/perun/openapi';
 import {
   ApiRequestConfigurationService,
+  OtherApplicationsService,
   NotificatorService,
   StoreService
 } from '@perun-web-apps/perun/services';
@@ -33,7 +34,7 @@ export class UserDashboardComponent implements OnInit {
               public translateService: TranslateService,
               private dialog: MatDialog,
               private apiRequestConfiguration: ApiRequestConfigurationService,
-              private utilsService: UtilsService
+              private otherApplicationService: OtherApplicationsService
   ) {
     translateService.get('USER_DETAIL.DASHBOARD.MAIL_CHANGE_SUCCESS').subscribe(res => this.mailSuccessMessage = res);
   }
@@ -130,9 +131,7 @@ export class UserDashboardComponent implements OnInit {
   }
 
   private getUserProfile() {
-    this.utilsService.getAppsConfig().subscribe(config => {
-      this.userProfileUrl = config.brands[0].newApps.profile ? config.brands[0].newApps.profile : null;
-    });
+    this.userProfileUrl = this.otherApplicationService.getUrlForOtherApplication("profile");
     this.userProfileName = this.storeService.get('profile_label_en');
   }
 }

--- a/apps/admin-gui/src/assets/config/defaultConfig.json
+++ b/apps/admin-gui/src/assets/config/defaultConfig.json
@@ -42,7 +42,6 @@
     "preferredLanguage",
     "preferredMail"
   ],
-  "pwd_reset_base_url": "https://perun-dev.cesnet.cz/fed/pwd-reset/",
   "password_requirements_help": [
     "default:Please <b>avoid using accented characters</b>. It might not be supported by all backend components and services.",
     "einfra:<p>Password must:</p><ul><li>contain only printing (non-accented) characters</li><li>be at least 10 characters long</li><li>consist of at least 3 of 4 character groups:<ul><li>lower-case letters</li><li>upper-case letters</li><li>digits</li><li>special characters</li></ul></li></ul>",

--- a/apps/user-profile/src/app/components/header/header.component.ts
+++ b/apps/user-profile/src/app/components/header/header.component.ts
@@ -1,8 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { StoreService } from '@perun-web-apps/perun/services';
+import { OtherApplicationsService, StoreService } from '@perun-web-apps/perun/services';
 import { DomSanitizer } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
-import { UtilsService } from '@perun-web-apps/perun/openapi';
 
 @Component({
   selector: 'perun-web-apps-header',
@@ -38,7 +37,7 @@ export class HeaderComponent implements OnInit {
   constructor( private storeService: StoreService,
                private sanitizer: DomSanitizer,
                private translate: TranslateService,
-               private utilsService: UtilsService) { }
+               private otherApplicationService: OtherApplicationsService) { }
 
   ngOnInit() {
     this.isDevel = this.storeService.get('is_devel');
@@ -60,9 +59,7 @@ export class HeaderComponent implements OnInit {
     }
 
     if (this.activeLink) {
-      this.utilsService.getAppsConfig().subscribe(config => {
-        this.adminGuiUrl = config.brands[0].newApps.admin ? config.brands[0].newApps.admin : null;
-      });
+      this.adminGuiUrl = this.otherApplicationService.getUrlForOtherApplication("admin");
     }
   }
 

--- a/apps/user-profile/src/app/services/user-profile-config.service.ts
+++ b/apps/user-profile/src/app/services/user-profile-config.service.ts
@@ -58,7 +58,8 @@ export class UserProfileConfigService {
       .then(isAuthenticated => {
         // if the authentication is successful, continue
         if (isAuthenticated) {
-          return this.initAuthService.loadPrincipal();
+          return this.initAuthService.loadPrincipal()
+            .then(() => this.appConfigService.loadAppsConfig());
         } else {
           return this.initAuthService.handleAuthStart();
         }

--- a/apps/user-profile/src/assets/config/defaultConfig.json
+++ b/apps/user-profile/src/assets/config/defaultConfig.json
@@ -24,7 +24,6 @@
   ],
   "consolidator_base_url": "https://perun-dev.cesnet.cz/",
   "registrar_base_url": "https://perun-dev.cesnet.cz/fed/registrar/",
-  "pwd_reset_base_url": "https://perun-dev.cesnet.cz/fed/pwd-reset/",
   "password_requirements_help": [
     "default:Please <b>avoid using accented characters</b>. It might not be supported by all backend components and services.",
     "einfra:<p>Password must:</p><ul><li>contain only printing (non-accented) characters</li><li>be at least 10 characters long</li><li>consist of at least 3 of 4 character groups:<ul><li>lower-case letters</li><li>upper-case letters</li><li>digits</li><li>special characters</li></ul></li></ul>",

--- a/libs/config/src/lib/app-config.service.ts
+++ b/libs/config/src/lib/app-config.service.ts
@@ -4,6 +4,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { StoreService } from '@perun-web-apps/perun/services';
 import { AuthzResolverService } from '@perun-web-apps/perun/openapi';
 import { Title } from '@angular/platform-browser';
+import { UtilsService } from '@perun-web-apps/perun/openapi';
 
 declare const tinycolor: any;
 
@@ -34,7 +35,8 @@ export class AppConfigService {
   constructor(private http: HttpClient,
               private storeService: StoreService,
               private authzSevice: AuthzResolverService,
-              private titleService: Title) {}
+              private titleService: Title,
+              private utilsService: UtilsService) {}
 
   initializeColors(
     entityColorConfigs: EntityColorConfig[],
@@ -159,6 +161,15 @@ export class AppConfigService {
       this.authzSevice.configuration.basePath = apiUrl;
       this.titleService.setTitle(this.storeService.get('document_title'));
       resolve();
+    });
+  }
+
+  loadAppsConfig(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.utilsService.getAppsConfig().subscribe(appsConfig => {
+        this.storeService.setAppsConfig(appsConfig);
+        resolve();
+      }, error => reject(error));
     });
   }
 }

--- a/libs/perun/components/src/lib/password-reset/password-reset.component.ts
+++ b/libs/perun/components/src/lib/password-reset/password-reset.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Attribute, AttributesManagerService} from '@perun-web-apps/perun/openapi';
-import { StoreService } from '@perun-web-apps/perun/services';
+import { Attribute, AttributesManagerService } from '@perun-web-apps/perun/openapi';
+import { OtherApplicationsService, StoreService } from '@perun-web-apps/perun/services';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
@@ -26,7 +26,8 @@ export class PasswordResetComponent implements OnInit {
               private store: StoreService,
               private dialog: MatDialog,
               private route: ActivatedRoute,
-              private router: Router) {
+              private router: Router,
+              private otherApplicationService: OtherApplicationsService) {
   }
 
   ngOnInit(): void {
@@ -53,8 +54,7 @@ export class PasswordResetComponent implements OnInit {
   }
 
   resetPassword(login: string) {
-    const url = this.store.get('pwd_reset_base_url');
-    location.href = `${url}?login-namespace=${login}`;
+    window.open(this.otherApplicationService.getUrlForOtherApplication("pwdReset", login), '_blank');
   }
 
   changePassword(login){

--- a/libs/perun/services/src/index.ts
+++ b/libs/perun/services/src/index.ts
@@ -16,3 +16,4 @@ export { DynamicDataSource } from './lib/dynamicDataSource'
 export { PreferredLanguageService } from './lib/preferred-language.service'
 export { SponsoredMembersPdfService } from './lib/sponsored-members-pdf.service';
 export { PDFService } from './lib/pdf.service';
+export { OtherApplicationsService } from './lib/other-applications.service';

--- a/libs/perun/services/src/lib/force-router.service.ts
+++ b/libs/perun/services/src/lib/force-router.service.ts
@@ -2,6 +2,14 @@ import { Injectable } from '@angular/core';
 import { NavigationExtras, NavigationStart, Router } from '@angular/router';
 
 export type NavigateType = 'back' | 'forward';
+
+/**
+ * This class fixes one specific Angular routing bug. When user wants to redirect
+ * from one entity to other entity with the same type, but with another id, then
+ * the routing didn't use to work correctly.
+ *
+ * Example: Perun admin -> Users -> Select user -> Service Accounts -> Select service account
+ */
 @Injectable({
   providedIn: 'root'
 })

--- a/libs/perun/services/src/lib/other-applications.service.ts
+++ b/libs/perun/services/src/lib/other-applications.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@angular/core';
+import { StoreService } from './store.service';
+import { Brand } from '@perun-web-apps/perun/openapi';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OtherApplicationsService {
+
+  constructor(private storeService: StoreService) { }
+
+  /**
+   * Returns brand according to base domain or default brand
+   *
+   * @param brands array of brands from configuration
+   * @param domain base domain of running app (Example: https://perun-dev.cz)
+   */
+  private static getBrandContainingDomain(brands: Brand[], domain: string): Brand {
+    for (const brand of brands) {
+      if (brand.newApps.admin === domain || brand.newApps.profile === domain || brand.newApps.pwdReset === domain) {
+        return brand;
+      }
+    }
+    return brands[0];
+  }
+
+  /**
+   * This function returns url for application based on appType given in parameter.
+   *
+   * URL of other application differs according to base url of running application
+   * and brands configuration. If base domain doesn't match any url in brands configuration,
+   * then will be used default brand.
+   * If new application url is not defined in brand configuration, then will be used old gui.
+   *
+   * @param appType type of requested app (admin | profile | pwdReset)
+   * @param login login namespace for pwd reset app
+   */
+  getUrlForOtherApplication(appType: string, login?: string): string {
+    const currentUrl = window.location.href;
+    const splittedUrl = currentUrl.split("/");
+    const domain = splittedUrl[0] + "//" + splittedUrl[2]; // protocol with domain
+
+    const brand = OtherApplicationsService.getBrandContainingDomain(this.storeService.getAppsConfig().brands, domain);
+    let url: string;
+
+    if (!brand.newApps[appType]) {
+      // url for new app of appType doesn't exist - set url to old gui
+      url = brand.oldGuiDomain + "/fed";
+
+      switch (appType) {
+        case "admin":
+          url += "/gui/"
+          break;
+        case "profile":
+          url += "/profile/"
+          break;
+        case "pwdReset":
+          url += "/pwd-reset/"
+          break;
+      }
+    } else {
+      url = brand.newApps[appType];
+      if (appType === "pwdReset") {
+        url += `?login-namespace=${login}`
+      }
+    }
+
+    return url;
+  }
+}

--- a/libs/perun/services/src/lib/store.service.ts
+++ b/libs/perun/services/src/lib/store.service.ts
@@ -12,6 +12,7 @@ export class StoreService {
 
   private instanceConfig;
   private defaultConfig;
+  private appsConfig;
   private principal: PerunPrincipal;
   private initialPageId: number;
   private branding = '';
@@ -24,6 +25,14 @@ export class StoreService {
 
   setDefaultConfig(defaultConfig: any) {
     this.defaultConfig = defaultConfig;
+  }
+
+  getAppsConfig() {
+    return this.appsConfig;
+  }
+
+  setAppsConfig(appsConfig: any) {
+    this.appsConfig = appsConfig;
   }
 
   setPerunPrincipal(principal: PerunPrincipal): void {


### PR DESCRIPTION
* Now are used all urls to other applications according to brand configuation.
* If no brand fix to domain, then will be used default brand.
* If the url for new app isn't defined for this brand, then will be used url for old gui.

BREAKING CHANGE: deleted "pwd_reset_base_url" property from defaultConfig files