### PR TITLE
fix: redirect from login page to home if user logged in

### DIFF
--- a/libs/perun/login/src/lib/login-screen/login-screen.component.ts
+++ b/libs/perun/login/src/lib/login-screen/login-screen.component.ts
@@ -1,14 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { AuthService } from '@perun-web-apps/perun/services';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'perun-web-apps-login-screen',
   templateUrl: './login-screen.component.html',
   styleUrls: ['./login-screen.component.scss'],
 })
-export class LoginScreenComponent {
-  constructor(private auth: AuthService) {}
+export class LoginScreenComponent implements OnInit {
+  constructor(private auth: AuthService, private router: Router) {}
 
+  ngOnInit() {
+    if (this.auth.isLoggedIn()) {
+      this.router.navigate(['/home']);
+    }
+  }
   startAuth(): void {
     this.auth.startAuthentication();
   }


### PR DESCRIPTION
* when user is logged in and goes to /login, the login component isn't displayed and the user is redirected to /home instead