### PR TITLE
feat(admin): use estimated count of audit messages in custom paginator

### DIFF
--- a/apps/admin-gui/src/app/shared/components/audit-messages-list/audit-messages-list.component.ts
+++ b/apps/admin-gui/src/app/shared/components/audit-messages-list/audit-messages-list.component.ts
@@ -8,7 +8,8 @@ import {
 } from '@perun-web-apps/perun/utils';
 import { MatDialog } from '@angular/material/dialog';
 import { AuditMessageDetailDialogComponent } from '../dialogs/audit-message-detail-dialog/audit-message-detail-dialog.component';
-import { DynamicDataSource, DynamicPaginatingService } from '@perun-web-apps/perun/services';
+import { CustomMatPaginator, DynamicDataSource, DynamicPaginatingService } from '@perun-web-apps/perun/services';
+import { MatPaginatorIntl } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { merge } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -18,7 +19,11 @@ import { formatDate } from '@angular/common';
 @Component({
   selector: 'app-audit-messages-list',
   templateUrl: './audit-messages-list.component.html',
-  styleUrls: ['./audit-messages-list.component.scss']
+  styleUrls: ['./audit-messages-list.component.scss'],
+  providers: [{
+    provide: MatPaginatorIntl,
+    useClass: CustomMatPaginator
+  }]
 })
 export class AuditMessagesListComponent implements OnInit, OnChanges, AfterViewInit {
 

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2737,7 +2737,8 @@
         "NO_FILTER_RESULTS_ALERT": "No results match the given search criteria.",
         "NO_MEMBERS": "No members found",
         "NO_USERS": "No users found.",
-        "NO_FACILITIES": "No facilities found."
+        "NO_FACILITIES": "No facilities found.",
+        "NO_AUDIT_MESSAGES": "No audit messages found."
       }
     }
   }

--- a/libs/perun/services/src/index.ts
+++ b/libs/perun/services/src/index.ts
@@ -17,3 +17,4 @@ export { PreferredLanguageService } from './lib/preferred-language.service'
 export { SponsoredMembersPdfService } from './lib/sponsored-members-pdf.service';
 export { PDFService } from './lib/pdf.service';
 export { OtherApplicationsService } from './lib/other-applications.service';
+export { CustomMatPaginator } from './lib/custom-mat-paginator';

--- a/libs/perun/services/src/lib/custom-mat-paginator.ts
+++ b/libs/perun/services/src/lib/custom-mat-paginator.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { MatPaginatorIntl } from '@angular/material/paginator';
+
+@Injectable()
+export class CustomMatPaginator extends MatPaginatorIntl {
+
+  getRangeLabel = function (page, pageSize, length) {
+    let estimatedLength;
+    if (length < 1000) {
+      estimatedLength = length;
+    } else if (length < 10000) {
+      estimatedLength = "1 000";
+    } else if (length < 100000) {
+      estimatedLength = "10 000";
+    } else {
+      estimatedLength = "100 000";
+    }
+    const start = page * pageSize + 1;
+    const end = (page + 1) * pageSize;
+    return `${start} – ${end} of ${estimatedLength} +`;
+  };
+
+}


### PR DESCRIPTION
* If the total count of audit messages is greater than 1000, then is the total count only estimated.
* This estimated count is represented by `1 000 +`, `10 000 +` or `100 000 +`.