### PR TITLE
fix: don't load oidc config and refresh token if service access authe…

### DIFF
--- a/libs/perun/services/src/lib/init-auth.service.ts
+++ b/libs/perun/services/src/lib/init-auth.service.ts
@@ -53,14 +53,14 @@ export class InitAuthService {
       } else {
         return this.router.navigate([location.pathname]).then(() => true);
       }
-    }
+    } else if (location.pathname !== '/service-access') {
+      this.authService.loadConfigData();
 
-    this.authService.loadConfigData();
-
-    if (this.storeService.skipOidc()) {
-      return new Promise<boolean>((resolve) => resolve(true));
-    } else {
-      return this.authService.verifyAuth();
+      if (this.storeService.skipOidc()) {
+        return new Promise<boolean>((resolve) => resolve(true));
+      } else {
+        return this.authService.verifyAuth();
+      }
     }
   }
 


### PR DESCRIPTION
…ntication is used

* when we are logged via basic auth or are on /service-access we don't have to initialize oidc config or try to refresh token
* because when we are trying to refresh token then we are loading discovery document which is making http request to proxy, but the configuration to that don't have to be there or the cors on the proxy could not be set correctly which could lead to constant logging of the application