### PR TITLE
fix(lib): show alert icon at top

### DIFF
--- a/libs/ui/alerts/src/lib/alert/alert.component.html
+++ b/libs/ui/alerts/src/lib/alert/alert.component.html
@@ -1,5 +1,5 @@
 <div
-  class="perun-alert d-flex align-items-center"
+  class="perun-alert d-flex align-items-flex-start"
   [class.warn-alert]="alert_type === 'warn'"
   [class.error-alert]="alert_type === 'error'"
   [class.info-alert]="alert_type === 'info'">


### PR DESCRIPTION
* instead of showing alert icon centered to block of text it will be shown at the top