### PR TITLE
fix(admin): store entity id in storage with correct type

### DIFF
--- a/apps/admin-gui/src/app/admin/pages/admin-user-detail-page/admin-user-detail-page.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-user-detail-page/admin-user-detail-page.component.ts
@@ -35,7 +35,7 @@ export class AdminUserDetailPageComponent implements OnInit {
     this.loading = true;
     this.route.params.subscribe(params => {
       const userId = params['userId'];
-      this.entityStorageService.setEntity({id: userId, beanName: 'User'});
+      this.entityStorageService.setEntity({id: Number(userId), beanName: 'User'});
 
       this.path = `/admin/users/${userId}`;
       this.regex = `/admin/users/\\d+`;

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-service-identities/service-identity-detail-page/service-identity-detail-page.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-service-identities/service-identity-detail-page/service-identity-detail-page.component.ts
@@ -34,7 +34,7 @@ export class ServiceIdentityDetailPageComponent implements OnInit {
     this.loading = true;
     this.route.params.subscribe(params => {
       const userId = params['userId'];
-      this.entityStorageService.setEntity({id: userId, beanName: 'User'});
+      this.entityStorageService.setEntity({id: Number(userId), beanName: 'User'});
 
       this.usersService.getUserById(userId).subscribe(user => {
         this.user = user;

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-detail-page.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-detail-page.component.ts
@@ -46,7 +46,7 @@ export class VoDetailPageComponent implements OnInit {
 
       this.voService.getVoById(voId).subscribe(vo => {
         this.vo = vo;
-        this.entityStorageService.setEntity({id: voId, beanName: vo.beanName});
+        this.entityStorageService.setEntity({id: vo.id, beanName: vo.beanName});
         this.editAuth = this.authResolver.isAuthorized('updateVo_Vo_policy', [this.vo]);
         this.removeAuth = this.authResolver.isAuthorized('deleteVo_Vo_policy', [this.vo]);
 


### PR DESCRIPTION
* Some ids of entities were stored in storage with type `string` instead of `number`, which used to break authorization to some objects in the admin-gui.