### PR TITLE
feat(admin-gui): manual consent evaluation for service and consent hub

### DIFF
--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-consent-hubs/admin-consent-hubs.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-consent-hubs/admin-consent-hubs.component.html
@@ -2,6 +2,15 @@
   <h1 class="page-subtitle">{{'ADMIN.CONSENT_HUBS.TITLE' | translate}}</h1>
 
   <perun-web-apps-refresh-button (refresh)="refreshTable()"></perun-web-apps-refresh-button>
+  <button
+    *ngIf="authResolver.isPerunAdmin()"
+    (click)="evaluateConsents()"
+    [disabled]="selection.selected.length === 0"
+    color="accent"
+    class="action-button mr-2"
+    mat-flat-button>
+    {{'ADMIN.CONSENT_HUBS.EVALUATE_CONSENTS' | translate}}
+  </button>
   <perun-web-apps-immediate-filter
     [placeholder]="'ADMIN.CONSENT_HUBS.SEARCH'"
     (filter)="applyFilter($event)">
@@ -11,6 +20,7 @@
   <app-perun-web-apps-consent-hubs-list
     *ngIf="!loading"
     [consentHubs]="consentHubs"
+    [selection]="selection"
     [filterValue]="filterValue"
     [tableId]="tableId">
   </app-perun-web-apps-consent-hubs-list>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-detail-page.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-detail-page.component.html
@@ -45,6 +45,17 @@
             </mat-icon>
           </button>
         </span>
+        <button
+          *ngIf="authResolver.isPerunAdmin()"
+          (click)="evaluateConsents()"
+          color="accent"
+          class="action-button ml-2"
+          mat-flat-button>
+          {{'SERVICE_DETAIL.EVALUATE_CONSENTS' | translate}}
+        </button>
+        <span class="mt-1 ml-2 entity-info">
+          {{service.useExpiredMembers ? ('SERVICE_DETAIL.USE_EXPIRED_MEMBERS_ENABLED' | translate) : ('SERVICE_DETAIL.USE_EXPIRED_MEMBERS_DISABLED' | translate)}}
+        </span>
       </div>
     </div>
   </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-detail-page.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-detail-page.component.ts
@@ -1,6 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { fadeIn } from '@perun-web-apps/perun/animations';
-import { InputUpdateService, Service, ServicesManagerService } from '@perun-web-apps/perun/openapi';
+import {
+  ConsentsManagerService,
+  InputUpdateService,
+  Service,
+  ServicesManagerService,
+} from '@perun-web-apps/perun/openapi';
 import { ActivatedRoute, Router } from '@angular/router';
 import { SideMenuService } from '../../../../../core/services/common/side-menu.service';
 import { SideMenuItemService } from '../../../../../shared/side-menu/side-menu-item.service';
@@ -14,6 +19,7 @@ import {
 } from '@perun-web-apps/perun/services';
 import { DeleteServiceDialogComponent } from '../../../../../shared/components/dialogs/delete-service-dialog/delete-service-dialog.component';
 import { TranslateService } from '@ngx-translate/core';
+import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
 
 @Component({
   selector: 'app-service-detail-page',
@@ -25,6 +31,7 @@ export class ServiceDetailPageComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
+    private consentsManager: ConsentsManagerService,
     private serviceManager: ServicesManagerService,
     private sideMenuService: SideMenuService,
     private sideMenuItemService: SideMenuItemService,
@@ -117,5 +124,30 @@ export class ServiceDetailPageComponent implements OnInit {
       },
       () => (this.loading = false)
     );
+  }
+
+  evaluateConsents() {
+    const config = getDefaultDialogConfig();
+    config.width = '500px';
+    config.data = {
+      title: this.translate.instant('SERVICE_DETAIL.CONFIRM_DIALOG_TITLE'),
+      theme: 'service-theme',
+      description: this.translate.instant('SERVICE_DETAIL.CONFIRM_DIALOG_DESCRIPTION'),
+      items: [this.service.name],
+      type: 'confirmation',
+      showAsk: false,
+    };
+
+    const dialogRef = this.dialog.open(UniversalConfirmationItemsDialogComponent, config);
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.consentsManager
+          .evaluateConsentsForService(this.service.id)
+          .subscribe(() =>
+            this.notificator.showSuccess(this.translate.instant('SERVICE_DETAIL.EVALUATION_FINISH'))
+          );
+      }
+    });
   }
 }

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-tags/resource-tags.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-tags/resource-tags.component.ts
@@ -8,7 +8,7 @@ import {
   GuiAuthResolver,
   NotificatorService,
 } from '@perun-web-apps/perun/services';
-import { UniversalRemoveItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
+import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import { AddResourceTagToResourceDialogComponent } from '../../../../shared/components/dialogs/add-resource-tag-to-resource-dialog/add-resource-tag-to-resource-dialog.component';
@@ -58,9 +58,11 @@ export class ResourceTagsComponent implements OnInit {
       title: 'RESOURCE_DETAIL.TAGS.REMOVE_TAGS_DIALOG_TITLE',
       description: 'RESOURCE_DETAIL.TAGS.REMOVE_TAGS_DIALOG_DESCRIPTION',
       theme: 'resource-theme',
+      type: 'remove',
+      showAsk: true,
     };
 
-    const dialogRef = this.dialog.open(UniversalRemoveItemsDialogComponent, config);
+    const dialogRef = this.dialog.open(UniversalConfirmationItemsDialogComponent, config);
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/apps/admin-gui/src/app/shared/components/consent-hubs-list/consent-hubs-list.component.html
+++ b/apps/admin-gui/src/app/shared/components/consent-hubs-list/consent-hubs-list.component.html
@@ -12,6 +12,27 @@
       matSortActive="id"
       matSortDirection="asc"
       matSortDisableClear>
+      <ng-container matColumnDef="select">
+        <th *matHeaderCellDef mat-header-cell class="align-checkbox">
+          <mat-checkbox
+            (change)="$event ? masterToggle() : null"
+            [aria-label]="checkboxLabel()"
+            [checked]="selection.hasValue() && isAllSelected()"
+            [indeterminate]="selection.hasValue() && !isAllSelected()"
+            color="primary">
+          </mat-checkbox>
+        </th>
+        <td *matCellDef="let consentHub" class="static-column-size align-checkbox" mat-cell>
+          <mat-checkbox
+            (change)="$event ? selection.toggle(consentHub) : null"
+            (click)="$event.stopPropagation()"
+            [aria-label]="checkboxLabel(consentHub)"
+            [checked]="selection.isSelected(consentHub)"
+            color="primary">
+          </mat-checkbox>
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="id">
         <th *matHeaderCellDef mat-header-cell mat-sort-header>
           {{'SHARED.COMPONENTS.CONSENT_HUBS_LIST.ID' | translate}}

--- a/apps/admin-gui/src/app/shared/components/consent-hubs-list/consent-hubs-list.component.ts
+++ b/apps/admin-gui/src/app/shared/components/consent-hubs-list/consent-hubs-list.component.ts
@@ -16,6 +16,7 @@ import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import { EditEnforceConsentsDialogComponent } from '../dialogs/edit-enforce-consents-dialog/edit-enforce-consents-dialog.component';
+import { SelectionModel } from '@angular/cdk/collections';
 
 @Component({
   selector: 'app-perun-web-apps-consent-hubs-list',
@@ -33,8 +34,9 @@ export class ConsentHubsListComponent implements OnChanges {
 
   @Input() consentHubs: ConsentHub[];
   @Input() filterValue = '';
-  @Input() displayedColumns: string[] = ['id', 'name', 'enforceConsents', 'facilities'];
+  @Input() displayedColumns: string[] = ['select', 'id', 'name', 'enforceConsents', 'facilities'];
   @Input() tableId: string;
+  @Input() selection = new SelectionModel<ConsentHub>(true, []);
 
   @ViewChild(TableWrapperComponent, { static: true }) child: TableWrapperComponent;
 
@@ -49,7 +51,7 @@ export class ConsentHubsListComponent implements OnChanges {
   exporting = false;
   pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
 
-  ngOnChanges(): void {
+  ngOnChanges() {
     this.dataSource = new MatTableDataSource<ConsentHub>(this.consentHubs);
     this.setDataSource();
   }
@@ -82,6 +84,39 @@ export class ConsentHubsListComponent implements OnChanges {
       ),
       format
     );
+  }
+
+  /** Whether the number of selected elements matches the total number of rows. */
+  isAllSelected() {
+    return this.tableCheckbox.isAllSelected(
+      this.selection.selected.length,
+      this.filterValue,
+      this.child.paginator.pageSize,
+      this.child.paginator.hasNextPage(),
+      this.dataSource
+    );
+  }
+
+  /** Selects all rows if they are not all selected; otherwise clear selection. */
+  masterToggle() {
+    this.tableCheckbox.masterToggle(
+      this.isAllSelected(),
+      this.selection,
+      this.filterValue,
+      this.dataSource,
+      this.sort,
+      this.child.paginator.pageSize,
+      this.child.paginator.pageIndex,
+      false
+    );
+  }
+
+  /** The label for the checkbox on the passed row */
+  checkboxLabel(row?: ConsentHub): string {
+    if (!row) {
+      return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
+    }
+    return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.id + 1}`;
   }
 
   setDataSource(): void {

--- a/apps/admin-gui/src/app/vos/components/application-detail/application-detail.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-detail/application-detail.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@perun-web-apps/perun/openapi';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { EditApplicationFormItemDataDialogComponent } from '../../../shared/components/dialogs/edit-application-form-item-data-dialog/edit-application-form-item-data-dialog.component';
-import { UniversalRemoveItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
+import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
 
 @Component({
   selector: 'app-application-detail',
@@ -181,9 +181,11 @@ export class ApplicationDetailComponent implements OnInit {
       title: 'VO_DETAIL.APPLICATION.APPLICATION_DETAIL.DELETE_APPLICATION_TITLE',
       description: 'VO_DETAIL.APPLICATION.APPLICATION_DETAIL.DELETE_APPLICATION_DESCRIPTION',
       theme: 'vo-theme',
+      type: 'remove',
+      showAsk: true,
     };
 
-    const dialogRef = this.dialog.open(UniversalRemoveItemsDialogComponent, config);
+    const dialogRef = this.dialog.open(UniversalConfirmationItemsDialogComponent, config);
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.ts
@@ -7,7 +7,7 @@ import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { GuiAuthResolver } from '@perun-web-apps/perun/services';
 import { MatDialog } from '@angular/material/dialog';
 import { AddGroupToRegistrationComponent } from '../../../shared/components/dialogs/add-group-to-registration/add-group-to-registration.component';
-import { UniversalRemoveItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
+import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { GroupsListComponent } from '@perun-web-apps/perun/components';
 
 @Component({
@@ -82,9 +82,11 @@ export class ApplicationFormManageGroupsComponent implements OnInit {
       description:
         'VO_DETAIL.SETTINGS.APPLICATION_FORM.MANAGE_GROUPS_PAGE.REMOVE_GROUP_DIALOG_DESCRIPTION',
       theme: 'vo-theme',
+      type: 'remove',
+      showAsk: true,
     };
 
-    const dialogRef = this.dialog.open(UniversalRemoveItemsDialogComponent, config);
+    const dialogRef = this.dialog.open(UniversalConfirmationItemsDialogComponent, config);
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-member-organizations/vo-settings-member-organizations.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-member-organizations/vo-settings-member-organizations.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@perun-web-apps/perun/services';
 import { SelectionModel } from '@angular/cdk/collections';
 import { ReloadEntityDetailService } from '../../../../../core/services/common/reload-entity-detail.service';
-import { UniversalRemoveItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
+import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -91,10 +91,12 @@ export class VoSettingsMemberOrganizationsComponent implements OnInit {
       title: 'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.REMOVE_MEMBER_ORGANIZATION.TITLE',
       alert: 'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.REMOVE_MEMBER_ORGANIZATION.WARNING',
       theme: 'vo-theme',
+      type: 'remove',
+      showAsk: true,
     };
 
     this.dialog
-      .open(UniversalRemoveItemsDialogComponent, config)
+      .open(UniversalConfirmationItemsDialogComponent, config)
       .afterClosed()
       .subscribe((result) => {
         if (result) {

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -817,9 +817,15 @@
   "SERVICE_DETAIL": {
     "ENTITY": "Service",
     "STATUS": "Status",
+    "EVALUATE_CONSENTS": "Evaluate consents",
+    "CONFIRM_DIALOG_TITLE": "Evaluate consents confirmation",
+    "CONFIRM_DIALOG_DESCRIPTION": "Are you sure you want to evaluate consents for this service?",
+    "EVALUATION_FINISH": "Consents evaluation completed",
     "STATUS_CHANGE_SUCCESS": "Service status was successfully changed",
     "ENABLED": "Enabled",
     "DISABLED": "Disabled",
+    "USE_EXPIRED_MEMBERS_ENABLED": "This service is using expired members as well",
+    "USE_EXPIRED_MEMBERS_DISABLED": "This service is not using expired members",
     "DESCRIPTION": "Description",
     "REQUIRED_ATTRIBUTES": {
       "TITLE": "Required attributes",
@@ -2263,6 +2269,10 @@
     },
     "CONSENT_HUBS": {
       "TITLE": "Consent hubs",
+      "EVALUATE_CONSENTS": "Evaluate consents",
+      "CONFIRM_DIALOG_TITLE": "Evaluate consents confirmation",
+      "CONFIRM_DIALOG_DESCRIPTION": "Are you sure you want to evaluate consents for all selected consent hubs?",
+      "EVALUATION_FINISH": "Consents evaluation completed",
       "SEARCH": "Search by Id, Name or Facilities"
     }
   },

--- a/apps/publications/src/app/components/add-authors/add-authors.component.ts
+++ b/apps/publications/src/app/components/add-authors/add-authors.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { AddAuthorsDialogComponent } from '../../dialogs/add-authors-dialog/add-authors-dialog.component';
-import { UniversalRemoveItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
+import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { Author, CabinetManagerService, PublicationForGUI } from '@perun-web-apps/perun/openapi';
 import { SelectionModel } from '@angular/cdk/collections';
 import { MatDialog } from '@angular/material/dialog';
@@ -78,9 +78,11 @@ export class AddAuthorsComponent implements OnInit {
       title: 'DIALOGS.REMOVE_AUTHORS.TITLE',
       description: 'DIALOGS.REMOVE_AUTHORS.DESCRIPTION',
       theme: 'user-theme',
+      type: 'remove',
+      showAsk: true,
     };
 
-    const dialogRef = this.dialog.open(UniversalRemoveItemsDialogComponent, config);
+    const dialogRef = this.dialog.open(UniversalConfirmationItemsDialogComponent, config);
 
     dialogRef.afterClosed().subscribe((authorshipRemoved) => {
       if (authorshipRemoved) {

--- a/apps/publications/src/app/components/add-thanks/add-thanks.component.ts
+++ b/apps/publications/src/app/components/add-thanks/add-thanks.component.ts
@@ -11,7 +11,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { TABLE_PUBLICATION_THANKS } from '@perun-web-apps/config/table-config';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { AddThanksDialogComponent } from '../../dialogs/add-thanks-dialog/add-thanks-dialog.component';
-import { UniversalRemoveItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
+import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
 
 @Component({
   selector: 'perun-web-apps-add-thanks',
@@ -71,9 +71,11 @@ export class AddThanksComponent implements OnInit {
       title: 'PUBLICATION_DETAIL.REMOVE_THANKS_DIALOG_TITLE',
       description: 'PUBLICATION_DETAIL.REMOVE_THANKS_DIALOG_DESCRIPTION',
       theme: 'user-theme',
+      type: 'remove',
+      showAsk: true,
     };
 
-    const dialogRef = this.dialog.open(UniversalRemoveItemsDialogComponent, config);
+    const dialogRef = this.dialog.open(UniversalConfirmationItemsDialogComponent, config);
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/libs/perun/dialogs/src/index.ts
+++ b/libs/perun/dialogs/src/index.ts
@@ -10,7 +10,7 @@ export * from './lib/edit-attribute-dialog/edit-attribute-dialog.component';
 export * from './lib/attribute-value-list-edit-dialog/attribute-value-list-edit-dialog.component';
 export * from './lib/attribute-value-list-delete-dialog/attribute-value-list-delete-dialog.component';
 export * from './lib/change-email-dialog/change-email-dialog.component';
-export * from './lib/universal-remove-items-dialog/universal-remove-items-dialog.component';
+export * from './lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component';
 export * from './lib/member-tree-view-dialog/member-tree-view-dialog.component';
 export * from './lib/mail-change-failed-dialog/mail-change-failed-dialog.component';
 export * from './lib/change-group-expiration-dialog/change-group-expiration-dialog.component';

--- a/libs/perun/dialogs/src/lib/perun-dialogs.module.ts
+++ b/libs/perun/dialogs/src/lib/perun-dialogs.module.ts
@@ -26,7 +26,7 @@ import { PerunPipesModule } from '@perun-web-apps/perun/pipes';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
 import { AttributeValueListDeleteDialogComponent } from './attribute-value-list-delete-dialog/attribute-value-list-delete-dialog.component';
 import { ChangeEmailDialogComponent } from './change-email-dialog/change-email-dialog.component';
-import { UniversalRemoveItemsDialogComponent } from './universal-remove-items-dialog/universal-remove-items-dialog.component';
+import { UniversalConfirmationItemsDialogComponent } from './universal-confirmation-items-dialog/universal-confirmation-items-dialog.component';
 import { MemberTreeViewDialogComponent } from './member-tree-view-dialog/member-tree-view-dialog.component';
 import { RouterModule } from '@angular/router';
 import { MatTreeModule } from '@angular/material/tree';
@@ -76,7 +76,7 @@ import { PerunNamespacePasswordFormModule } from '@perun-web-apps/perun/namespac
     AttributeValueListEditDialogComponent,
     AttributeValueListDeleteDialogComponent,
     ChangeEmailDialogComponent,
-    UniversalRemoveItemsDialogComponent,
+    UniversalConfirmationItemsDialogComponent,
     MemberTreeViewDialogComponent,
     MailChangeFailedDialogComponent,
     UniversalConfirmationDialogComponent,
@@ -98,7 +98,7 @@ import { PerunNamespacePasswordFormModule } from '@perun-web-apps/perun/namespac
     AttributeValueListEditDialogComponent,
     AttributeValueListDeleteDialogComponent,
     ChangeEmailDialogComponent,
-    UniversalRemoveItemsDialogComponent,
+    UniversalConfirmationItemsDialogComponent,
     MemberTreeViewDialogComponent,
     MailChangeFailedDialogComponent,
     ChangeGroupExpirationDialogComponent,

--- a/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.html
@@ -6,7 +6,7 @@
       {{this.data.description | translate}}
     </p>
 
-    <div class="font-weight-bold">
+    <div class="font-weight-bold" *ngIf="data.showAsk">
       {{'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_REMOVE_ITEMS_DIALOG.ASK' | translate}}
     </div>
 
@@ -27,7 +27,22 @@
     <button mat-flat-button class="ml-auto" (click)="onCancel()">
       {{'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_REMOVE_ITEMS_DIALOG.CANCEL_BUTTON' | translate}}
     </button>
-    <button mat-flat-button class="ml-2" color="warn" [disabled]="loading" (click)="onSubmit()">
+    <button
+      mat-flat-button
+      class="ml-2"
+      color="warn"
+      [disabled]="loading"
+      (click)="onSubmit()"
+      *ngIf="data.type === 'remove'">
+      {{'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_REMOVE_ITEMS_DIALOG.SUBMIT_BUTTON' | translate}}
+    </button>
+    <button
+      mat-flat-button
+      class="ml-2"
+      color="accent"
+      [disabled]="loading"
+      (click)="onSubmit()"
+      *ngIf="data.type === 'confirmation'">
       {{'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_REMOVE_ITEMS_DIALOG.SUBMIT_BUTTON' | translate}}
     </button>
   </div>

--- a/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.ts
@@ -2,23 +2,25 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 
-export interface DeleteItemsDialogData {
+export interface UniversalConfirmationItemsDialogData {
   theme: string;
   title: string;
   description: string;
   items: string[];
   alert: string;
+  type: 'remove' | 'confirmation';
+  showAsk: boolean;
 }
 
 @Component({
-  selector: 'perun-web-apps-universal-remove-items-dialog',
-  templateUrl: './universal-remove-items-dialog.component.html',
-  styleUrls: ['./universal-remove-items-dialog.component.scss'],
+  selector: 'perun-web-apps-universal-confirmation-items-dialog',
+  templateUrl: './universal-confirmation-items-dialog.component.html',
+  styleUrls: ['./universal-confirmation-items-dialog.component.scss'],
 })
-export class UniversalRemoveItemsDialogComponent implements OnInit {
+export class UniversalConfirmationItemsDialogComponent implements OnInit {
   constructor(
-    public dialogRef: MatDialogRef<UniversalRemoveItemsDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: DeleteItemsDialogData
+    public dialogRef: MatDialogRef<UniversalConfirmationItemsDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: UniversalConfirmationItemsDialogData
   ) {}
 
   displayedColumns: string[] = ['name'];

--- a/libs/perun/openapi/src/lib/api/consentsManager.service.ts
+++ b/libs/perun/openapi/src/lib/api/consentsManager.service.ts
@@ -152,6 +152,166 @@ export class ConsentsManagerService {
   }
 
   /**
+   * Evaluates consents for given consent hub.
+   * @param consentHub id of ConsentHub
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public evaluateConsentsForConsentHub(
+    consentHub: number,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<any>;
+  public evaluateConsentsForConsentHub(
+    consentHub: number,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<any>>;
+  public evaluateConsentsForConsentHub(
+    consentHub: number,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<any>>;
+  public evaluateConsentsForConsentHub(
+    consentHub: number,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (consentHub === null || consentHub === undefined) {
+      throw new Error(
+        'Required parameter consentHub was null or undefined when calling evaluateConsentsForConsentHub.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (consentHub !== undefined && consentHub !== null) {
+      queryParameters = queryParameters.set('consentHub', <any>consentHub);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.post<any>(
+      `${this.configuration.basePath}/urlinjsonout/consentsManager/evaluateConsentsForConsentHub`,
+      null,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * Evaluates consents for all consent hubs with given service.
+   * @param service id of Service
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public evaluateConsentsForService(
+    service: number,
+    observe?: 'body',
+    reportProgress?: boolean
+  ): Observable<any>;
+  public evaluateConsentsForService(
+    service: number,
+    observe?: 'response',
+    reportProgress?: boolean
+  ): Observable<HttpResponse<any>>;
+  public evaluateConsentsForService(
+    service: number,
+    observe?: 'events',
+    reportProgress?: boolean
+  ): Observable<HttpEvent<any>>;
+  public evaluateConsentsForService(
+    service: number,
+    observe: any = 'body',
+    reportProgress: boolean = false
+  ): Observable<any> {
+    if (service === null || service === undefined) {
+      throw new Error(
+        'Required parameter service was null or undefined when calling evaluateConsentsForService.'
+      );
+    }
+
+    let queryParameters = new HttpParams({ encoder: this.encoder });
+    if (service !== undefined && service !== null) {
+      queryParameters = queryParameters.set('service', <any>service);
+    }
+
+    let headers = this.defaultHeaders;
+
+    // authentication (ApiKeyAuth) required
+    if (this.configuration.apiKeys && this.configuration.apiKeys['Authorization']) {
+      headers = headers.set('Authorization', this.configuration.apiKeys['Authorization']);
+    }
+
+    // authentication (BasicAuth) required
+    if (this.configuration.username || this.configuration.password) {
+      headers = headers.set(
+        'Authorization',
+        'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password)
+      );
+    }
+    // authentication (BearerAuth) required
+    if (this.configuration.accessToken) {
+      const accessToken =
+        typeof this.configuration.accessToken === 'function'
+          ? this.configuration.accessToken()
+          : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+    // to determine the Accept header
+    const httpHeaderAccepts: string[] = ['application/json'];
+    const httpHeaderAcceptSelected: string | undefined =
+      this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+    return this.httpClient.post<any>(
+      `${this.configuration.basePath}/urlinjsonout/consentsManager/evaluateConsentsForService`,
+      null,
+      {
+        params: queryParameters,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
    * Return list of all Consent Hubs
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.

--- a/libs/perun/openapi/src/lib/model/service.ts
+++ b/libs/perun/openapi/src/lib/model/service.ts
@@ -18,4 +18,5 @@ export interface Service extends Auditable {
   recurrence?: number;
   enabled?: boolean;
   script?: string;
+  useExpiredMembers?: boolean;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14606,6 +14606,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -19676,6 +19682,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
       "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
+    },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/portfinder": {
       "version": "1.0.28",
@@ -34835,6 +34852,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -38555,6 +38578,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
       "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "peer": true
     },
     "portfinder": {
       "version": "1.0.28",


### PR DESCRIPTION
* on service detail, new button added to initiate consent evaluation for given service
* on consent hubs page, new column for checkboxes added
* also, new button added to initiate consent evaluation for selected consent hubs

Note: This PR is waiting for its backend counterpart to be merged.