### PR TITLE
feat(admin): UX change in dialog for adding hosts

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/add-host-dialog/add-host-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-host-dialog/add-host-dialog.component.html
@@ -1,6 +1,5 @@
 <div class="{{theme}}">
   <h1 mat-dialog-title>{{this.facilityName}}: {{'DIALOGS.ADD_HOST.TITLE' | translate}}</h1>
-  <h1 class="page-subtitle">{{'DIALOGS.ADD_HOST.SUBTITLE' | translate}}:</h1>
   <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
   <div *ngIf="!loading" mat-dialog-content class="dialog-container">
     <mat-form-field>
@@ -12,6 +11,8 @@
         cols="50"
         matInput
         required
+        [placeholder]="'DIALOGS.ADD_HOST.SUBTITLE' | translate"
+        perunWebAppsAutoFocus
         [formControl]="hostsCtrl">
       </textarea>
       <mat-error *ngIf="this.hostsCtrl.hasError('required')">
@@ -21,7 +22,7 @@
         {{'DIALOGS.ADD_HOST.INVALID_HOST' | translate}}{{this.hostsCtrl.getError('invalidHost').value}}
       </mat-error>
     </mat-form-field>
-    <div class="text-muted">{{'DIALOGS.ADD_HOST.HINT'| translate}}</div>
+    <app-alert alert_type="info">{{'DIALOGS.ADD_HOST.HINT'| translate}}</app-alert>
   </div>
   <div mat-dialog-actions>
     <button

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1607,7 +1607,7 @@
       "TITLE": "Add hosts",
       "ADD": "Add",
       "CANCEL": "Cancel",
-      "SUBTITLE": "Hostnames",
+      "SUBTITLE": "Hostnames:",
       "HINT": "Enter one host per line. You can use \"[x-y]\" in hostname to generate hosts with numbers from x to y. This replacer can be specified multiple times in one hostname to generate MxN combinations.",
       "WARNING": "Please enter at least one hostname to add it to facility.",
       "SUCCESS": "Added hosts.",


### PR DESCRIPTION
* hint below the input area has been wrapped by info alert
* title changed to placeholder text and input area is now focused from the start