### PR TITLE
fix(admin): fix assign group/assign resource button auth

### DIFF
--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
@@ -1,7 +1,7 @@
 <h1 class="page-subtitle">{{'RESOURCE_DETAIL.ASSIGNED_GROUPS.TITLE' | translate}}</h1>
 <perun-web-apps-refresh-button (refresh)="loadAllGroups()"></perun-web-apps-refresh-button>
 <button (click)="addGroup()"
-        *ngIf="guiAuthResolver.isAuthorized('assignGroupsToResource_List<Group>_Resource_policy',[resource])"
+        *ngIf="guiAuthResolver.isAuthorized('getAllGroups_Vo_policy',[resource])"
         class="action-button"
         color="accent"
         mat-flat-button>

--- a/apps/admin-gui/src/app/shared/components/dialogs/assign-group-to-resource-dialog/assign-group-to-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/assign-group-to-resource-dialog/assign-group-to-resource-dialog.component.html
@@ -9,11 +9,6 @@
           placeholder="{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.FILTER_DESCRIPTION' | translate}}"
           (filter)="applyFilter($event)">
         </perun-web-apps-debounce-filter>
-        <!-- first do the functionality to this checkbox then you can show it<mat-checkbox-->
-        <!--      color="primary"-->
-        <!--      [(ngModel)]="checkGroups">-->
-        <!--      {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.CONFIGURE_GROUPS' | translate}}-->
-        <!--    </mat-checkbox>-->
         <perun-web-apps-groups-list
           [tableId]="tableId"
           [groups]="unAssignedGroups"

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.ts
@@ -90,7 +90,7 @@ export class GroupResourcesComponent implements OnInit {
   addResource() {
     const config = getDefaultDialogConfig();
     config.width = '1000px';
-    config.data = {theme: 'group-theme', group: this.group, voId: this.group.voId, unwantedResources: this.resources.map(res => res.id)};
+    config.data = {theme: 'group-theme', group: this.group};
 
     const dialogRef = this.dialog.open(AddGroupResourceDialogComponent, config);
 


### PR DESCRIPTION
* on page resource-groups the button for assign was hidden
for
combination of roles trustedFacilityAdmin+FacilityAdmin
and
resource-selfService + groupAdmin
* on dialogs
assign-group-to-resource and add-group-resource the filtration of
entities shown in table added so the user in table sees only the
entities which he 1. have the priviledge to assign 2. are not already
assigned