### PR TITLE
fix(admin): disable checkboxes for members from member VOs

### DIFF
--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.ts
@@ -43,6 +43,7 @@ export class VoMembersComponent implements OnInit {
     Urns.USER_DEF_ORGANIZATION,
     Urns.USER_DEF_PREFERRED_MAIL,
     Urns.MEMBER_DEF_EXPIRATION,
+    Urns.MEMBER_LIFECYCLE_ALTERABLE,
   ];
   statuses = new FormControl();
   statusList = ['VALID', 'INVALID', 'EXPIRED', 'DISABLED'];

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2195,7 +2195,8 @@
     "NO_MEMBERS_ALERT": "No members present",
     "NO_FILTER_RESULTS_ALERT": "No members are matching your query",
     "INDIRECT_MEMBER": "Indirect member",
-    "CHECKBOX_TOOLTIP": "Indirect members cannot be removed"
+    "CHECKBOX_TOOLTIP_INDIRECT": "Indirect members cannot be removed",
+    "CHECKBOX_TOOLTIP_UNALTERABLE": "Members from member organizations cannot be directly removed"
   },
   "MEMBERS_CANDIDATES_LIST": {
     "STATUS": "Status",

--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
@@ -34,8 +34,8 @@
             [aria-label]="checkboxLabel(member)"
             [checked]="selection.isSelected(member)"
             attr.data-cy="{{member.user.firstName | lowercase}}-checkbox"
-            [disabled]="member.membershipType === 'INDIRECT'"
-            [matTooltip]="member.membershipType === 'INDIRECT' ? ('MEMBERS_LIST.CHECKBOX_TOOLTIP' | translate):''"
+            [disabled]="(member | memberListCheckboxDisabled)"
+            [matTooltip]="(member | memberCheckboxLabel)"
             color="primary">
           </mat-checkbox>
         </td>

--- a/libs/perun/pipes/src/index.ts
+++ b/libs/perun/pipes/src/index.ts
@@ -9,6 +9,8 @@ export * from './lib/member-status-icon.pipe';
 export * from './lib/member-status-tooltip.pipe';
 export * from './lib/member-email.pipe';
 export * from './lib/member-logins.pipe';
+export * from './lib/member-list-checkbox-disabled.pipe';
+export * from './lib/member-checkbox-label.pipe';
 export * from './lib/parse-date.pipe';
 export * from './lib/technical-owners.pipe';
 export * from './lib/filter-unique-objects.pipe';

--- a/libs/perun/pipes/src/lib/member-checkbox-label.pipe.ts
+++ b/libs/perun/pipes/src/lib/member-checkbox-label.pipe.ts
@@ -1,0 +1,23 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { RichMember } from '@perun-web-apps/perun/openapi';
+
+@Pipe({
+  name: 'memberCheckboxLabel',
+})
+export class MemberCheckboxLabelPipe implements PipeTransform {
+  constructor(private translate: TranslateService) {}
+
+  transform(value: RichMember): string {
+    if (value.membershipType === 'INDIRECT') {
+      return this.translate.instant('MEMBERS_LIST.CHECKBOX_TOOLTIP_INDIRECT') as string;
+    }
+    const attr = value.memberAttributes.find((obj) => obj.friendlyName === 'isLifecycleAlterable');
+    if (attr) {
+      return attr.value
+        ? ''
+        : (this.translate.instant('MEMBERS_LIST.CHECKBOX_TOOLTIP_UNALTERABLE') as string);
+    }
+    return '';
+  }
+}

--- a/libs/perun/pipes/src/lib/member-list-checkbox-disabled.pipe.ts
+++ b/libs/perun/pipes/src/lib/member-list-checkbox-disabled.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { RichMember } from '@perun-web-apps/perun/openapi';
+
+@Pipe({
+  name: 'memberListCheckboxDisabled',
+})
+export class MemberListCheckboxDisabledPipe implements PipeTransform {
+  transform(value: RichMember): boolean {
+    if (value.membershipType === 'INDIRECT') {
+      return true;
+    }
+    const attr = value.memberAttributes.find((obj) => obj.friendlyName === 'isLifecycleAlterable');
+    if (attr) {
+      return !attr.value;
+    }
+    return false;
+  }
+}

--- a/libs/perun/pipes/src/lib/perun-pipes.module.ts
+++ b/libs/perun/pipes/src/lib/perun-pipes.module.ts
@@ -17,6 +17,8 @@ import { MemberEmailPipe } from './member-email.pipe';
 import { MemberLoginsPipe } from './member-logins.pipe';
 import { GroupExpirationPipe } from './group-expiration.pipe';
 import { MemberOrganizationPipe } from './member-organization.pipe';
+import { MemberListCheckboxDisabledPipe } from './member-list-checkbox-disabled.pipe';
+import { MemberCheckboxLabelPipe } from './member-checkbox-label.pipe';
 import { ParseDatePipe } from './parse-date.pipe';
 import { TechnicalOwnersPipe } from './technical-owners.pipe';
 import { FilterUniqueObjectsPipe } from './filter-unique-objects.pipe';
@@ -54,6 +56,8 @@ import { GroupMembersActionButtonDisabledTooltipPipe } from './group-members-act
     MemberEmailPipe,
     MemberLoginsPipe,
     MemberOrganizationPipe,
+    MemberListCheckboxDisabledPipe,
+    MemberCheckboxLabelPipe,
     GroupExpirationPipe,
     ParseDatePipe,
     TechnicalOwnersPipe,
@@ -92,6 +96,8 @@ import { GroupMembersActionButtonDisabledTooltipPipe } from './group-members-act
     MemberLoginsPipe,
     GroupExpirationPipe,
     MemberOrganizationPipe,
+    MemberListCheckboxDisabledPipe,
+    MemberCheckboxLabelPipe,
     ParseDatePipe,
     TechnicalOwnersPipe,
     FilterUniqueObjectsPipe,

--- a/libs/perun/urns/src/lib/perun-urns.ts
+++ b/libs/perun/urns/src/lib/perun-urns.ts
@@ -6,6 +6,7 @@ export class Urns {
   static MEMBER_DEF_ORGANIZATION = 'urn:perun:member:attribute-def:def:organization';
   static MEMBER_DEF_MAIL = 'urn:perun:member:attribute-def:def:mail';
   static MEMBER_CORE_ID = 'urn:perun:member:attribute-def:core:id';
+  static MEMBER_LIFECYCLE_ALTERABLE = 'urn:perun:member:attribute-def:virt:isLifecycleAlterable';
 
   // Vo
   static VO_DEF_EXPIRATION_RULES = 'urn:perun:vo:attribute-def:def:membershipExpirationRules';


### PR DESCRIPTION
* on the members section of a VO, disable checkboxes for members that come from member VOs, which previously was doable and resulted in an error.