### PR TITLE
feat(profile): manage consents

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -696,7 +696,6 @@
       },
       "schematics": {
         "@nrwl/angular:component": {
-          "styleext": "scss"
         }
       },
       "tags": []

--- a/apps/user-profile/src/app/app-routing.module.ts
+++ b/apps/user-profile/src/app/app-routing.module.ts
@@ -22,6 +22,9 @@ import {
   LoginScreenComponent,
   LoginScreenServiceAccessComponent,
 } from '@perun-web-apps/perun/login';
+import { ConsentsPageComponent } from './pages/consents-page/consents-page.component';
+import { ConsentRequestComponent } from './pages/consents-page/consent-request/consent-request.component';
+import { ConsentsPreviewComponent } from './pages/consents-page/consents-preview/consents-preview.component';
 
 const routes: Routes = [
   {
@@ -71,6 +74,23 @@ const routes: Routes = [
         path: 'privacy',
         component: PrivacyPageComponent,
         data: { breadcrumb: 'MENU_ITEMS.PRIVACY' },
+      },
+      {
+        path: 'consents',
+        component: ConsentsPageComponent,
+        data: { breadcrumb: 'MENU_ITEMS.CONSENTS' },
+        children: [
+          {
+            path: '',
+            component: ConsentsPreviewComponent,
+            data: { breadcrumb: 'MENU_ITEMS.CONSENTS' },
+          },
+          {
+            path: ':consentId',
+            component: ConsentRequestComponent,
+            data: { breadcrumb: 'MENU_ITEMS.CONSENT_REQUEST' },
+          },
+        ],
       },
       {
         path: 'settings',

--- a/apps/user-profile/src/app/app.module.ts
+++ b/apps/user-profile/src/app/app.module.ts
@@ -75,6 +75,9 @@ import { PerunLoginModule } from '@perun-web-apps/perun/login';
 import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
 import { MatMenuModule } from '@angular/material/menu';
 import { OAuthModule } from 'angular-oauth2-oidc';
+import { ConsentsPageComponent } from './pages/consents-page/consents-page.component';
+import { ConsentRequestComponent } from './pages/consents-page/consent-request/consent-request.component';
+import { ConsentsPreviewComponent } from './pages/consents-page/consents-preview/consents-preview.component';
 
 export const API_INTERCEPTOR_PROVIDER: Provider = {
   provide: HTTP_INTERCEPTORS,
@@ -129,6 +132,9 @@ const loadConfigs = (appConfig: UserProfileConfigService) => () => appConfig.ini
     BreadcrumbsComponent,
     SettingsAuthenticationComponent,
     AddAuthImgDialogComponent,
+    ConsentsPageComponent,
+    ConsentRequestComponent,
+    ConsentsPreviewComponent,
   ],
   imports: [
     BrowserModule,

--- a/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.html
+++ b/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.html
@@ -1,0 +1,29 @@
+<div class="d-flex">
+  <div class="card p-4 mat-elevation-z3 ml-auto mr-auto">
+    <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
+    <div *ngIf="!loading">
+      <h1 class="page-title">
+        {{ 'CONSENTS.REQUEST.TITLE' | customTranslate | translate }}
+      </h1>
+      <div class="page-subtitle">{{consent.consentHub.name}}</div>
+
+      <div>
+        {{ 'CONSENTS.REQUEST.CONSENT_TEXT_UNSIGNED' | customTranslate | translate }}:
+        <ul>
+          <li *ngFor="let attribute of consent.attributes">
+            {{ attribute.displayName }}
+          </li>
+        </ul>
+      </div>
+      <!--    <mat-checkbox class="minimize-checkbox mb-n2">{{ 'CONSENTS.REQUEST.CHECKBOX' | customTranslate | translate }}</mat-checkbox>-->
+      <div class="d-flex">
+        <button mat-flat-button color="warn" class="mr-2 ml-auto" (click)="rejectConsent()">
+          {{ 'CONSENTS.REQUEST.REJECT_CONSENT_BUTTON' | customTranslate | translate }}
+        </button>
+        <button mat-flat-button color="accent" (click)="grantConsent()">
+          {{ 'CONSENTS.REQUEST.GRANT_CONSENT_BUTTON' | customTranslate | translate }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.scss
+++ b/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.scss
@@ -1,0 +1,4 @@
+.minimize-checkbox {
+  font-size: 0.7rem;
+  color: grey;
+}

--- a/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.ts
+++ b/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.ts
@@ -1,0 +1,75 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { ApiRequestConfigurationService, NotificatorService } from '@perun-web-apps/perun/services';
+import { TranslateService } from '@ngx-translate/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Consent, ConsentsManagerService } from '@perun-web-apps/perun/openapi';
+
+@Component({
+  selector: 'perun-web-apps-consent-request',
+  templateUrl: './consent-request.component.html',
+  styleUrls: ['./consent-request.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class ConsentRequestComponent implements OnInit {
+  constructor(
+    private notificator: NotificatorService,
+    private translate: TranslateService,
+    private consentService: ConsentsManagerService,
+    private route: ActivatedRoute,
+    private apiRequest: ApiRequestConfigurationService,
+    private router: Router
+  ) {}
+
+  consent: Consent;
+  loading = false;
+
+  ngOnInit(): void {
+    this.loading = true;
+    this.route.params.subscribe((params) => {
+      const consentId = params['consentId'];
+      this.apiRequest.dontHandleErrorForNext();
+      this.consentService.getConsentById(consentId).subscribe(
+        (consent) => {
+          this.consent = consent;
+          if (this.consent.status !== 'UNSIGNED') {
+            this.router.navigate(['/profile', 'consents'], { queryParamsHandling: 'merge' });
+          }
+          this.loading = false;
+        },
+        (error) => {
+          this.loading = false;
+          if (error.error.name !== 'ConsentNotExistsException') {
+            this.notificator.showRPCError(error.error);
+          }
+          this.router.navigate(['/profile', 'consents'], { queryParamsHandling: 'merge' });
+        }
+      );
+    });
+  }
+
+  grantConsent() {
+    this.loading = true;
+    this.consentService.changeConsentStatus(this.consent.id, 'GRANTED').subscribe(
+      () => {
+        this.notificator.showSuccess(
+          this.translate.instant('CONSENTS.CONSENT_GRANTED') + this.consent.consentHub.name
+        );
+        this.router.navigate(['/profile', 'consents'], { queryParamsHandling: 'merge' });
+      },
+      () => (this.loading = false)
+    );
+  }
+
+  rejectConsent() {
+    this.loading = true;
+    this.consentService.changeConsentStatus(this.consent.id, 'REVOKED').subscribe(
+      () => {
+        this.notificator.showSuccess(
+          this.translate.instant('CONSENTS.CONSENT_REJECTED') + this.consent.consentHub.name
+        );
+        this.router.navigate(['/profile', 'consents'], { queryParamsHandling: 'merge' });
+      },
+      () => (this.loading = false)
+    );
+  }
+}

--- a/apps/user-profile/src/app/pages/consents-page/consents-page.component.html
+++ b/apps/user-profile/src/app/pages/consents-page/consents-page.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/apps/user-profile/src/app/pages/consents-page/consents-page.component.ts
+++ b/apps/user-profile/src/app/pages/consents-page/consents-page.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'perun-web-apps-consents-page',
+  templateUrl: './consents-page.component.html',
+  styleUrls: ['./consents-page.component.scss'],
+})
+export class ConsentsPageComponent {
+  constructor() {}
+}

--- a/apps/user-profile/src/app/pages/consents-page/consents-preview/consents-preview.component.html
+++ b/apps/user-profile/src/app/pages/consents-page/consents-preview/consents-preview.component.html
@@ -1,0 +1,46 @@
+<h1 class="page-title mt-2">
+  {{ 'CONSENTS.TITLE' | customTranslate | translate }}
+</h1>
+<div class="user-theme">
+  <div *ngIf="!loading && unsignedConsents.length !== 0">
+    <div class="page-subtitle">
+      {{ 'CONSENTS.UNSIGNED_CONSENTS' | customTranslate | translate }}
+    </div>
+
+    <perun-web-apps-immediate-filter
+      [placeholder]="'CONSENTS.FILTER' | customTranslate | translate"
+      (filter)="applyFilterUnsigned($event)">
+    </perun-web-apps-immediate-filter>
+
+    <perun-web-apps-consents-list
+      [consents]="unsignedConsents"
+      [filterValue]="filterValueUnsigned"
+      [tableId]="'TABLE_USER_CONSENTS'"
+      (grantConsent)="grantConsent($event)"
+      (rejectConsent)="rejectConsent($event)"
+      [displayedColumns]="['status', 'name']"></perun-web-apps-consents-list>
+
+    <!--    <button mat-flat-button color="accent" class="mt-3" (click)="grantAll()">-->
+    <!--      {{ 'CONSENTS.GRANT_ALL' | customTranslate | translate }}-->
+    <!--    </button>-->
+  </div>
+
+  <div *ngIf="!loading">
+    <div class="page-subtitle mt-4">
+      {{ 'CONSENTS.PROCESSED_CONSENTS' | customTranslate | translate }}
+    </div>
+    <perun-web-apps-immediate-filter
+      [placeholder]="'CONSENTS.FILTER' | customTranslate | translate"
+      (filter)="applyFilterSigned($event)">
+    </perun-web-apps-immediate-filter>
+    <perun-web-apps-consents-list
+      [consents]="signedConsents"
+      [tableId]="'TABLE_USER_CONSENTS'"
+      [filterValue]="filterValueSigned"
+      (grantConsent)="grantConsent($event)"
+      (rejectConsent)="rejectConsent($event)"
+      [displayedColumns]="['status', 'name']"></perun-web-apps-consents-list>
+  </div>
+
+  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
+</div>

--- a/apps/user-profile/src/app/pages/consents-page/consents-preview/consents-preview.component.ts
+++ b/apps/user-profile/src/app/pages/consents-page/consents-preview/consents-preview.component.ts
@@ -1,0 +1,98 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { NotificatorService, StoreService } from '@perun-web-apps/perun/services';
+import { TranslateService } from '@ngx-translate/core';
+import { Consent, ConsentsManagerService } from '@perun-web-apps/perun/openapi';
+
+@Component({
+  selector: 'perun-web-apps-consents-preview',
+  templateUrl: './consents-preview.component.html',
+  styleUrls: ['./consents-preview.component.scss'],
+})
+export class ConsentsPreviewComponent implements OnInit {
+  constructor(
+    private router: Router,
+    private notificator: NotificatorService,
+    private translate: TranslateService,
+    private storeService: StoreService,
+    private consentService: ConsentsManagerService
+  ) {}
+
+  loading = false;
+  unsignedConsents: Consent[] = [];
+  signedConsents: Consent[] = [];
+  filterValueUnsigned = '';
+  filterValueSigned = '';
+
+  ngOnInit(): void {
+    this.loading = true;
+    this.consentService.getConsentsForUser(this.storeService.getPerunPrincipal().userId).subscribe(
+      (consents) => {
+        this.unsignedConsents = consents.filter((item) => item.status === 'UNSIGNED');
+        this.signedConsents = consents.filter((item) => item.status !== 'UNSIGNED');
+        this.loading = false;
+      },
+      () => (this.loading = false)
+    );
+  }
+
+  grantAll() {
+    //call to backend
+    this.loading = true;
+    this.notificator.showSuccess(this.translate.instant('CONSENTS.GRANT_ALL_NOTIFICATION'));
+    this.loading = false;
+  }
+
+  rejectConsent(id: number) {
+    this.loading = true;
+    this.consentService.changeConsentStatus(id, 'REVOKED').subscribe(
+      () => {
+        const consent =
+          this.unsignedConsents.find((c) => c.id === id) ??
+          this.signedConsents.find((c) => c.id === id);
+        this.moveConsent(consent);
+        const translatedNotification =
+          consent.status === 'GRANTED'
+            ? this.translate.instant('CONSENTS.CONSENT_REVOKED')
+            : this.translate.instant('CONSENTS.CONSENT_REJECTED');
+        consent.status = 'REVOKED';
+        this.notificator.showSuccess(translatedNotification + consent.consentHub.name);
+        this.loading = false;
+      },
+      () => (this.loading = false)
+    );
+  }
+
+  moveConsent(consent: Consent) {
+    if (consent.status === 'UNSIGNED') {
+      this.signedConsents = [...this.signedConsents, consent];
+      this.unsignedConsents = this.unsignedConsents.filter((c) => c.id !== consent.id);
+    }
+  }
+
+  grantConsent(id: number) {
+    this.loading = true;
+    this.consentService.changeConsentStatus(id, 'GRANTED').subscribe(
+      () => {
+        const consent =
+          this.unsignedConsents.find((c) => c.id === id) ??
+          this.signedConsents.find((c) => c.id === id);
+        this.moveConsent(consent);
+        consent.status = 'GRANTED';
+        this.notificator.showSuccess(
+          this.translate.instant('CONSENTS.CONSENT_GRANTED') + consent.consentHub.name
+        );
+        this.loading = false;
+      },
+      () => (this.loading = false)
+    );
+  }
+
+  applyFilterUnsigned($event: string) {
+    this.filterValueUnsigned = $event;
+  }
+
+  applyFilterSigned($event: string) {
+    this.filterValueSigned = $event;
+  }
+}

--- a/apps/user-profile/src/app/services/side-menu-item.service.ts
+++ b/apps/user-profile/src/app/services/side-menu-item.service.ts
@@ -66,6 +66,15 @@ export class SideMenuItemService {
             tabName: 'privacy',
           });
           break;
+        case 'consents':
+          items.push({
+            label: 'MENU_ITEMS.CONSENTS',
+            icon: 'fact_check',
+            link: '/profile/consents',
+            activatedRegex: '^/profile/consents',
+            tabName: 'consents',
+          });
+          break;
         case 'settings':
           items.push({
             label: 'MENU_ITEMS.SETTINGS',

--- a/apps/user-profile/src/assets/config/defaultConfig.json
+++ b/apps/user-profile/src/assets/config/defaultConfig.json
@@ -94,6 +94,7 @@
     "groups",
     "vos",
     "privacy",
+    "consents",
     "settings",
     "data_quotas",
     "ssh_keys",

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -10,6 +10,8 @@
     "GROUPS": "Skupiny",
     "VOS": "Organizace",
     "PRIVACY": "Soukromí",
+    "CONSENTS": "Souhlasy",
+    "CONSENT_REQUEST": "Žádost o souhlas",
     "SETTINGS": "Nastavení"
   },
   "SETTINGS": {
@@ -64,6 +66,27 @@
     "FILTER": "Filtrovat osobní data dle jména organizace",
     "USER_INFO": "Informace o Vás",
     "DATA": "Informace využívané organizací "
+  },
+  "CONSENTS": {
+    "TITLE": "Souhlasy",
+    "FILTER": "Filtrovat souhlasy dle jména služby",
+    "GRANT_ALL": "Dát souhlas všem",
+    "STATUS_GRANTED": "Udělen",
+    "STATUS_REVOKED": "Odmítnut",
+    "STATUS_UNSIGNED": "Nevyřízený",
+    "UNSIGNED_CONSENTS": "Souhlasy, které vyžadují vaši pozornost",
+    "GRANT_ALL_NOTIFICATION": "Souhlas udělen ke všem službám",
+    "CONSENT_GRANTED": "Souhlas byl udělen službě ",
+    "CONSENT_REVOKED": "Souhlas byl odvolán službě ",
+    "CONSENT_REJECTED": "Souhlas byl odmítnut službě ",
+    "PROCESSED_CONSENTS": "Vyřešené souhlasy",
+    "REQUEST": {
+      "TITLE": "Žádost o souhlas",
+      "CHECKBOX": "Zrušte předchozí souhlas pro atributy, které již nejsou vyžadovány",
+      "CONSENT_TEXT_UNSIGNED": "Požadovaná služba vyžaduje přístup k vašim osobním údajům",
+      "GRANT_CONSENT_BUTTON": "Udělit souhlas",
+      "REJECT_CONSENT_BUTTON": "Odmítnout souhlas"
+    }
   },
   "MEMBERSHIP_LIST": {
     "NAME": "Jméno",
@@ -361,6 +384,17 @@
           "BACKEND_ERROR": "Zadané heslo nesplňuje požadavky pro daný namespace",
           "FIELD_EMPTY": "Tohle políčko musí být vyplněné",
           "PWD_DONT_MATCH": "Hesla se neshodují"
+        },
+        "CONSENTS_LIST": {
+          "STATUS": "Status",
+          "SERVICE_NAME": "Jméno služby",
+          "GRANTED_TEXT": "Tato služba má přístup k těmto osobním údajům",
+          "REVOKED_TEXT": "Tato služba vyžaduje přístup k vašim osobním údajům (bez udělení souhlasu nemusí služba fungovat správně)",
+          "UNSIGNED_TEXT": "Požadovaná služba vyžaduje přístup k vašim osobním údajům",
+          "NO_CONSENTS": "Nebyly nalezeny žádné souhlasy",
+          "REVOKE_CONSENT_BUTTON": "Odmítnout souhlas",
+          "REJECT_CONSENT_BUTTON": "Odvolat souhlas",
+          "GRANT_CONSENT_BUTTON": "Udělit souhlas"
         }
       },
       "ORGANIZATIONS": {

--- a/apps/user-profile/src/assets/i18n/en.json
+++ b/apps/user-profile/src/assets/i18n/en.json
@@ -10,6 +10,8 @@
     "GROUPS": "Groups",
     "VOS": "Organizations",
     "PRIVACY": "Privacy",
+    "CONSENTS": "Consents",
+    "CONSENT_REQUEST": "Consent request",
     "SETTINGS": "Settings"
   },
   "SETTINGS": {
@@ -64,6 +66,27 @@
     "FILTER": "Filter private data by organization's name",
     "USER_INFO": "Information about you",
     "DATA": "Information used by "
+  },
+  "CONSENTS": {
+    "TITLE": "Consents",
+    "FILTER": "Filter consents by service name",
+    "GRANT_ALL": "Grant consent to all",
+    "STATUS_GRANTED": "Granted",
+    "STATUS_REVOKED": "Rejected",
+    "STATUS_UNSIGNED": "Pending",
+    "UNSIGNED_CONSENTS": "Consents that need your attention",
+    "GRANT_ALL_NOTIFICATION": "Consent granted to all services",
+    "CONSENT_GRANTED": "Consent was granted for ",
+    "CONSENT_REVOKED": "Consent was revoked for ",
+    "CONSENT_REJECTED": "Consent was rejected for ",
+    "PROCESSED_CONSENTS": "Resolved consents",
+    "REQUEST": {
+      "TITLE": "Consent request",
+      "CHECKBOX": "Revoke previous consent for attributes that are not required anymore",
+      "CONSENT_TEXT_UNSIGNED": "The requested service requires access to your personal data",
+      "GRANT_CONSENT_BUTTON": "Grant consent",
+      "REJECT_CONSENT_BUTTON": "Reject consent"
+    }
   },
   "MEMBERSHIP_LIST": {
     "NAME": "Name",
@@ -437,6 +460,17 @@
           "BACKEND_ERROR": "Entered password doesn't meet the selected namespace's criteria",
           "FIELD_EMPTY": "Empty value is not allowed",
           "PWD_DONT_MATCH": "Passwords do not match"
+        },
+        "CONSENTS_LIST": {
+          "STATUS": "Status",
+          "SERVICE_NAME": "Service name",
+          "GRANTED_TEXT": "This service has access to this personal data",
+          "REVOKED_TEXT": "This service requires access to your personal data (the service might not work properly unless the consent is granted)",
+          "UNSIGNED_TEXT": "The requested service requires access to your personal data",
+          "NO_CONSENTS": "No consents found",
+          "REVOKE_CONSENT_BUTTON": "Revoke consent",
+          "REJECT_CONSENT_BUTTON": "Reject consent",
+          "GRANT_CONSENT_BUTTON": "Grant consent"
         }
       },
       "ORGANIZATIONS": {

--- a/apps/user-profile/src/styles.scss
+++ b/apps/user-profile/src/styles.scss
@@ -108,6 +108,11 @@ button:focus {
   font-size: 1.5rem;
 }
 
+.page-subtitle {
+  margin-bottom: 0.5rem;
+  font-size: 1.2rem;
+}
+
 .dark-hover-list-item {
   &:hover {
     background-color: rgba(0, 0, 0, 0.05);
@@ -115,7 +120,7 @@ button:focus {
 }
 
 th,
-td {
+td.mat-cell {
   padding: 0.25rem !important;
 }
 

--- a/libs/config/table-config/src/lib/table-config.service.ts
+++ b/libs/config/table-config/src/lib/table-config.service.ts
@@ -108,3 +108,4 @@ export const TABLE_SERVICE_MEMBERS = '77';
 export const TABLE_ASSIGN_RESOURCE_TO_GROUP = '78';
 export const TABLE_AUDIT_MESSAGES = '79';
 export const TABLE_CONSENT_HUBS = '80';
+export const TABLE_USER_CONSENTS = '81';

--- a/libs/perun/components/src/lib/consent-status/consent-status.component.html
+++ b/libs/perun/components/src/lib/consent-status/consent-status.component.html
@@ -1,0 +1,12 @@
+<span *ngIf="consentStatus === 'UNSIGNED'">
+  <mat-icon color="warn">priority_high</mat-icon>
+  <span> {{'CONSENTS.STATUS_UNSIGNED' | customTranslate | translate}}</span>
+</span>
+<span *ngIf="consentStatus === 'REVOKED'">
+  <mat-icon color="warn">close</mat-icon>
+  <span> {{'CONSENTS.STATUS_REVOKED' | customTranslate | translate}}</span>
+</span>
+<span *ngIf="consentStatus === 'GRANTED'">
+  <mat-icon color="accent">check</mat-icon>
+  <span> {{'CONSENTS.STATUS_GRANTED' | customTranslate | translate}}</span>
+</span>

--- a/libs/perun/components/src/lib/consent-status/consent-status.component.scss
+++ b/libs/perun/components/src/lib/consent-status/consent-status.component.scss
@@ -1,0 +1,3 @@
+mat-icon {
+  vertical-align: bottom;
+}

--- a/libs/perun/components/src/lib/consent-status/consent-status.component.ts
+++ b/libs/perun/components/src/lib/consent-status/consent-status.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'perun-web-apps-consent-status',
+  templateUrl: './consent-status.component.html',
+  styleUrls: ['./consent-status.component.scss'],
+})
+export class ConsentStatusComponent {
+  constructor() {}
+
+  @Input()
+  consentStatus: string;
+}

--- a/libs/perun/components/src/lib/consents-list/consents-list.component.css
+++ b/libs/perun/components/src/lib/consents-list/consents-list.component.css
@@ -1,0 +1,24 @@
+tr.consent-detail-row {
+  height: 0 !important;
+}
+
+.consent-row td {
+  cursor: pointer;
+  border-bottom-width: 0 !important;
+}
+
+.consent-detail {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+th,
+td.mat-cell {
+  padding: 0 !important;
+}
+
+.mat-cell,
+.mat-footer-cell {
+  font-size: 1rem !important;
+}

--- a/libs/perun/components/src/lib/consents-list/consents-list.component.html
+++ b/libs/perun/components/src/lib/consents-list/consents-list.component.html
@@ -1,0 +1,120 @@
+<div [hidden]="dataSource.filteredData.length === 0" class="card">
+  <perun-web-apps-table-wrapper
+    (exportData)="exportData($event)"
+    [tableId]="tableId"
+    [dataLength]="dataSource.filteredData.length"
+    [pageSizeOptions]="pageSizeOptions">
+    <table
+      mat-table
+      [dataSource]="dataSource"
+      matSort
+      matSortActive="status"
+      matSortDirection="asc"
+      matSortDisableClear
+      multiTemplateDataRows
+      class="w-100">
+      <ng-container matColumnDef="select">
+        <th mat-header-cell *matHeaderCellDef class="align-checkbox">
+          <mat-checkbox
+            color="primary"
+            (change)="$event ? masterToggle() : null"
+            [checked]="selection.hasValue() && isAllSelected()"
+            [indeterminate]="selection.hasValue() && !isAllSelected()">
+          </mat-checkbox>
+        </th>
+        <td mat-cell *matCellDef="let consent" class="static-column-size align-checkbox">
+          <mat-checkbox
+            color="primary"
+            (click)="$event.stopPropagation()"
+            (change)="$event ? selection.toggle(consent) : null"
+            [checked]="selection.isSelected(consent)">
+          </mat-checkbox>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th *matHeaderCellDef mat-header-cell mat-sort-header>
+          {{'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.STATUS' | customTranslate | translate}}
+        </th>
+        <td mat-cell *matCellDef="let consent">
+          <perun-web-apps-consent-status
+            [consentStatus]="consent.status"></perun-web-apps-consent-status>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="name">
+        <th *matHeaderCellDef mat-header-cell mat-sort-header>
+          {{'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.SERVICE_NAME' | customTranslate | translate}}
+        </th>
+        <td mat-cell *matCellDef="let consent">
+          {{consent.consentHub.name}}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="expandedDetail">
+        <td mat-cell *matCellDef="let consent" [attr.colspan]="displayedColumns.length">
+          <div
+            [@detailExpand]="consent === expandedConsent ? 'expanded' : 'collapsed'"
+            class="consent-detail">
+            <div class="p-3">
+              <div *ngIf="consent.status === 'GRANTED'">
+                {{'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.GRANTED_TEXT' | customTranslate | translate}}
+                :
+              </div>
+              <div *ngIf="consent.status === 'REVOKED'">
+                {{'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.REVOKED_TEXT' | customTranslate | translate}}
+                :
+              </div>
+              <div *ngIf="consent.status === 'UNSIGNED'">
+                {{'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.UNSIGNED_TEXT' | customTranslate | translate}}
+                :
+              </div>
+              <ul>
+                <li *ngFor="let attribute of consent.attributes">
+                  {{ attribute.displayName }}
+                </li>
+              </ul>
+              <div class="d-flex">
+                <button
+                  *ngIf="consent.status !== 'REVOKED'"
+                  mat-flat-button
+                  class="mr-2"
+                  color="warn"
+                  (click)="rejectConsent.emit(consent.id)">
+                  {{(consent.status === 'UNSIGNED' ? 'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.REJECT_CONSENT_BUTTON' :
+                  'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.REVOKE_CONSENT_BUTTON') | customTranslate | translate}}
+                </button>
+                <button
+                  *ngIf="consent.status !== 'GRANTED'"
+                  mat-flat-button
+                  color="accent"
+                  (click)="grantConsent.emit(consent.id)">
+                  {{'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.GRANT_CONSENT_BUTTON' | customTranslate | translate}}
+                </button>
+              </div>
+            </div>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr
+        mat-row
+        *matRowDef="let consent; columns: displayedColumns;"
+        [class.example-expanded-row]="expandedConsent === consent"
+        (click)="expandedConsent = expandedConsent === consent ? null : consent"
+        class="dark-hover-list-item consent-row"></tr>
+      <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="consent-detail-row"></tr>
+    </table>
+  </perun-web-apps-table-wrapper>
+</div>
+
+<app-alert
+  *ngIf="dataSource.filteredData.length === 0 && dataSource.data.length !== 0"
+  alert_type="warn">
+  {{'SHARED_LIB.UI.ALERTS.NO_FILTER_RESULTS_ALERT' | customTranslate | translate}}
+</app-alert>
+
+<app-alert *ngIf="dataSource.data.length === 0" alert_type="warn">
+  {{'SHARED_LIB.PERUN.COMPONENTS.CONSENTS_LIST.NO_CONSENTS' | customTranslate | translate}}
+</app-alert>

--- a/libs/perun/components/src/lib/consents-list/consents-list.component.ts
+++ b/libs/perun/components/src/lib/consents-list/consents-list.component.ts
@@ -1,0 +1,146 @@
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { MatSort } from '@angular/material/sort';
+import {
+  customDataSourceFilterPredicate,
+  customDataSourceSort,
+  downloadData,
+  getDataForExport,
+  TABLE_ITEMS_COUNT_OPTIONS,
+  TableWrapperComponent,
+} from '@perun-web-apps/perun/utils';
+import { SelectionModel } from '@angular/cdk/collections';
+import { MatTableDataSource } from '@angular/material/table';
+import { TableCheckbox } from '@perun-web-apps/perun/services';
+import { animate, state, style, transition, trigger } from '@angular/animations';
+import { Consent } from '@perun-web-apps/perun/openapi';
+
+@Component({
+  selector: 'perun-web-apps-consents-list',
+  templateUrl: './consents-list.component.html',
+  styleUrls: ['./consents-list.component.css'],
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed', style({ height: '0px', minHeight: '0' })),
+      state('expanded', style({ height: '*' })),
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
+})
+export class ConsentsListComponent implements AfterViewInit, OnChanges {
+  constructor(private tableCheckbox: TableCheckbox) {}
+
+  @ViewChild(MatSort, { static: true }) set matSort(ms: MatSort) {
+    this.sort = ms;
+    this.setDataSource();
+  }
+
+  @ViewChild(TableWrapperComponent, { static: true }) child: TableWrapperComponent;
+
+  @Input()
+  consents: Consent[] = [];
+
+  @Input()
+  selection = new SelectionModel<Consent>(true, []);
+
+  private sort: MatSort;
+
+  @Input()
+  displayedColumns: string[] = ['select', 'status', 'name'];
+  expandedConsent: Consent | null;
+  dataSource: MatTableDataSource<Consent>;
+
+  @Input()
+  filterValue = '';
+
+  @Input()
+  tableId: string;
+
+  @Output()
+  grantConsent: EventEmitter<number> = new EventEmitter();
+
+  @Output()
+  rejectConsent: EventEmitter<number> = new EventEmitter();
+
+  pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
+
+  ngOnChanges(): void {
+    this.dataSource = new MatTableDataSource<Consent>(this.consents);
+    this.setDataSource();
+  }
+
+  ngAfterViewInit(): void {
+    this.dataSource.paginator = this.child.paginator;
+  }
+
+  getDataForColumn(data: Consent, column: string): string {
+    switch (column) {
+      case 'name':
+        return data.consentHub.name;
+      case 'status':
+        return data.status;
+      default:
+        return '';
+    }
+  }
+
+  exportData(format: string) {
+    downloadData(
+      getDataForExport(
+        this.dataSource.filteredData,
+        this.displayedColumns,
+        this.getDataForColumn,
+        this
+      ),
+      format
+    );
+  }
+
+  setDataSource() {
+    if (this.dataSource) {
+      this.dataSource.filterPredicate = (data: Consent, filter: string) =>
+        customDataSourceFilterPredicate(
+          data,
+          filter,
+          this.displayedColumns,
+          this.getDataForColumn,
+          this
+        );
+      this.dataSource.sortData = (data: Consent[], sort: MatSort) =>
+        customDataSourceSort(data, sort, this.getDataForColumn, this);
+      this.dataSource.sort = this.sort;
+      this.dataSource.paginator = this.child.paginator;
+      this.dataSource.filter = this.filterValue;
+    }
+  }
+
+  isAllSelected() {
+    return this.tableCheckbox.isAllSelected(
+      this.selection.selected.length,
+      this.filterValue,
+      this.child.paginator.pageSize,
+      this.child.paginator.hasNextPage(),
+      this.dataSource
+    );
+  }
+
+  masterToggle() {
+    this.tableCheckbox.masterToggle(
+      this.isAllSelected(),
+      this.selection,
+      this.filterValue,
+      this.dataSource,
+      this.sort,
+      this.child.paginator.pageSize,
+      this.child.paginator.pageIndex,
+      false
+    );
+  }
+}

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -89,6 +89,9 @@ import { SelectionItemSearchSelectComponent } from './selection-item-search-sele
 import { ServiceSearchSelectComponent } from './service-search-select/service-search-select.component';
 import { AdvancedFilterComponent } from './advanced-filter/advanced-filter.component';
 import { NotAuthorizedPageComponent } from './not-authorized-page/not-authorized-page.component';
+import { ConsentsListComponent } from './consents-list/consents-list.component';
+import { ConsentStatusComponent } from './consent-status/consent-status.component';
+import { UiMaterialModule } from '@perun-web-apps/ui/material';
 
 @Injectable()
 export class AppDateAdapter extends NativeDateAdapter {
@@ -154,6 +157,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     ScrollingModule,
     MatDialogModule,
     PerunUtilsModule,
+    UiMaterialModule,
   ],
   declarations: [
     VosListComponent,
@@ -210,6 +214,8 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     ServiceSearchSelectComponent,
     AdvancedFilterComponent,
     NotAuthorizedPageComponent,
+    ConsentsListComponent,
+    ConsentStatusComponent,
   ],
   exports: [
     VosListComponent,
@@ -263,6 +269,8 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     ServiceSearchSelectComponent,
     AdvancedFilterComponent,
     NotAuthorizedPageComponent,
+    ConsentStatusComponent,
+    ConsentsListComponent,
   ],
   providers: [
     { provide: DateAdapter, useClass: AppDateAdapter },

--- a/libs/perun/openapi/src/lib/api/consentsManager.service.ts
+++ b/libs/perun/openapi/src/lib/api/consentsManager.service.ts
@@ -23,7 +23,9 @@ import {
 import { CustomHttpParameterCodec } from '../encoder';
 import { Observable } from 'rxjs';
 
+import { Consent } from '../model/consent';
 import { ConsentHub } from '../model/consentHub';
+import { ConsentStatus } from '../model/consentStatus';
 import { InputUpdateConsentHub } from '../model/inputUpdateConsentHub';
 import { PerunException } from '../model/perunException';
 
@@ -54,6 +56,99 @@ export class ConsentsManagerService {
       this.configuration.basePath = basePath;
     }
     this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
+  }
+
+  /**
+   * Changes value of consent status.
+   * @param consent id of Consent
+   * @param status consent status
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public changeConsentStatus(
+    consent: number,
+    status: ConsentStatus,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<Consent>;
+  public changeConsentStatus(
+    consent: number,
+    status: ConsentStatus,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Consent>>;
+  public changeConsentStatus(
+    consent: number,
+    status: ConsentStatus,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Consent>>;
+  public changeConsentStatus(
+    consent: number,
+    status: ConsentStatus,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (consent === null || consent === undefined) {
+      throw new Error(
+        'Required parameter consent was null or undefined when calling changeConsentStatus.'
+      );
+    }
+    if (status === null || status === undefined) {
+      throw new Error(
+        'Required parameter status was null or undefined when calling changeConsentStatus.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (consent !== undefined && consent !== null) {
+      queryParameters = queryParameters.set('consent', <any>consent);
+    }
+    if (status !== undefined && status !== null) {
+      queryParameters = queryParameters.set('status', <any>status);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.post<Consent>(
+      `${this.configuration.basePath}/urlinjsonout/consentsManager/changeConsentStatus`,
+      null,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
   }
 
   /**
@@ -110,6 +205,244 @@ export class ConsentsManagerService {
     return this.httpClient.get<Array<ConsentHub>>(
       `${this.configuration.basePath}/json/consentsManager/getAllConsentHubs`,
       {
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Return list of all existing Consents
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getAllConsents(observe?: 'body', reportProgress?: boolean): Observable<Array<Consent>>;
+  public getAllConsents(
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Array<Consent>>>;
+  public getAllConsents(
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Array<Consent>>>;
+  public getAllConsents(observe: any = 'body', reportProgress: boolean = false): Observable<any> {
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.get<Array<Consent>>(
+      `${this.configuration.basePath}/json/consentsManager/getAllConsents`,
+      {
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Return Consent object with corresponding id
+   * @param id numeric id
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getConsentById(
+    id: number,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<Consent>;
+  public getConsentById(
+    id: number,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Consent>>;
+  public getConsentById(
+    id: number,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Consent>>;
+  public getConsentById(
+    id: number,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (id === null || id === undefined) {
+      throw new Error('Required parameter id was null or undefined when calling getConsentById.');
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (id !== undefined && id !== null) {
+      queryParameters = queryParameters.set('id', <any>id);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.get<Consent>(
+      `${this.configuration.basePath}/json/consentsManager/getConsentById`,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Return Consent object for chosen user in specified consent hub with specified status
+   * @param user id of User
+   * @param consentHub id of ConsentHub
+   * @param status consent status
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getConsentForUserAndConsentHub(
+    user: number,
+    consentHub: number,
+    status: ConsentStatus,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<Consent>;
+  public getConsentForUserAndConsentHub(
+    user: number,
+    consentHub: number,
+    status: ConsentStatus,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Consent>>;
+  public getConsentForUserAndConsentHub(
+    user: number,
+    consentHub: number,
+    status: ConsentStatus,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Consent>>;
+  public getConsentForUserAndConsentHub(
+    user: number,
+    consentHub: number,
+    status: ConsentStatus,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (user === null || user === undefined) {
+      throw new Error(
+        'Required parameter user was null or undefined when calling getConsentForUserAndConsentHub.'
+      );
+    }
+    if (consentHub === null || consentHub === undefined) {
+      throw new Error(
+        'Required parameter consentHub was null or undefined when calling getConsentForUserAndConsentHub.'
+      );
+    }
+    if (status === null || status === undefined) {
+      throw new Error(
+        'Required parameter status was null or undefined when calling getConsentForUserAndConsentHub.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (user !== undefined && user !== null) {
+      queryParameters = queryParameters.set('user', <any>user);
+    }
+    if (consentHub !== undefined && consentHub !== null) {
+      queryParameters = queryParameters.set('consentHub', <any>consentHub);
+    }
+    if (status !== undefined && status !== null) {
+      queryParameters = queryParameters.set('status', <any>status);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.get<Consent>(
+      `${this.configuration.basePath}/json/consentsManager/getConsentForUserAndConsentHub`,
+      {
+        params: queryParameters,
         withCredentials: this.configuration.withCredentials,
         headers: headers,
         observe: observe,
@@ -345,6 +678,440 @@ export class ConsentsManagerService {
 
     return this.httpClient.get<ConsentHub>(
       `${this.configuration.basePath}/json/consentsManager/getConsentHubByName`,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Return Consents for ConsentHub with corresponding id
+   * @param consentHub id of ConsentHub
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getConsentsForConsentHub(
+    consentHub: number,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<Array<Consent>>;
+  public getConsentsForConsentHub(
+    consentHub: number,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Array<Consent>>>;
+  public getConsentsForConsentHub(
+    consentHub: number,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Array<Consent>>>;
+  public getConsentsForConsentHub(
+    consentHub: number,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (consentHub === null || consentHub === undefined) {
+      throw new Error(
+        'Required parameter consentHub was null or undefined when calling getConsentsForConsentHub.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (consentHub !== undefined && consentHub !== null) {
+      queryParameters = queryParameters.set('consentHub', <any>consentHub);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.get<Array<Consent>>(
+      `${this.configuration.basePath}/json/consentsManager/getConsentsForConsentHub/id`,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Return Consents of certain status for ConsentHub with corresponding id
+   * @param consentHub id of ConsentHub
+   * @param status consent status
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getConsentsForConsentHubWithStatus(
+    consentHub: number,
+    status: ConsentStatus,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<Array<Consent>>;
+  public getConsentsForConsentHubWithStatus(
+    consentHub: number,
+    status: ConsentStatus,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Array<Consent>>>;
+  public getConsentsForConsentHubWithStatus(
+    consentHub: number,
+    status: ConsentStatus,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Array<Consent>>>;
+  public getConsentsForConsentHubWithStatus(
+    consentHub: number,
+    status: ConsentStatus,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (consentHub === null || consentHub === undefined) {
+      throw new Error(
+        'Required parameter consentHub was null or undefined when calling getConsentsForConsentHubWithStatus.'
+      );
+    }
+    if (status === null || status === undefined) {
+      throw new Error(
+        'Required parameter status was null or undefined when calling getConsentsForConsentHubWithStatus.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (consentHub !== undefined && consentHub !== null) {
+      queryParameters = queryParameters.set('consentHub', <any>consentHub);
+    }
+    if (status !== undefined && status !== null) {
+      queryParameters = queryParameters.set('status', <any>status);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.get<Array<Consent>>(
+      `${this.configuration.basePath}/json/consentsManager/getConsentsForConsentHub/id-s`,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Return Consents for user with corresponding id
+   * @param user id of User
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getConsentsForUser(
+    user: number,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<Array<Consent>>;
+  public getConsentsForUser(
+    user: number,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Array<Consent>>>;
+  public getConsentsForUser(
+    user: number,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Array<Consent>>>;
+  public getConsentsForUser(
+    user: number,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (user === null || user === undefined) {
+      throw new Error(
+        'Required parameter user was null or undefined when calling getConsentsForUser.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (user !== undefined && user !== null) {
+      queryParameters = queryParameters.set('user', <any>user);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.get<Array<Consent>>(
+      `${this.configuration.basePath}/json/consentsManager/getConsentsForUser/id`,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Return Consents for specified user in specified consent hub
+   * @param user id of User
+   * @param consentHub id of ConsentHub
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getConsentsForUserAndConsentHub(
+    user: number,
+    consentHub: number,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<Array<Consent>>;
+  public getConsentsForUserAndConsentHub(
+    user: number,
+    consentHub: number,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Array<Consent>>>;
+  public getConsentsForUserAndConsentHub(
+    user: number,
+    consentHub: number,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Array<Consent>>>;
+  public getConsentsForUserAndConsentHub(
+    user: number,
+    consentHub: number,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (user === null || user === undefined) {
+      throw new Error(
+        'Required parameter user was null or undefined when calling getConsentsForUserAndConsentHub.'
+      );
+    }
+    if (consentHub === null || consentHub === undefined) {
+      throw new Error(
+        'Required parameter consentHub was null or undefined when calling getConsentsForUserAndConsentHub.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (user !== undefined && user !== null) {
+      queryParameters = queryParameters.set('user', <any>user);
+    }
+    if (consentHub !== undefined && consentHub !== null) {
+      queryParameters = queryParameters.set('consentHub', <any>consentHub);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.get<Array<Consent>>(
+      `${this.configuration.basePath}/json/consentsManager/getConsentsForUserAndConsentHub`,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Return Consents of certain status for user with corresponding id
+   * @param user id of User
+   * @param status consent status
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getConsentsForUserWithStatus(
+    user: number,
+    status: ConsentStatus,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<Array<Consent>>;
+  public getConsentsForUserWithStatus(
+    user: number,
+    status: ConsentStatus,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<Array<Consent>>>;
+  public getConsentsForUserWithStatus(
+    user: number,
+    status: ConsentStatus,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<Array<Consent>>>;
+  public getConsentsForUserWithStatus(
+    user: number,
+    status: ConsentStatus,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (user === null || user === undefined) {
+      throw new Error(
+        'Required parameter user was null or undefined when calling getConsentsForUserWithStatus.'
+      );
+    }
+    if (status === null || status === undefined) {
+      throw new Error(
+        'Required parameter status was null or undefined when calling getConsentsForUserWithStatus.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (user !== undefined && user !== null) {
+      queryParameters = queryParameters.set('user', <any>user);
+    }
+    if (status !== undefined && status !== null) {
+      queryParameters = queryParameters.set('status', <any>status);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.get<Array<Consent>>(
+      `${this.configuration.basePath}/json/consentsManager/getConsentsForUser/id-s`,
       {
         params: queryParameters,
         withCredentials: this.configuration.withCredentials,

--- a/libs/ui/material/src/lib/ui-material.module.ts
+++ b/libs/ui/material/src/lib/ui-material.module.ts
@@ -19,7 +19,6 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
-import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatSortModule } from '@angular/material/sort';
@@ -50,7 +49,6 @@ import { MatSelectModule } from '@angular/material/select';
     MatNativeDateModule,
     MatSidenavModule,
     MatListModule,
-    PerunSharedComponentsModule,
     MatMenuModule,
     MatToolbarModule,
     MatSortModule,
@@ -80,7 +78,6 @@ import { MatSelectModule } from '@angular/material/select';
     MatNativeDateModule,
     MatSidenavModule,
     MatListModule,
-    PerunSharedComponentsModule,
     MatMenuModule,
     MatToolbarModule,
     MatSortModule,


### PR DESCRIPTION
* user can manage his consents in consents page
* the user is redirected
from email url to page /profile/consents/:consentId

BREAKING CHANGE: * add new item 'consents' to 'displayed_tabs' array if you want to show consents page in menu