### PR TITLE
fix: use localStorage for storing access token/refresh token

### DIFF
--- a/apps/admin-gui/src/app/app.module.ts
+++ b/apps/admin-gui/src/app/app.module.ts
@@ -30,7 +30,7 @@ import {
 } from 'ngx-perfect-scrollbar';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { PerunLoginModule } from '@perun-web-apps/perun/login';
-import { OAuthModule } from 'angular-oauth2-oidc';
+import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 
 export const API_INTERCEPTOR_PROVIDER: Provider = {
   provide: HTTP_INTERCEPTORS,
@@ -110,6 +110,7 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
       provide: PERFECT_SCROLLBAR_CONFIG,
       useValue: DEFAULT_PERFECT_SCROLLBAR_CONFIG,
     },
+    { provide: OAuthStorage, useFactory: (): OAuthStorage => localStorage },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/consolidator/src/app/app.module.ts
+++ b/apps/consolidator/src/app/app.module.ts
@@ -4,11 +4,12 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 import { NxWelcomeComponent } from './nx-welcome.component';
 import { RouterModule } from '@angular/router';
+import { OAuthStorage } from 'angular-oauth2-oidc';
 
 @NgModule({
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [BrowserModule, RouterModule.forRoot([], { initialNavigation: 'enabledBlocking' })],
-  providers: [],
+  providers: [{ provide: OAuthStorage, useFactory: (): OAuthStorage => localStorage }],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/apps/linker/src/app/app.module.ts
+++ b/apps/linker/src/app/app.module.ts
@@ -4,11 +4,12 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 import { NxWelcomeComponent } from './nx-welcome.component';
 import { RouterModule } from '@angular/router';
+import { OAuthStorage } from 'angular-oauth2-oidc';
 
 @NgModule({
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [BrowserModule, RouterModule.forRoot([], { initialNavigation: 'enabledBlocking' })],
-  providers: [],
+  providers: [{ provide: OAuthStorage, useFactory: (): OAuthStorage => localStorage }],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/apps/password-reset/src/app/app.module.ts
+++ b/apps/password-reset/src/app/app.module.ts
@@ -19,7 +19,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { PasswordResetConfigService } from './services/password-reset-config.service';
 import { PERUN_API_SERVICE } from '@perun-web-apps/perun/tokens';
 import { UiMaterialModule } from '@perun-web-apps/ui/material';
-import { OAuthModule } from 'angular-oauth2-oidc';
+import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { HeaderComponent } from './components/header/header.component';
 import { PasswordResetPageComponent } from './pages/password-reset-page/password-reset-page.component';
 import { PasswordResetFormComponent } from './components/password-reset-form/password-reset-form.component';
@@ -96,6 +96,7 @@ const loadConfigs = (appConfig: PasswordResetConfigService) => (): Promise<void>
       provide: PERUN_API_SERVICE,
       useClass: ApiService,
     },
+    { provide: OAuthStorage, useFactory: (): OAuthStorage => localStorage },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/publications/src/app/app.module.ts
+++ b/apps/publications/src/app/app.module.ts
@@ -52,7 +52,7 @@ import { AddThanksComponent } from './components/add-thanks/add-thanks.component
 import { ImportPublicationsPageComponent } from './pages/create-publication-page/import-publications-page/import-publications-page.component';
 import { YearRangeComponent } from './components/year-range/year-range.component';
 import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
-import { OAuthModule } from 'angular-oauth2-oidc';
+import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 
 export const API_INTERCEPTOR_PROVIDER: Provider = {
@@ -151,6 +151,7 @@ const loadConfigs: (appConfig: PublicationsConfigService) => () => Promise<void>
       useClass: ApiService,
     },
     MomentDateModule,
+    { provide: OAuthStorage, useFactory: (): OAuthStorage => localStorage },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/user-profile/src/app/app.module.ts
+++ b/apps/user-profile/src/app/app.module.ts
@@ -74,7 +74,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { PerunLoginModule } from '@perun-web-apps/perun/login';
 import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
 import { MatMenuModule } from '@angular/material/menu';
-import { OAuthModule } from 'angular-oauth2-oidc';
+import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { ConsentsPageComponent } from './pages/consents-page/consents-page.component';
 import { ConsentRequestComponent } from './pages/consents-page/consent-request/consent-request.component';
 import { ConsentsPreviewComponent } from './pages/consents-page/consents-preview/consents-preview.component';
@@ -207,6 +207,7 @@ const loadConfigs: (appConfig: UserProfileConfigService) => () => Promise<void> 
       useClass: ApiService,
     },
     Title,
+    { provide: OAuthStorage, useFactory: (): OAuthStorage => localStorage },
   ],
   exports: [SideMenuComponent],
   bootstrap: [AppComponent],


### PR DESCRIPTION
* storing tokens is moved from session storage to local storage because session storage is storing the data only for one tab,
but we want to share tokens across multiple tabs
* refreshing token is now only triggered when access token is expired
* expiration of tokens was moved from 0.75(default) to random number from 0.5 to 0.75 so the refreshing of the token is not triggered by multiple tabs at the same time
* sidemenu items url links members applications and groups fixed