### PR TITLE
fix(admin): missing text in create sponsored member dialog

### DIFF
--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1819,6 +1819,7 @@
       "OK": "Ok",
       "CREATE": "Create",
       "LOGIN": "Login",
+      "PASSWORD": "Password",
       "EMAIL": "Email",
       "SUCCESS": "Sponsored user created",
       "EMAIL_ERROR": "Email is not valid",


### PR DESCRIPTION
* add missing text for "password"