### PR TITLE
refactor: remove sidemenu_item_icon_color property from the configura…

### DIFF
--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-item/side-menu-item.component.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-item/side-menu-item.component.ts
@@ -38,7 +38,6 @@ export class SideMenuItemComponent {
   expanded = true;
   linkBgColor = this.store.get('theme', 'sidemenu_item_links_bg_color');
   linkTextColor = this.store.get('theme', 'sidemenu_item_links_text_color');
-  iconColor = this.store.get('theme', 'sidemenu_item_icon_color');
   dividerStyle = '1px solid ' + this.store.get('theme', 'sidemenu_divider_color');
 
   @Input()

--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-root-item/side-menu-root-item.component.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-root-item/side-menu-root-item.component.ts
@@ -41,7 +41,6 @@ export class SideMenuRootItemComponent implements OnInit, OnChanges {
   expanded = false;
   linkBgColor = this.store.get('theme', 'sidemenu_item_links_bg_color');
   linkTextColor = this.store.get('theme', 'sidemenu_item_links_text_color');
-  iconColor = this.store.get('theme', 'sidemenu_item_icon_color');
 
   @Input()
   sideNav: MatSidenav;

--- a/apps/admin-gui/src/assets/config/defaultConfig.json
+++ b/apps/admin-gui/src/assets/config/defaultConfig.json
@@ -127,7 +127,6 @@
     "sidemenu_bg_color": "#263238",
     "sidemenu_border_color": "#071e24",
     "sidemenu_item_links_bg_color": "#1b2428",
-    "sidemenu_item_icon_color": "#ffffff",
     "sidemenu_hover_color": "#566268",
     "sidemenu_root_active_color": "#465258",
     "sidemenu-link-hover": "#566268",

--- a/apps/publications/src/app/components/side-menu/side-menu.component.html
+++ b/apps/publications/src/app/components/side-menu/side-menu.component.html
@@ -8,8 +8,8 @@
     [matRippleColor]="'rgba(255, 255, 255, 0.1)'"
     class="side-menu-item-height"
     routerLink="{{item.link}}">
-    <mat-icon *ngIf="item.isSVG" [svgIcon]="item.icon"></mat-icon>
-    <mat-icon *ngIf="!item.isSVG" [ngStyle]="{'color': iconColor}">{{item.icon}}</mat-icon>
+    <mat-icon *ngIf="item.isSVG" [svgIcon]="item.icon" class="perun-icon"></mat-icon>
+    <mat-icon *ngIf="!item.isSVG">{{item.icon}}</mat-icon>
     <span class="nav-caption ml-3">{{item.label | translate}}</span>
   </mat-list-item>
 </mat-nav-list>

--- a/apps/publications/src/app/components/side-menu/side-menu.component.ts
+++ b/apps/publications/src/app/components/side-menu/side-menu.component.ts
@@ -30,7 +30,6 @@ export class SideMenuComponent implements OnInit {
 
   items: SideMenuItem[] = [];
   textColor = this.storeService.get('theme', 'sidemenu_text_color');
-  iconColor = this.storeService.get('theme', 'sidemenu_item_icon_color');
 
   ngOnInit() {
     this.items = this.sideMenuItemService.getSideMenuItems();

--- a/apps/publications/src/assets/config/defaultConfig.json
+++ b/apps/publications/src/assets/config/defaultConfig.json
@@ -88,7 +88,6 @@
     "sidemenu_text_color": "#ffffff",
     "sidemenu_bg_color": "#263238",
     "sidemenu_border_color": "#071e24",
-    "sidemenu_item_icon_color": "#ffffff",
     "sidemenu_hover_color": "#566268",
     "sidemenu-link-active": "#465258",
     "sidemenu_active_text_color": "#ffffff",

--- a/apps/publications/src/styles.scss
+++ b/apps/publications/src/styles.scss
@@ -311,3 +311,15 @@ $i: 0;
 .action-button::after {
   content: '\2026';
 }
+
+.perun-icon {
+  path {
+    fill: currentColor;
+  }
+  rect {
+    fill: currentColor;
+  }
+  polygon {
+    fill: currentColor;
+  }
+}

--- a/apps/user-profile/src/app/components/side-menu/side-menu.component.html
+++ b/apps/user-profile/src/app/components/side-menu/side-menu.component.html
@@ -9,7 +9,7 @@
     class="side-menu-item-height"
     routerLink="{{item.external ? null: item.link}}"
     queryParamsHandling="merge">
-    <mat-icon [ngStyle]="{'color': iconColor}">{{item.icon}}</mat-icon>
+    <mat-icon>{{item.icon}}</mat-icon>
     <span
       class="nav-caption ml-3"
       >{{item.external ? (item | localisedText: lang:'label') : item.label | customTranslate: lang | translate}}</span

--- a/apps/user-profile/src/app/components/side-menu/side-menu.component.ts
+++ b/apps/user-profile/src/app/components/side-menu/side-menu.component.ts
@@ -34,7 +34,6 @@ export class SideMenuComponent implements OnInit {
   items: SideMenuItem[] = [];
   lang = 'en';
   textColor = this.storeService.get('theme', 'sidemenu_text_color');
-  iconColor = this.storeService.get('theme', 'sidemenu_item_icon_color');
 
   ngOnInit() {
     this.translateService.onLangChange.subscribe((lang) => {

--- a/apps/user-profile/src/assets/config/defaultConfig.json
+++ b/apps/user-profile/src/assets/config/defaultConfig.json
@@ -224,7 +224,6 @@
     "sidemenu_text_color": "#ffffff",
     "sidemenu_bg_color": "#263238",
     "sidemenu_border_color": "#071e24",
-    "sidemenu_item_icon_color": "#ffffff",
     "sidemenu_hover_color": "#566268",
     "sidemenu-link-active": "#465258",
     "sidemenu_active_text_color": "#ffffff",


### PR DESCRIPTION
…tion

* by this change no instanceConfig needs to be rewritten so this is not breaking change
* removing from theme: { sidemenu_item_icon_color} - in admin gui it was unused completely and in user profile + publications it didn't make any sense (who wants the color of the icon different than the color of the text right next to it)
* and by that it caused more problems - when developer wants to set color of the text, when the item is active, the icon color will remain the same - but we want to change the color of icon too