### PR TITLE
feat(admin): make "Home" side menu item highlighted when on home page…

### DIFF
--- a/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.html
+++ b/apps/admin-gui/src/app/shared/perun-nav/perun-nav.component.html
@@ -6,7 +6,7 @@
       menu
     </mat-icon>
   </button>
-  <a [routerLink]="['/']"
+  <a [routerLink]="['/home']"
      queryParamsHandling="merge"
      class="mt-auto mb-auto">
     <div [innerHTML]="logo"

--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
@@ -86,7 +86,7 @@ export class SideMenuItemService {
       colorClass: 'base-item-color-activated',
       icon: 'perun-home-white',
       baseColorClass: 'base-item-color',
-      baseColorClassRegex: '^dont-use$',
+      baseColorClassRegex: '^/home$',
       activatedClass: 'dark-item-activated',
       linksClass: 'dark-item-links',
       backgroundColorCss: this.baseItemColor,


### PR DESCRIPTION
…, similar to other sections

* Changed "baseColorClassRegex" attribute to the correct Regexp to match home page link
* Made clicking the logo direct to /home