### PR TITLE
fix(admin): evaluating route authorization

### DIFF
--- a/apps/admin-gui-e2e/src/integration/facility-management-perun_admin.spec.js
+++ b/apps/admin-gui-e2e/src/integration/facility-management-perun_admin.spec.js
@@ -3,7 +3,7 @@ context('Actions', () => {
   const dbFacilityName2 = 'test-e2e-facility-from-db-2';
   const dbVoName = 'test-e2e-vo-from-db-for-facility';
   const dbResourceName = 'test-e2e-resource-from-db';
-  
+
   const addedAttribute = 'login-namespace';
   const deleteAttribute = 'gid-namespace';
   const addManagerUser = 'facility-manager-2';
@@ -19,6 +19,8 @@ context('Actions', () => {
   })
 
   beforeEach(() => {
+    // save route for correct authorization
+    localStorage.setItem('routeAuthGuard', '/facilities');
     cy.visit('facilities');
   })
 

--- a/libs/perun/services/src/lib/init-auth.service.ts
+++ b/libs/perun/services/src/lib/init-auth.service.ts
@@ -83,6 +83,11 @@ export class InitAuthService {
         } else {
           this.storeService.setPerunPrincipal(perunPrincipal);
           this.authResolver.init(perunPrincipal);
+          const previousUrl = localStorage.getItem('routeAuthGuard');
+          if (previousUrl) {
+            localStorage.removeItem('routeAuthGuard');
+            void this.router.navigate([previousUrl]);
+          }
         }
       });
   }
@@ -101,6 +106,7 @@ export class InitAuthService {
         resolve();
       });
     } else if (this.storeService.get('auto_auth_redirect')) {
+      localStorage.setItem('routeAuthGuard', window.location.pathname);
       return (
         this.startAuth()
           // start a promise that will never resolve, so the app loading won't finish in case
@@ -109,6 +115,7 @@ export class InitAuthService {
       );
     } else {
       this.setLoginScreen(true);
+      localStorage.setItem('routeAuthGuard', window.location.pathname);
       const query = location.search.substr(1).split('&');
       const queryParams = {};
       for (const param of query) {


### PR DESCRIPTION
* If a logged-out user tried to access some specific url, immediately after logging in gui told
him/her that he/she is not authorized to access this page even if he/she has rights to access it
(route policy was checked before the principal was loaded).
* E2E test file for facility admin was also edited according to this new behavior.