### PR TITLE
fix(admin): the setting of a federation attribute for some application form item

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.html
@@ -45,7 +45,7 @@
               [label]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.REQUIRED' | translate"
               [description]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.REQUIRED_DESCRIPTION' | translate">
               <section>
-                <mat-checkbox [(ngModel)]="this.applicationFormItem.required"> </mat-checkbox>
+                <mat-checkbox [(ngModel)]="this.applicationFormItem.required"></mat-checkbox>
               </section>
             </app-edit-application-form-item-line>
             <div *ngIf="typesWithUpdatable.indexOf(this.applicationFormItem.type) > -1">
@@ -53,7 +53,7 @@
                 [label]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.UPDATABLE' | translate"
                 [description]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.UPDATABLE_DESCRIPTION' | translate">
                 <section>
-                  <mat-checkbox [(ngModel)]="this.applicationFormItem.updatable"> </mat-checkbox>
+                  <mat-checkbox [(ngModel)]="this.applicationFormItem.updatable"></mat-checkbox>
                 </section>
               </app-edit-application-form-item-line>
             </div>
@@ -91,10 +91,10 @@
                   [selectedAttribute]="applicationFormItem.federationAttribute"
                   [asGroup]="!!data.group"
                   [type]="itemType.FEDERATION"
-                  (itemSelected)="federationAttribute = $event.value">
+                  (itemSelected)="changeFederationAttribute($event)">
                 </perun-web-apps-selection-item-search-select>
               </div>
-              <div *ngIf="federationAttribute === 'custom'" class="w-100">
+              <div *ngIf="federationAttributeDN === ' -- custom value -- '" class="w-100">
                 <mat-form-field class="w-100">
                   <input matInput [(ngModel)]="applicationFormItem.federationAttribute" />
                 </mat-form-field>
@@ -269,15 +269,25 @@
       <button mat-flat-button class="ml-auto mt-auto" (click)="cancel()">
         {{'DIALOGS.APPLICATION_FORM_EDIT_ITEM.CANCEL_BUTTON' | translate}}
       </button>
-      <button
-        mat-flat-button
-        class="ml-2 mt-auto"
-        color="accent"
-        data-cy="edit-form-item-button-dialog"
-        [disabled]="loading"
-        (click)="submit()">
-        {{'DIALOGS.APPLICATION_FORM_EDIT_ITEM.SUBMIT_BUTTON' | translate}}
-      </button>
+      <div
+        [matTooltipDisabled]="!applicationFormItem.required ||
+          applicationFormItem.perunSourceAttribute !== '' ||
+          applicationFormItem.federationAttribute !== '' ||
+          (applicationFormItem.disabled !== 'ALWAYS' && applicationFormItem.hidden !== 'ALWAYS')"
+        matTooltip="{{'DIALOGS.APPLICATION_FORM_EDIT_ITEM.SUBMIT_BUTTON_DISABLED_TOOLTIP' | translate}}">
+        <button
+          mat-flat-button
+          class="ml-2 mt-auto"
+          color="accent"
+          data-cy="edit-form-item-button-dialog"
+          [disabled]="loading || (applicationFormItem.required &&
+            applicationFormItem.perunSourceAttribute === '' &&
+            applicationFormItem.federationAttribute === '' &&
+            (applicationFormItem.disabled === 'ALWAYS' || applicationFormItem.hidden === 'ALWAYS'))"
+          (click)="submit()">
+          {{'DIALOGS.APPLICATION_FORM_EDIT_ITEM.SUBMIT_BUTTON' | translate}}
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import { ApplicationFormItem, AppType, Group, Type } from '@perun-web-apps/perun/openapi';
@@ -6,7 +6,7 @@ import { AttributeDefinition, AttributesManagerService } from '@perun-web-apps/p
 import { createNewApplicationFormItem } from '@perun-web-apps/perun/utils';
 import DisabledEnum = ApplicationFormItem.DisabledEnum;
 import HiddenEnum = ApplicationFormItem.HiddenEnum;
-import { ItemType, NO_FORM_ITEM } from '@perun-web-apps/perun/components';
+import { ItemType, NO_FORM_ITEM, SelectionItem } from '@perun-web-apps/perun/components';
 import { StoreService } from '@perun-web-apps/perun/services';
 
 export interface EditApplicationFormItemDialogComponentData {
@@ -25,7 +25,7 @@ export interface EditApplicationFormItemDialogComponentData {
 export class EditApplicationFormItemDialogComponent implements OnInit {
   applicationFormItem: ApplicationFormItem;
   attributeDefinitions: AttributeDefinition[];
-  federationAttribute = '';
+  federationAttributeDN = '';
   itemType = ItemType;
   options: { [key: string]: [string, string][] };
   theme: string;
@@ -77,7 +77,8 @@ export class EditApplicationFormItemDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: EditApplicationFormItemDialogComponentData,
     private attributesManager: AttributesManagerService,
     private translateService: TranslateService,
-    private store: StoreService
+    private store: StoreService,
+    private cd: ChangeDetectorRef
   ) {}
 
   ngOnInit() {
@@ -176,6 +177,12 @@ export class EditApplicationFormItemDialogComponent implements OnInit {
     for (const lang of this.languages) {
       this.updateOption(lang);
     }
+  }
+
+  changeFederationAttribute(fedAttribute: SelectionItem) {
+    this.applicationFormItem.federationAttribute = fedAttribute.value;
+    this.federationAttributeDN = fedAttribute.displayName;
+    this.cd.detectChanges();
   }
 
   copy(from: ApplicationFormItem, to: ApplicationFormItem) {

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -77,7 +77,7 @@
     "SERVICE_CONFIG": "Configure services",
     "DESTINATION_CONFIG": "Configure destinations",
     "DESTINATION": "Destinations",
-    "ATTS":  "Attributes",
+    "ATTS": "Attributes",
     "MANAGERS": "Managers",
     "SUMMARY": "Summary",
     "CANCEL": "Cancel",
@@ -536,7 +536,7 @@
         "NEW": "Waiting for mail verification",
         "VERIFIED": "Submitted"
       },
-      "DATE" : {
+      "DATE": {
         "START": "Start date",
         "END": "End date"
       },
@@ -686,7 +686,7 @@
         "SUCCESS_REMOVED": "External source successfully removed: "
       }
     },
-    "STATISTICS":{
+    "STATISTICS": {
       "TITLE": "Statistics",
       "VO_STATUS_COUNT": "Members by organization status",
       "GROUP_STATUS_COUNT": "Members by group status"
@@ -853,7 +853,7 @@
       "MANAGERS": "Managers",
       "ASSIGNED_SERVICES": "Assigned services",
       "ASSIGNED_MEMBERS": "Assigned members",
-      "RESOURCE_TAGS":  "Assigned tags"
+      "RESOURCE_TAGS": "Assigned tags"
     },
     "GROUP": {
       "OVERVIEW": "Overview",
@@ -1180,6 +1180,7 @@
       "SHORT_NAME_DESCRIPTION": "Internal item identification (used as a fallback when you forgot to set \"Label\" for some language).",
       "CANCEL_BUTTON": "Cancel",
       "SUBMIT_BUTTON": "Submit",
+      "SUBMIT_BUTTON_DISABLED_TOOLTIP": "This item is required and hidden or disabled, but it has no prefilled value (Source and Federation attributes are empty)",
       "BASIC_SETTINGS": "Basic settings",
       "LANGUAGE_CS": "Language: cz",
       "LANGUAGE_EN": "Language: en",
@@ -1588,7 +1589,6 @@
       "OPTIONS": "Set options",
       "NEXT": "Next",
       "BACK": "Back"
-
     },
     "ADD_GROUP_TO_REGISTRATION": {
       "TITLE": "Assign group to registration",
@@ -1821,9 +1821,9 @@
       "TITLE": "Remove service from facility",
       "CHECKBOXES_DESCRIPTION": "You can also remove:",
       "CHECKBOXES_DISABLED": "Enabled only for all resources",
-      "CHECKBOX_TASK_AND_TASK_RESULTS" : "Task and task results",
-      "CHECKBOX_TASK_RESULTS" : "Task results",
-      "CHECKBOX_DESTINATION" : "Destination",
+      "CHECKBOX_TASK_AND_TASK_RESULTS": "Task and task results",
+      "CHECKBOX_TASK_RESULTS": "Task results",
+      "CHECKBOX_DESTINATION": "Destination",
       "DESCRIPTION": "Following resources will be affected.",
       "ASK": "Do you want to proceed?",
       "SUCCESS": "Service was successfully removed",
@@ -2459,7 +2459,7 @@
     "SPONSORSHIP_MEMBERS": "Members you are sponsor of",
     "RESOURCESELFSERVICE": "Resource self service",
     "RESOURCESELFSERVICE_RESOURCES": "Resources you are manager of",
-    "RESOURCEOBSERVER":  "Resource observer",
+    "RESOURCEOBSERVER": "Resource observer",
     "RESOURCEOBSERVER_RESOURCES": "Resources you are observer of"
   },
   "SHARED_LIB": {
@@ -2517,7 +2517,7 @@
           "FIND_VO": "Find organization...",
           "NO_VO_FOUND": "No matching organization found"
         },
-        "SERVICE_PACKAGE_SEARCH_SELECT":  {
+        "SERVICE_PACKAGE_SEARCH_SELECT": {
           "SELECT_PACKAGE": "Select service package",
           "FIND_PACKAGE": "Find service package...",
           "NO_PACKAGE_FOUND": "No matching service package found"

--- a/libs/perun/components/src/lib/selection-item-search-select/selection-item-search-select.component.ts
+++ b/libs/perun/components/src/lib/selection-item-search-select/selection-item-search-select.component.ts
@@ -148,6 +148,9 @@ export class SelectionItemSearchSelectComponent implements OnInit {
         return;
       }
     }
+    // get correct custom value
+    this.item = this.items[1];
+    this.item.value = this.selectedAttribute;
   }
 
   sortAttributes(attributes: SelectionItem[]) {


### PR DESCRIPTION
* The setting of a federation attribute used to be broken - user wasn't able to change the federation attribute via dialog.
* In this PR was also fixed the setting of a custom federation attribute.
* In this PR was also added a check which disables to add a required item which is hidden or disabled (uneditable) and also has no source or federation attribute (it can't have any prefilled value).