### PR TITLE
fix(admin): parsing userId on myProfile/attributes page

### DIFF
--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-attributes/user-attributes.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-attributes/user-attributes.component.ts
@@ -22,7 +22,7 @@ export class UserAttributesComponent implements OnInit {
   ngOnInit(): void {
     this.route.parent.params.subscribe((params) => {
       this.userId = Number(params['userId']);
-      if (this.userId === undefined) {
+      if (!this.userId) {
         this.userId = this.store.getPerunPrincipal().userId;
       }
 


### PR DESCRIPTION
* We tried to parse userId from url and if it was undefined, then we parsed it from principal. As we
changed type notation from as number to Number(), the userId is equal to NaN (if it isn't present in
the url) and the check just for undefined was failing, so we didn't parse the userId from principal.