### PR TITLE
feat(admin): added columns to sponsored members list

### DIFF
--- a/apps/admin-gui/src/app/shared/components/sponsored-members-list/sponsored-members-list.component.html
+++ b/apps/admin-gui/src/app/shared/components/sponsored-members-list/sponsored-members-list.component.html
@@ -51,6 +51,20 @@
           {{sponsoredMember.member.user | userFullName}}
         </td>
       </ng-container>
+      <ng-container matColumnDef="email">
+        <th *matHeaderCellDef mat-header-cell>
+          {{'SHARED.COMPONENTS.SPONSORED_MEMBERS_LIST.EMAIL' | translate}}
+        </th>
+        <td *matCellDef="let sponsoredMember" mat-cell>{{sponsoredMember.member | memberEmail}}</td>
+      </ng-container>
+      <ng-container matColumnDef="logins">
+        <th *matHeaderCellDef mat-header-cell>
+          {{'SHARED.COMPONENTS.SPONSORED_MEMBERS_LIST.LOGIN' | translate}}
+        </th>
+        <td *matCellDef="let sponsoredMember" mat-cell>
+          {{sponsoredMember.member | memberLogins}}
+        </td>
+      </ng-container>
       <ng-container matColumnDef="sponsors">
         <th *matHeaderCellDef mat-header-cell mat-sort-header>
           {{'SHARED.COMPONENTS.SPONSORED_MEMBERS_LIST.SPONSORS' | translate}}

--- a/apps/admin-gui/src/app/shared/components/sponsored-members-list/sponsored-members-list.component.ts
+++ b/apps/admin-gui/src/app/shared/components/sponsored-members-list/sponsored-members-list.component.ts
@@ -46,7 +46,7 @@ export class SponsoredMembersListComponent implements OnChanges {
   filterValue = '';
 
   @Input()
-  displayedColumns: string[] = ['id', 'name', 'sponsors', 'menu'];
+  displayedColumns: string[] = ['id', 'name', 'email', 'logins', 'sponsors', 'menu'];
 
   @Input()
   disableRouting = false;

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-sponsored-members/vo-settings-sponsored-members.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-sponsored-members/vo-settings-sponsored-members.component.ts
@@ -51,14 +51,7 @@ export class VoSettingsSponsoredMembersComponent implements OnInit {
 
   voSponsors: RichUser[] = [];
 
-  //TODO uncomment when we need those parameters
-  private attrNames = [
-    //Urns.USER_DEF_ORGANIZATION,
-    //Urns.USER_DEF_PREFERRED_MAIL,
-    //Urns.MEMBER_DEF_ORGANIZATION,
-    //Urns.MEMBER_DEF_MAIL,
-    //Urns.MEMBER_DEF_EXPIRATION
-  ];
+  private attrNames = [Urns.USER_DEF_PREFERRED_MAIL];
 
   selection = new SelectionModel<MemberWithSponsors>(true, []);
   searchString = '';
@@ -68,6 +61,7 @@ export class VoSettingsSponsoredMembersComponent implements OnInit {
   ngOnInit(): void {
     this.loading = true;
     this.vo = this.entityStorageService.getEntity();
+    this.attrNames = this.attrNames.concat(this.storeService.getLoginAttributeNames());
     this.setAuthRights();
 
     const availableRoles = ['SPONSOR'];

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2390,6 +2390,8 @@
       "SPONSORED_MEMBERS_LIST": {
         "ID": "Id",
         "NAME": "Name",
+        "EMAIL": "Email",
+        "LOGIN": "Login",
         "SPONSORS": "Sponsors",
         "NO_SPONSORED_MEMBERS_WARNING": "No sponsored members found",
         "PASSWORD_RESET": "Reset password"


### PR DESCRIPTION
* added column logins and email to sponsored member list so sponsor can
view his sponsored members and also his email and logins (the sponsor
have access to that information when creating the sponsored member, so
he should also have preview on the list - he doest have priviledge to go
to member detail)

this PR is reaction to RT ticket:
Dobrý den,

rád bych se zeptal, jak je to s oprávněním běžného zaměstnance v perunu. Nemyslím teď IT technika. Uživatelka si vytvořila sponzorovaný účet a potom v přehledu svých sponzorovaných účtů si ale nemůže jednotlivé účty rozkliknout a zkontrolovat např. učo. Pokud si tedy hned po vygenerování účtu neuloží údaje, tak se k nim už posléze nedostane.

Děkuji,

BTW - this PR doesnt resolve this problem completely - problem is that sponsor doesnt have the priviledge to read email and login attributes, but with new attributes rights this can be resolved, also other roles that can read this attributes should have preview of this information on this page