### PR TITLE
feat(admin): improve list of assigned groups to resource

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/assign-group-to-resource-dialog/assign-group-to-resource-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/assign-group-to-resource-dialog/assign-group-to-resource-dialog.component.ts
@@ -12,6 +12,7 @@ import { MatStepper } from '@angular/material/stepper';
 export interface AssignGroupToResourceDialogData {
   theme: string;
   resource: Resource;
+  onlyAutoAssignedGroups: Group[];
 }
 
 @Component({
@@ -37,7 +38,7 @@ export class AssignGroupToResourceDialogComponent implements OnInit {
   theme: string;
 
   resource: Resource;
-  unAssignedGroups: Group[] = [];
+  unAssignedGroups: Group[] = this.data.onlyAutoAssignedGroups;
   async = true;
   autoAssignSubgroups = false;
   asActive = true;

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2491,7 +2491,8 @@
           "ALREADY_MEMBER_TOOLTIP": "User is already member of group",
           "CREATE_RELATION_AUTH_TOOLTIP": "You don't have permission to create relation with this group.",
           "SYNCHRONIZED_GROUP": "Group is filled with members from an external source",
-          "INDIRECT_GROUP": "This group is assigned as a part of a groups tree."
+          "INDIRECT_GROUP": "This group is assigned as a part of a groups tree.",
+          "MULTIPLE_ASSIGNMENTS": "This group is assigned manually and also as a part of a groups tree. You can remove only manual assignment."
         },
         "GROUP_MENU": {
           "MOVE": "Move group",

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.html
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.html
@@ -59,9 +59,12 @@
         <ng-container matColumnDef="indirectGroupAssigment">
           <th *matHeaderCellDef mat-header-cell></th>
           <td *matCellDef="let group" mat-cell>
-            <mat-icon *ngIf="group.sourceGroupId"
+            <mat-icon *ngIf="group.sourceGroupId && !group.moreTypesOfAssignment"
                       matTooltipPosition="above"
                       [matTooltip]="'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.INDIRECT_GROUP' | translate">account_tree</mat-icon>
+            <mat-icon *ngIf="group.moreTypesOfAssignment"
+                      matTooltipPosition="above"
+                      [matTooltip]="'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.MULTIPLE_ASSIGNMENTS' | translate">alt_route</mat-icon>
           </td>
         </ng-container>
         <ng-container matColumnDef="name">

--- a/libs/perun/models/src/lib/GroupWithStatus.ts
+++ b/libs/perun/models/src/lib/GroupWithStatus.ts
@@ -5,4 +5,5 @@ export interface GroupWithStatus extends RichGroup {
   status?: GroupResourceStatus;
   failureCause?: string;
   sourceGroupId?: number;
+  moreTypesOfAssignment?: boolean;
 }


### PR DESCRIPTION
* Each group is displayed in this table only once now.
* If some group is assigned manually and also automatically, it will have a special icon with info in the tooltip. This group will be also able to remove (then will stay only automatic assignment).
* If some group is assigned only automatically, now will be possible to assign this group also manually in the assign-group-to-resource dialog.