### PR TITLE
fix(admin): reduce number of calls to backend when viewing assigned users to resource

### DIFF
--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-users/facility-allowed-users.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-users/facility-allowed-users.component.ts
@@ -112,50 +112,19 @@ export class FacilityAllowedUsersComponent implements OnInit {
         this.facilityService.getAllowedVos(this.facility.id).subscribe(
           (vos) => {
             this.vos = [this.emptyVo].concat(vos);
-            this.services = [];
-            this.getAssignedServices(this.resources, this.resources.length - 1);
+            this.serviceService.getAssignedServices(this.facility.id).subscribe(
+              (services) => {
+                this.services = [this.emptyService].concat(services);
+                this.filteredServices = this.services;
+                this.loading = false;
+              },
+              () => (this.loading = false)
+            );
           },
           () => (this.loading = false)
         );
       },
       () => (this.loading = false)
-    );
-  }
-
-  getAssignedServices(resources: Resource[], idx: number): void {
-    // resource at index 0 is just placeholder
-    if (idx === 0) {
-      this.services = [this.emptyService].concat(this.services);
-      this.filteredServices = this.services;
-
-      this.changeFilter();
-      this.loading = false;
-      return;
-    }
-
-    this.resourceService.getAssignedServicesToResource(resources[idx].id).subscribe(
-      (services) => {
-        this.services = this.services.concat(services);
-        this.resourceAssignedServices.set(
-          resources[idx].id,
-          services.map((service) => service.id)
-        );
-        this.getAssignedServices(resources, idx - 1);
-      },
-      () => (this.loading = false)
-    );
-  }
-
-  getFilteredServices(resources: Resource[]): Service[] {
-    const serviceIds: Set<number> = new Set<number>();
-    resources.forEach((res) => {
-      this.resourceAssignedServices
-        .get(res.id)
-        .forEach((serviceId: number) => serviceIds.add(serviceId));
-    });
-
-    return [this.emptyService].concat(
-      this.services.filter((service) => serviceIds.has(service.id))
     );
   }
 
@@ -178,7 +147,14 @@ export class FacilityAllowedUsersComponent implements OnInit {
       this.filteredServices = this.services;
     } else {
       this.filteredResources = this.resources.filter((res) => res.voId === vo.id);
-      this.filteredServices = this.getFilteredServices(this.filteredResources);
+      this.serviceService.getAssignedServicesVo(this.facility.id, vo.id).subscribe(
+        (services) => {
+          this.filteredServices = [this.emptyService].concat(services);
+          this.loading = false;
+        },
+        () => (this.loading = false)
+      );
+
       this.filteredResources = [this.emptyResource].concat(this.filteredResources);
     }
     this.changeFilter();
@@ -196,7 +172,13 @@ export class FacilityAllowedUsersComponent implements OnInit {
     if (resource.id === -1) {
       this.filteredServices = this.services;
     } else {
-      this.filteredServices = this.getFilteredServices([resource]);
+      this.resourceService.getAssignedServicesToResource(resource.id).subscribe(
+        (services) => {
+          this.filteredServices = [this.emptyService].concat(services);
+          this.loading = false;
+        },
+        () => (this.loading = false)
+      );
     }
     this.changeFilter();
   }

--- a/libs/perun/openapi/src/lib/api/servicesManager.service.ts
+++ b/libs/perun/openapi/src/lib/api/servicesManager.service.ts
@@ -3135,7 +3135,120 @@ export class ServicesManagerService {
     }
 
     return this.httpClient.get<Array<Service>>(
-      `${this.configuration.basePath}/json/servicesManager/getAssignedServices`,
+      `${this.configuration.basePath}/json/servicesManager/getAssignedServices/f`,
+      {
+        context: localVarHttpContext,
+        params: localVarQueryParameters,
+        responseType: <any>responseType_,
+        withCredentials: this.configuration.withCredentials,
+        headers: localVarHeaders,
+        observe: observe,
+        reportProgress: reportProgress,
+      }
+    );
+  }
+
+  /**
+   * List all services associated with the facility and vo (via resource).
+   * @param facility id of Facility
+   * @param vo id of Vo
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getAssignedServicesVo(
+    facility: number,
+    vo: number,
+    observe?: 'body',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<Array<Service>>;
+  public getAssignedServicesVo(
+    facility: number,
+    vo: number,
+    observe?: 'response',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpResponse<Array<Service>>>;
+  public getAssignedServicesVo(
+    facility: number,
+    vo: number,
+    observe?: 'events',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpEvent<Array<Service>>>;
+  public getAssignedServicesVo(
+    facility: number,
+    vo: number,
+    observe: any = 'body',
+    reportProgress: boolean = false,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<any> {
+    if (facility === null || facility === undefined) {
+      throw new Error(
+        'Required parameter facility was null or undefined when calling getAssignedServicesVo.'
+      );
+    }
+    if (vo === null || vo === undefined) {
+      throw new Error(
+        'Required parameter vo was null or undefined when calling getAssignedServicesVo.'
+      );
+    }
+
+    let localVarQueryParameters = new HttpParams({ encoder: this.encoder });
+    if (facility !== undefined && facility !== null) {
+      localVarQueryParameters = this.addToHttpParams(
+        localVarQueryParameters,
+        <any>facility,
+        'facility'
+      );
+    }
+    if (vo !== undefined && vo !== null) {
+      localVarQueryParameters = this.addToHttpParams(localVarQueryParameters, <any>vo, 'vo');
+    }
+
+    let localVarHeaders = this.defaultHeaders;
+
+    let localVarCredential: string | undefined;
+    // authentication (BasicAuth) required
+    localVarCredential = this.configuration.lookupCredential('BasicAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Basic ' + localVarCredential);
+    }
+
+    // authentication (BearerAuth) required
+    localVarCredential = this.configuration.lookupCredential('BearerAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+    }
+
+    let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+    if (localVarHttpHeaderAcceptSelected === undefined) {
+      // to determine the Accept header
+      const httpHeaderAccepts: string[] = ['application/json'];
+      localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    }
+    if (localVarHttpHeaderAcceptSelected !== undefined) {
+      localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+    }
+
+    let localVarHttpContext: HttpContext | undefined = options && options.context;
+    if (localVarHttpContext === undefined) {
+      localVarHttpContext = new HttpContext();
+    }
+
+    let responseType_: 'text' | 'json' | 'blob' = 'json';
+    if (localVarHttpHeaderAcceptSelected) {
+      if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+        responseType_ = 'text';
+      } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+        responseType_ = 'json';
+      } else {
+        responseType_ = 'blob';
+      }
+    }
+
+    return this.httpClient.get<Array<Service>>(
+      `${this.configuration.basePath}/json/servicesManager/getAssignedServices/f-v`,
       {
         context: localVarHttpContext,
         params: localVarQueryParameters,


### PR DESCRIPTION


* get all services assigned to facility with one call instead of getting them from each resource
* when filtering services by Vo, call a new method getAssignedServicesVo()