### PR TITLE
feat(admin): add Searcher to the admin section

### DIFF
--- a/apps/admin-gui/src/app/admin/admin-routing.module.ts
+++ b/apps/admin-gui/src/app/admin/admin-routing.module.ts
@@ -31,6 +31,7 @@ import { UserFacilitiesComponent } from '../users/pages/user-detail-page/user-fa
 import { UserAccountsComponent } from '../users/pages/user-detail-page/user-accounts/user-accounts.component';
 import { AdminAuditLogComponent } from './pages/admin-page/admin-audit-log/admin-audit-log.component';
 import { AdminConsentHubsComponent } from './pages/admin-page/admin-consent-hubs/admin-consent-hubs.component';
+import { AdminSearcherComponent } from './pages/admin-page/admin-searcher/admin-searcher.component';
 
 const routes: Routes = [
   {
@@ -102,6 +103,11 @@ const routes: Routes = [
         path: 'consent_hubs',
         component: AdminConsentHubsComponent,
         data: { animation: 'AdminConsentHubsPage' },
+      },
+      {
+        path: 'searcher',
+        component: AdminSearcherComponent,
+        data: { animation: 'AdminSearcherPage' },
       },
     ],
   },

--- a/apps/admin-gui/src/app/admin/admin.module.ts
+++ b/apps/admin-gui/src/app/admin/admin.module.ts
@@ -27,6 +27,7 @@ import { ServiceDestinationsComponent } from './pages/admin-page/admin-services/
 import { AdminOwnersComponent } from './pages/admin-page/admin-owners/admin-owners.component';
 import { AdminAuditLogComponent } from './pages/admin-page/admin-audit-log/admin-audit-log.component';
 import { AdminConsentHubsComponent } from './pages/admin-page/admin-consent-hubs/admin-consent-hubs.component';
+import { AdminSearcherComponent } from './pages/admin-page/admin-searcher/admin-searcher.component';
 
 @NgModule({
   declarations: [
@@ -49,6 +50,7 @@ import { AdminConsentHubsComponent } from './pages/admin-page/admin-consent-hubs
     AdminOwnersComponent,
     AdminAuditLogComponent,
     AdminConsentHubsComponent,
+    AdminSearcherComponent,
   ],
   imports: [
     NgxGraphModule,

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-overview/admin-overview.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-overview/admin-overview.component.ts
@@ -60,5 +60,11 @@ export class AdminOverviewComponent {
       label: 'MENU_ITEMS.ADMIN.CONSENT_HUBS',
       style: 'admin-btn',
     },
+    {
+      cssIcon: 'perun-searcher',
+      url: '/admin/searcher',
+      label: 'MENU_ITEMS.ADMIN.SEARCHER',
+      style: 'admin-btn',
+    },
   ];
 }

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-searcher/admin-searcher.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-searcher/admin-searcher.component.html
@@ -1,0 +1,90 @@
+<h1 class="page-subtitle">{{'ADMIN.SEARCHER.TITLE' | translate}}</h1>
+<mat-tab-group (selectedIndexChange)="tabChanged($event)">
+  <mat-tab class="mb-2">
+    <ng-template matTabLabel>
+      {{'ADMIN.SEARCHER.TAB_USERS' | translate}}
+    </ng-template>
+    <ng-template matTabContent>
+      <perun-web-apps-attribute-search-select
+        *ngIf="!loading"
+        [attributes]="allAttrDefinitions"
+        [attributesForEntity]="'user'"
+        (search)="searchEntities($event, 'user')">
+      </perun-web-apps-attribute-search-select>
+      <app-users-list
+        *ngIf="!loadingEntityData"
+        [tableId]="tableId"
+        [displayedColumns]="['user', 'id', 'name']"
+        [users]="entities">
+      </app-users-list>
+    </ng-template>
+  </mat-tab>
+  <mat-tab>
+    <ng-template matTabLabel>
+      {{'ADMIN.SEARCHER.TAB_MEMBERS' | translate}}
+    </ng-template>
+    <ng-template matTabContent>
+      <div class="mt-3">
+        <perun-web-apps-vo-search-select
+          *ngIf="vos.length > 0"
+          [vos]="vos"
+          (voSelected)="voSelected($event)">
+        </perun-web-apps-vo-search-select>
+      </div>
+      <!-- we search members in searcher by user attributes !!! -->
+      <perun-web-apps-attribute-search-select
+        *ngIf="!loading"
+        [attributes]="allAttrDefinitions"
+        [attributesForEntity]="'user'"
+        (search)="searchEntities($event, 'member')">
+      </perun-web-apps-attribute-search-select>
+      <perun-web-apps-members-list
+        *ngIf="!loadingEntityData"
+        [tableId]="tableId"
+        [displayedColumns]="['id', 'voId', 'userId', 'status']"
+        [disableExpirationChange]="true"
+        (updateTable)="searchEntities(searchInput, 'member')"
+        [members]="entities">
+      </perun-web-apps-members-list>
+    </ng-template>
+  </mat-tab>
+  <mat-tab>
+    <ng-template matTabLabel>
+      {{'ADMIN.SEARCHER.TAB_FACILITIES' | translate}}
+    </ng-template>
+    <ng-template matTabContent>
+      <perun-web-apps-attribute-search-select
+        *ngIf="!loading"
+        [attributes]="allAttrDefinitions"
+        [attributesForEntity]="'facility'"
+        (search)="searchEntities($event, 'facility')">
+      </perun-web-apps-attribute-search-select>
+      <perun-web-apps-facilities-list
+        *ngIf="!loadingEntityData"
+        [tableId]="tableId"
+        [displayedColumns]="['id', 'name', 'description']"
+        [facilities]="entities">
+      </perun-web-apps-facilities-list>
+    </ng-template>
+  </mat-tab>
+  <mat-tab>
+    <ng-template matTabLabel>
+      {{'ADMIN.SEARCHER.TAB_RESOURCES' | translate}}
+    </ng-template>
+    <ng-template matTabContent>
+      <perun-web-apps-attribute-search-select
+        *ngIf="!loading"
+        [attributes]="allAttrDefinitions"
+        [attributesForEntity]="'resource'"
+        (search)="searchEntities($event, 'resource')">
+      </perun-web-apps-attribute-search-select>
+      <perun-web-apps-resources-list
+        *ngIf="!loadingEntityData"
+        [tableId]="tableId"
+        [displayedColumns]="['id', 'name', 'description', 'voId', 'facilityId']"
+        [resources]="entities">
+      </perun-web-apps-resources-list>
+    </ng-template>
+  </mat-tab>
+</mat-tab-group>
+<mat-spinner class="ml-auto mr-auto" *ngIf="loading || loadingEntityData"></mat-spinner>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-searcher/admin-searcher.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-searcher/admin-searcher.component.ts
@@ -1,0 +1,155 @@
+import { Component, HostBinding, OnInit } from '@angular/core';
+import {
+  AttributeDefinition,
+  AttributesManagerService,
+  EnrichedFacility,
+  RichMember,
+  RichUser,
+  SearcherService,
+  Vo,
+  VosManagerService,
+} from '@perun-web-apps/perun/openapi';
+import {
+  TABLE_SEARCHER_FACILITIES,
+  TABLE_SEARCHER_MEMBERS,
+  TABLE_SEARCHER_RESOURCES,
+  TABLE_SEARCHER_USERS,
+} from '@perun-web-apps/config/table-config';
+import { ResourceWithStatus } from '@perun-web-apps/perun/models';
+
+@Component({
+  selector: 'app-admin-searcher',
+  templateUrl: './admin-searcher.component.html',
+  styleUrls: ['./admin-searcher.component.scss'],
+})
+export class AdminSearcherComponent implements OnInit {
+  static id = 'AdminSearcherComponent';
+
+  @HostBinding('class.router-component') true;
+
+  constructor(
+    private attributesManager: AttributesManagerService,
+    private searcher: SearcherService,
+    private voService: VosManagerService
+  ) {}
+
+  loading: boolean;
+  loadingEntityData = false;
+  allAttrDefinitions: AttributeDefinition[] = [];
+  searchInput: { [p: string]: string };
+  tableId = TABLE_SEARCHER_USERS;
+  entities: RichUser[] | RichMember[] | EnrichedFacility[] | ResourceWithStatus[] = [];
+  vos: Vo[] = [];
+  selectedVo: Vo;
+
+  ngOnInit(): void {
+    this.loading = true;
+    this.attributesManager.getAllAttributeDefinitions().subscribe((attrDefs) => {
+      this.allAttrDefinitions = attrDefs;
+      this.loading = false;
+    });
+  }
+
+  tabChanged(indexChangeEvent: number): void {
+    this.entities = [];
+    switch (indexChangeEvent) {
+      case 0:
+        this.tableId = TABLE_SEARCHER_USERS;
+        break;
+      case 1:
+        this.loadingEntityData = true;
+        this.loadAllVos();
+        this.tableId = TABLE_SEARCHER_MEMBERS;
+        break;
+      case 2:
+        this.tableId = TABLE_SEARCHER_FACILITIES;
+        break;
+      case 3:
+        this.tableId = TABLE_SEARCHER_RESOURCES;
+        break;
+      default:
+        break;
+    }
+  }
+
+  loadAllVos(): void {
+    this.loadingEntityData = true;
+    this.voService.getAllVos().subscribe((vos) => {
+      this.vos = vos;
+      this.selectedVo = vos[0];
+      this.loadingEntityData = false;
+    });
+  }
+
+  voSelected(vo: Vo): void {
+    if (vo !== undefined) {
+      this.selectedVo = vo;
+    }
+  }
+
+  searchEntities(event: { [p: string]: string }, entity: string): void {
+    this.searchInput = event;
+    this.loadingEntityData = true;
+    switch (entity) {
+      case 'user':
+        this.getUsers();
+        break;
+      case 'member':
+        this.getMembers();
+        break;
+      case 'facility':
+        this.getFacilities();
+        break;
+      case 'resource':
+        this.getResources();
+        break;
+      default:
+        break;
+    }
+  }
+
+  getUsers(): void {
+    this.searcher
+      .getUsersSearcher({
+        attributesWithSearchingValues: this.searchInput,
+      })
+      .subscribe((users) => {
+        this.entities = users as RichUser[];
+        this.loadingEntityData = false;
+      });
+  }
+
+  getMembers(): void {
+    this.searcher
+      .getMembersByUserAttributes({
+        vo: this.selectedVo.id,
+        userAttributesWithSearchingValues: this.searchInput,
+      })
+      .subscribe((members) => {
+        this.entities = members as RichMember[];
+        this.loadingEntityData = false;
+      });
+  }
+
+  getFacilities(): void {
+    this.searcher
+      .getFacilities({
+        attributesWithSearchingValues: this.searchInput,
+      })
+      .subscribe((facilities) => {
+        this.entities = facilities.map((f) => ({ facility: f })) as EnrichedFacility[];
+        this.loadingEntityData = false;
+      });
+  }
+
+  getResources(): void {
+    this.searcher
+      .getAttributesResources({
+        attributesWithSearchingValues: this.searchInput,
+      })
+      .subscribe((resources) => {
+        this.entities = resources as ResourceWithStatus[];
+        this.loadingEntityData = false;
+      });
+  }
+}

--- a/apps/admin-gui/src/app/core/services/common/cache-route-reuse-strategy.ts
+++ b/apps/admin-gui/src/app/core/services/common/cache-route-reuse-strategy.ts
@@ -19,6 +19,7 @@ import { Injectable } from '@angular/core';
 import { VoSelectPageComponent } from '../../../vos/pages/vo-select-page/vo-select-page.component';
 import { FacilitySelectPageComponent } from '../../../facilities/pages/facility-select-page/facility-select-page.component';
 import { VoSettingsSponsoredMembersComponent } from '../../../vos/pages/vo-detail-page/vo-settings/vo-settings-sponsored-members/vo-settings-sponsored-members.component';
+import { AdminSearcherComponent } from '../../../admin/pages/admin-page/admin-searcher/admin-searcher.component';
 
 export class CachedRoute {
   routeHandle: DetachedRouteHandle;
@@ -63,7 +64,7 @@ export class CacheRouteReuseStrategy implements RouteReuseStrategy {
     },
     {
       type: 'admin',
-      components: [AdminUsersComponent.id],
+      components: [AdminUsersComponent.id, AdminSearcherComponent.id],
     },
     {
       type: 'entitySelect',

--- a/apps/admin-gui/src/app/shared/components/dialogs/application-form-copy-items-dialog/application-form-copy-items-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/application-form-copy-items-dialog/application-form-copy-items-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import {
@@ -41,6 +41,7 @@ export class ApplicationFormCopyItemsDialogComponent implements OnInit {
     private registrarManager: RegistrarManagerService,
     private notificatorService: NotificatorService,
     private apiRequest: ApiRequestConfigurationService,
+    private cd: ChangeDetectorRef,
     @Inject(MAT_DIALOG_DATA) public data: ApplicationFormCopyItemsDialogData
   ) {
     translateService
@@ -63,17 +64,7 @@ export class ApplicationFormCopyItemsDialogComponent implements OnInit {
       () => {
         this.voService.getMyVos().subscribe(
           (vos) => {
-            this.vos = vos.sort((vo1, vo2) => {
-              if (vo1.name > vo2.name) {
-                return 1;
-              }
-
-              if (vo1.name < vo2.name) {
-                return -1;
-              }
-
-              return 0;
-            });
+            this.vos = vos;
             this.loading = false;
           },
           () => (this.loading = false)
@@ -172,6 +163,7 @@ export class ApplicationFormCopyItemsDialogComponent implements OnInit {
 
   voSelected(vo: Vo) {
     this.selectedVo = vo;
+    this.cd.detectChanges();
     this.getGroups();
   }
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/notifications-copy-mails-dialog/notifications-copy-mails-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/notifications-copy-mails-dialog/notifications-copy-mails-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import { openClose } from '@perun-web-apps/perun/animations';
@@ -29,6 +29,7 @@ export class NotificationsCopyMailsDialogComponent implements OnInit {
     private groupService: GroupsManagerService,
     private translateService: TranslateService,
     private registrarService: RegistrarManagerService,
+    private cd: ChangeDetectorRef,
     @Inject(MAT_DIALOG_DATA) public data: NotificationsCopyMailsDialogData
   ) {}
 
@@ -59,18 +60,6 @@ export class NotificationsCopyMailsDialogComponent implements OnInit {
 
         this.voService.getAllVos().subscribe((vos) => {
           this.vos = vos;
-
-          this.vos = vos.sort((vo1, vo2) => {
-            if (vo1.name > vo2.name) {
-              return 1;
-            }
-
-            if (vo1.name < vo2.name) {
-              return -1;
-            }
-
-            return 0;
-          });
           this.loading = false;
         });
       },
@@ -129,10 +118,11 @@ export class NotificationsCopyMailsDialogComponent implements OnInit {
   voSelected(vo: Vo) {
     this.selectedVo = vo;
     this.getGroups();
+    this.cd.detectChanges();
   }
 
   getGroups() {
-    if (this.selectedVo !== null) {
+    if (this.selectedVo) {
       this.groupService.getAllGroups(this.selectedVo.id).subscribe((groups) => {
         this.groups = [this.fakeGroup].concat(groups);
       });

--- a/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.html
@@ -30,6 +30,7 @@
       [tableId]="tableId"
       *ngIf="firstSearchDone"
       [hidden]="loading"
+      [disableStatusChange]="true"
       [members]="members"
       [selection]="selection"
       [displayedColumns]="['checkbox', 'id', 'fullName', 'status', 'sponsored', 'email']"

--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
@@ -235,6 +235,11 @@ export class SideMenuItemService {
           url: ['/admin/consent_hubs'],
           activatedRegex: '^/admin/consent_hubs$',
         },
+        {
+          label: 'MENU_ITEMS.ADMIN.SEARCHER',
+          url: ['/admin/searcher'],
+          activatedRegex: '^/admin/searcher',
+        },
       ],
     };
   }

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-accounts/user-accounts.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-accounts/user-accounts.component.html
@@ -5,7 +5,6 @@
     *ngIf="!(initLoading || vos.length === 0)"
     class="w-50"
     [vos]="vos"
-    [vo]="vos[0]"
     (voSelected)="loadMember($event)">
   </perun-web-apps-vo-search-select>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-service-members/vo-settings-service-members.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-service-members/vo-settings-service-members.component.html
@@ -22,5 +22,6 @@
   *ngIf="!loading"
   [displayedColumns]="['checkbox','id', 'type', 'fullName', 'status']"
   [selection]="selection"
+  [disableStatusChange]="true"
   [filter]="searchString"
   [members]="members"></perun-web-apps-members-list>

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -926,7 +926,8 @@
       "SERVICES": "Services",
       "OWNERS": "Owners",
       "AUDIT_LOG": "Audit log",
-      "CONSENT_HUBS": "Consent hubs"
+      "CONSENT_HUBS": "Consent hubs",
+      "SEARCHER": "Searcher"
     },
     "VISUALIZER": {
       "ATTR_DEPENDENCIES": "Modules dependencies",
@@ -2135,6 +2136,8 @@
   },
   "MEMBERS_LIST": {
     "ID": "Id",
+    "VO_ID": "Organization Id",
+    "USER_ID": "User Id",
     "NAME": "Name",
     "STATUS": "Organization status",
     "GROUP_STATUS": "Group status",
@@ -2264,6 +2267,13 @@
     "CONSENT_HUBS": {
       "TITLE": "Consent hubs",
       "SEARCH": "Search by Id, Name or Facilities"
+    },
+    "SEARCHER": {
+      "TITLE": "Searcher",
+      "TAB_USERS": "User",
+      "TAB_MEMBERS": "Members",
+      "TAB_FACILITIES": "Facilities",
+      "TAB_RESOURCES": "Resources"
     }
   },
   "USER_DETAIL": {
@@ -2593,7 +2603,9 @@
           "TABLE_RESOURCE_ID": "Id",
           "TABLE_RESOURCE_NAME": "Name",
           "TABLE_VO_NAME": "Organization",
+          "TABLE_VO_ID": "Organization Id",
           "TABLE_FACILITY_NAME": "Facility name",
+          "TABLE_FACILITY_ID": "Facility Id",
           "TABLE_RESOURCE_TAGS": "Tags",
           "TABLE_SEARCH": "Filter",
           "TABLE_RESOURCE_DESCRIPTION": "Description",
@@ -2627,6 +2639,16 @@
           "SELECT_USER": "Select user",
           "FIND_USER": "Find user...",
           "NO_USER_FOUND": "No matching user found"
+        },
+        "ATTR_DEF_SEARCH_SELECT": {
+          "SELECT_ATTR_DEF": "Select attribute definition",
+          "FIND_ATTR_DEF": "Find attribute definition...",
+          "NO_ATTR_DEF_FOUND": "No matching attribute definition found",
+          "SEARCH_PLACEHOLDER": "Search by selected attribute",
+          "ADD_PARAMETER": "Add parameter",
+          "REMOVE_PARAMETER": "Remove",
+          "SEARCH_BUTTON": "Search",
+          "SEARCH_BUTTON_TOOLTIP": "Search string cannot be empty"
         },
         "ATTRIBUTE_VALUE_LIST": {
           "EDIT_DIALOG": {

--- a/libs/config/table-config/src/lib/table-config.service.ts
+++ b/libs/config/table-config/src/lib/table-config.service.ts
@@ -109,3 +109,7 @@ export const TABLE_ASSIGN_RESOURCE_TO_GROUP = '78';
 export const TABLE_AUDIT_MESSAGES = '79';
 export const TABLE_CONSENT_HUBS = '80';
 export const TABLE_USER_CONSENTS = '81';
+export const TABLE_SEARCHER_USERS = '82';
+export const TABLE_SEARCHER_MEMBERS = '83';
+export const TABLE_SEARCHER_FACILITIES = '84';
+export const TABLE_SEARCHER_RESOURCES = '85';

--- a/libs/perun/components/src/lib/attribute-search-select/attribute-search-select.component.html
+++ b/libs/perun/components/src/lib/attribute-search-select/attribute-search-select.component.html
@@ -1,0 +1,49 @@
+<div *ngIf="options !== undefined" class="container ml-0 mr-0 pl-0 pr-0 mt-3">
+  <div *ngFor="let option of options" class="row">
+    <div class="col-7">
+      <perun-web-apps-entity-search-select
+        [entities]="availableAttrDefs"
+        (entitySelected)="option[0] = $event.namespace + ':' + $event.friendlyName"
+        [searchFunction]="nameFunction"
+        [mainTextFunction]="nameFunction"
+        [secondaryTextFunction]="secondaryTextFunction"
+        [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.ATTR_DEF_SEARCH_SELECT.SELECT_ATTR_DEF' | translate"
+        [findPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.ATTR_DEF_SEARCH_SELECT.FIND_ATTR_DEF' | translate"
+        [noEntriesText]="'SHARED_LIB.PERUN.COMPONENTS.ATTR_DEF_SEARCH_SELECT.NO_ATTR_DEF_FOUND' | translate">
+      </perun-web-apps-entity-search-select>
+    </div>
+    <div class="col-4 pr-0">
+      <perun-web-apps-debounce-filter
+        [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.ATTR_DEF_SEARCH_SELECT.SEARCH_PLACEHOLDER'"
+        (filter)="option[1] = $event">
+      </perun-web-apps-debounce-filter>
+    </div>
+    <div class="col-1">
+      <button
+        class="mt-2"
+        mat-icon-button
+        color="warn"
+        matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.ATTR_DEF_SEARCH_SELECT.REMOVE_PARAMETER' | translate}}"
+        [disabled]="options.length === 1"
+        (click)="removeOption(option)">
+        <mat-icon>clear</mat-icon>
+      </button>
+    </div>
+  </div>
+  <button mat-flat-button color="accent" class="mr-2" (click)="addOption()">
+    {{'SHARED_LIB.PERUN.COMPONENTS.ATTR_DEF_SEARCH_SELECT.ADD_PARAMETER' | translate}}
+  </button>
+  <span
+    matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.ATTR_DEF_SEARCH_SELECT.SEARCH_BUTTON_TOOLTIP' | translate}}"
+    matTooltipPosition="below"
+    [matTooltipDisabled]="!emptySearchString()">
+    <button
+      mat-stroked-button
+      class="mr-2"
+      (click)="searchEntities()"
+      [disabled]="emptySearchString()">
+      <mat-icon>search</mat-icon>
+      {{'SHARED_LIB.PERUN.COMPONENTS.ATTR_DEF_SEARCH_SELECT.SEARCH_BUTTON' | translate}}
+    </button>
+  </span>
+</div>

--- a/libs/perun/components/src/lib/attribute-search-select/attribute-search-select.component.ts
+++ b/libs/perun/components/src/lib/attribute-search-select/attribute-search-select.component.ts
@@ -1,0 +1,52 @@
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { AttributeDefinition } from '@perun-web-apps/perun/openapi';
+import { compareFnDisplayName } from '@perun-web-apps/perun/utils';
+
+@Component({
+  selector: 'perun-web-apps-attribute-search-select',
+  templateUrl: './attribute-search-select.component.html',
+  styleUrls: ['./attribute-search-select.component.scss'],
+})
+export class AttributeSearchSelectComponent implements OnInit, OnChanges {
+  @Input() attributes: AttributeDefinition[];
+  @Input() attributesForEntity: 'user' | 'facility' | 'resource';
+  @Output() attributeSelected = new EventEmitter<AttributeDefinition>();
+  @Output() search = new EventEmitter<{ [p: string]: string }>();
+
+  availableAttrDefs: AttributeDefinition[] = [];
+  options: string[][] = [];
+
+  nameFunction = (attr: AttributeDefinition) => attr.displayName;
+  secondaryTextFunction: (attr: AttributeDefinition) => string = (attr) => '#' + attr.id;
+
+  ngOnInit() {
+    this.availableAttrDefs = this.attributes
+      .filter((attrDef) => attrDef.entity === this.attributesForEntity)
+      .sort(compareFnDisplayName);
+  }
+
+  ngOnChanges(): void {
+    this.options = [];
+    this.options.push([this.attributes[0].namespace + ':' + this.attributes[0].friendlyName, '']);
+  }
+
+  removeOption(option: string[]) {
+    this.options = this.options.filter((opt) => opt !== option);
+  }
+
+  addOption(): void {
+    this.options.push([this.attributes[0].namespace + ':' + this.attributes[0].friendlyName, '']);
+  }
+
+  emptySearchString(): boolean {
+    return this.options.some((opt) => opt[1].length === 0);
+  }
+
+  searchEntities() {
+    const inputGetEntity: { [p: string]: string } = {};
+    this.options.forEach((search) => {
+      inputGetEntity[search[0]] = search[1];
+    });
+    this.search.emit(inputGetEntity);
+  }
+}

--- a/libs/perun/components/src/lib/members-list/members-list.component.html
+++ b/libs/perun/components/src/lib/members-list/members-list.component.html
@@ -40,6 +40,18 @@
         <th *matHeaderCellDef mat-header-cell mat-sort-header>{{'MEMBERS_LIST.ID' | translate}}</th>
         <td *matCellDef="let member" class="static-column-size" mat-cell>{{member.id}}</td>
       </ng-container>
+      <ng-container matColumnDef="voId">
+        <th *matHeaderCellDef mat-header-cell mat-sort-header>
+          {{'MEMBERS_LIST.VO_ID' | translate}}
+        </th>
+        <td *matCellDef="let member" mat-cell>{{member.voId}}</td>
+      </ng-container>
+      <ng-container matColumnDef="userId">
+        <th *matHeaderCellDef mat-header-cell mat-sort-header>
+          {{'MEMBERS_LIST.USER_ID' | translate}}
+        </th>
+        <td *matCellDef="let member" mat-cell>{{member.userId}}</td>
+      </ng-container>
       <ng-container matColumnDef="type">
         <th *matHeaderCellDef mat-header-cell mat-sort-header></th>
         <td *matCellDef="let member" mat-cell>

--- a/libs/perun/components/src/lib/members-list/members-list.component.ts
+++ b/libs/perun/components/src/lib/members-list/members-list.component.ts
@@ -69,6 +69,8 @@ export class MembersListComponent implements OnChanges, AfterViewInit {
   displayedColumns: string[] = [
     'checkbox',
     'id',
+    'voId',
+    'userId',
     'type',
     'fullName',
     'status',
@@ -78,6 +80,10 @@ export class MembersListComponent implements OnChanges, AfterViewInit {
     'email',
     'logins',
   ];
+
+  @Input() disableStatusChange = false;
+
+  @Input() disableExpirationChange = false;
 
   @Input()
   tableId: string;
@@ -244,10 +250,10 @@ export class MembersListComponent implements OnChanges, AfterViewInit {
 
   changeStatus(event: any, member: RichMember) {
     event.stopPropagation();
-    if (member.status === 'INVALID') {
+    if (!this.disableStatusChange) {
       const config = getDefaultDialogConfig();
       config.width = '500px';
-      config.data = { member: member };
+      config.data = { member: member, disableChangeExpiration: this.disableExpirationChange };
 
       const dialogRef = this.dialog.open(ChangeMemberStatusDialogComponent, config);
       dialogRef.afterClosed().subscribe((success) => {

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -92,6 +92,7 @@ import { NotAuthorizedPageComponent } from './not-authorized-page/not-authorized
 import { ConsentsListComponent } from './consents-list/consents-list.component';
 import { ConsentStatusComponent } from './consent-status/consent-status.component';
 import { UiMaterialModule } from '@perun-web-apps/ui/material';
+import { AttributeSearchSelectComponent } from './attribute-search-select/attribute-search-select.component';
 
 @Injectable()
 export class AppDateAdapter extends NativeDateAdapter {
@@ -216,6 +217,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     NotAuthorizedPageComponent,
     ConsentsListComponent,
     ConsentStatusComponent,
+    AttributeSearchSelectComponent,
   ],
   exports: [
     VosListComponent,
@@ -271,6 +273,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     NotAuthorizedPageComponent,
     ConsentStatusComponent,
     ConsentsListComponent,
+    AttributeSearchSelectComponent,
   ],
   providers: [
     { provide: DateAdapter, useClass: AppDateAdapter },

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.html
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.html
@@ -76,6 +76,12 @@
         </th>
         <td mat-cell *matCellDef="let resource">{{resource.vo.name}}</td>
       </ng-container>
+      <ng-container matColumnDef="voId">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>
+          {{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_VO_ID' | translate}}
+        </th>
+        <td mat-cell *matCellDef="let resource">{{resource.voId}}</td>
+      </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>
           {{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_GROUP_RESOURCE_STATUS' | translate}}
@@ -98,6 +104,12 @@
           {{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_FACILITY_NAME' | translate}}
         </th>
         <td mat-cell *matCellDef="let resource">{{resource.facility.name}}</td>
+      </ng-container>
+      <ng-container matColumnDef="facilityId">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>
+          {{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_FACILITY_ID' | translate}}
+        </th>
+        <td mat-cell *matCellDef="let resource">{{resource.facilityId}}</td>
       </ng-container>
       <ng-container matColumnDef="tags">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.ts
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.ts
@@ -52,8 +52,10 @@ export class ResourcesListComponent implements OnInit, OnChanges {
     'indirectResourceAssigment',
     'name',
     'vo',
+    'voId',
     'status',
     'facility',
+    'facilityId',
     'tags',
     'description',
   ];

--- a/libs/perun/components/src/lib/vo-search-select/vo-search-select.component.ts
+++ b/libs/perun/components/src/lib/vo-search-select/vo-search-select.component.ts
@@ -1,12 +1,13 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { Vo } from '@perun-web-apps/perun/openapi';
+import { compareFnName } from '@perun-web-apps/perun/utils';
 
 @Component({
   selector: 'perun-web-apps-vo-search-select',
   templateUrl: './vo-search-select.component.html',
   styleUrls: ['./vo-search-select.component.css'],
 })
-export class VoSearchSelectComponent {
+export class VoSearchSelectComponent implements OnChanges {
   constructor() {}
 
   @Input()
@@ -21,4 +22,11 @@ export class VoSearchSelectComponent {
   nameFunction = (vo: Vo) => vo.name;
   shortNameFunction = (vo: Vo) => vo.shortName;
   searchFunction = (vo: Vo) => vo.name + vo.shortName + vo.id;
+
+  ngOnChanges() {
+    this.vos.sort(compareFnName);
+    if (!this.vo) {
+      this.vo = this.vos[0];
+    }
+  }
 }

--- a/libs/perun/dialogs/src/lib/change-member-status-dialog/change-member-status-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/change-member-status-dialog/change-member-status-dialog.component.ts
@@ -13,6 +13,7 @@ export interface ChangeMemberStatusDialogData {
   member: RichMember;
   voId?: number;
   groupId?: number;
+  disableChangeExpiration?: boolean;
 }
 
 @Component({
@@ -96,9 +97,10 @@ export class ChangeMemberStatusDialogComponent implements OnInit {
   changeStatus(event: MatSelectChange) {
     this.selectedStatus = event.value;
     if (
-      (this.actualStatus === 'VALID' && this.selectedStatus === 'EXPIRED') ||
-      (this.actualStatus === 'VALID' && this.selectedStatus === 'DISABLED') ||
-      this.selectedStatus === 'VALID'
+      ((this.actualStatus === 'VALID' && this.selectedStatus === 'EXPIRED') ||
+        (this.actualStatus === 'VALID' && this.selectedStatus === 'DISABLED') ||
+        this.selectedStatus === 'VALID') &&
+      !this.data.disableChangeExpiration
     ) {
       this.submitButtonText = this.changeStatusWithExpButton;
     } else {

--- a/libs/perun/openapi/src/lib/api/searcher.service.ts
+++ b/libs/perun/openapi/src/lib/api/searcher.service.ts
@@ -134,7 +134,7 @@ export class SearcherService {
     }
 
     return this.httpClient.post<Array<Resource>>(
-      `${this.configuration.basePath}/json/Searcher/getResources/attributes-match`,
+      `${this.configuration.basePath}/json/searcher/getResources/attributes-match`,
       inputGetResources1,
       {
         withCredentials: this.configuration.withCredentials,
@@ -216,7 +216,7 @@ export class SearcherService {
     }
 
     return this.httpClient.post<Array<Resource>>(
-      `${this.configuration.basePath}/json/Searcher/getResources/attributes`,
+      `${this.configuration.basePath}/json/searcher/getResources/attributes`,
       inputGetResources,
       {
         withCredentials: this.configuration.withCredentials,
@@ -298,7 +298,7 @@ export class SearcherService {
     }
 
     return this.httpClient.post<Array<Facility>>(
-      `${this.configuration.basePath}/json/Searcher/getFacilities`,
+      `${this.configuration.basePath}/json/searcher/getFacilities`,
       inputGetFacilities,
       {
         withCredentials: this.configuration.withCredentials,
@@ -380,7 +380,7 @@ export class SearcherService {
     }
 
     return this.httpClient.post<Array<Member>>(
-      `${this.configuration.basePath}/json/Searcher/getMembersByUserAttributes`,
+      `${this.configuration.basePath}/json/searcher/getMembersByUserAttributes`,
       inputGetMembersByUserAttributes,
       {
         withCredentials: this.configuration.withCredentials,
@@ -462,7 +462,7 @@ export class SearcherService {
     }
 
     return this.httpClient.post<Array<User>>(
-      `${this.configuration.basePath}/json/Searcher/getUsers`,
+      `${this.configuration.basePath}/json/searcher/getUsers`,
       inputGetUsers,
       {
         withCredentials: this.configuration.withCredentials,

--- a/libs/perun/pipes/src/lib/member-status-tooltip.pipe.ts
+++ b/libs/perun/pipes/src/lib/member-status-tooltip.pipe.ts
@@ -10,7 +10,7 @@ export class MemberStatusTooltipPipe implements PipeTransform {
     let memberExpiration = null;
     let groupExpiration = null;
 
-    if (member.memberAttributes !== null) {
+    if (member.memberAttributes) {
       memberExpiration = member.memberAttributes.find(
         (att) => att.friendlyName === 'membershipExpiration'
       );
@@ -27,12 +27,18 @@ export class MemberStatusTooltipPipe implements PipeTransform {
           : 'never'
       }`;
     } else {
-      res = `Status: ${parseMemberStatus(member.status, member.groupStatus)}
+      if (member.memberAttributes) {
+        res = `Status: ${parseMemberStatus(member.status, member.groupStatus)}
              Vo status: ${parseMemberStatus(member.status)}, Expiration: ${
-        memberExpiration && memberExpiration.value
-          ? (memberExpiration.value as unknown as string)
-          : 'never'
-      }`;
+          memberExpiration && memberExpiration.value
+            ? (memberExpiration.value as unknown as string)
+            : 'never'
+        }`;
+      } else {
+        // we can't display correct expiration without attributes, but we can still display statuses
+        res = `Status: ${parseMemberStatus(member.status, member.groupStatus)}
+             Vo status: ${parseMemberStatus(member.status)}`;
+      }
     }
     return res;
   }

--- a/libs/perun/services/src/lib/custom-icon.service.ts
+++ b/libs/perun/services/src/lib/custom-icon.service.ts
@@ -204,6 +204,10 @@ export class CustomIconService {
       url: 'assets/img/PerunWebImages/hierarchical_vo-black.svg',
       name: 'perun-hierarchical-vo',
     },
+    {
+      url: 'assets/img/PerunWebImages/searcher-blue.svg',
+      name: 'perun-searcher',
+    },
   ];
 
   registerPerunRefreshIcon() {

--- a/libs/perun/utils/src/lib/perun-utils.ts
+++ b/libs/perun/utils/src/lib/perun-utils.ts
@@ -752,6 +752,14 @@ export function compareFnName(a, b) {
     : -1;
 }
 
+export function compareFnDisplayName(a, b) {
+  return a.displayName.toLowerCase() > b.displayName.toLowerCase()
+    ? 1
+    : a.displayName.toLowerCase() === b.displayName.toLowerCase()
+    ? 0
+    : -1;
+}
+
 export function compareFnUser(a, b) {
   let first, second;
   if (a.user) {


### PR DESCRIPTION
* Added Searcher page with four tabs (users, members, facilities, resources).
* To members-list and resources-list were added new columns according to the old GUI.
* At this moment, we get the Member object from BE, but member status tooltip and member expiation settings require RichMember, so some other components have to be changed.