### PR TITLE
fix(lib): link to old password reset

### DIFF
--- a/libs/perun/services/src/lib/other-applications.service.ts
+++ b/libs/perun/services/src/lib/other-applications.service.ts
@@ -61,7 +61,7 @@ export class OtherApplicationsService {
           url += '/profile/';
           break;
         case 'pwdReset':
-          url += '/pwd-reset/';
+          url += `/pwd-reset/?login-namespace=${login}`;
           break;
       }
     } else {


### PR DESCRIPTION
* Fixed link to old password reset in admin gui and in user profile. Namespace used to be forgotten
in url to old password reset.