### PR TITLE
feat: server side pagination

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/add-member-group-dialog/add-member-group-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-member-group-dialog/add-member-group-dialog.component.html
@@ -12,10 +12,10 @@
       [disableGroups]="true"
       [disableMembers]="true"
       [displayedColumns]="['select', 'id', 'name', 'description']"
-      [filter]="filterValue"
       [groupsToDisableCheckbox]="membersGroups"
       [disableRouting]="true"
       [groups]="groups"
+      [filter]="filterValue"
       [selection]="selection">
     </perun-web-apps-groups-list>
   </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-relation-dialog/create-relation-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-relation-dialog/create-relation-dialog.component.html
@@ -14,7 +14,6 @@
   <div class="dialog-container" mat-dialog-content>
     <perun-web-apps-groups-list
       *ngIf="!loading"
-      [authType]="'create-relation-dialog'"
       [groupsToDisableCheckbox]="groupsToDisable"
       [disableGroups]="true"
       [groups]="groups"
@@ -23,7 +22,9 @@
       [disableRouting]="true"
       [displayedColumns]="['select', 'id', 'name', 'description']"
       [filter]="filterValue"
-      [tableId]="tableId"></perun-web-apps-groups-list>
+      [tableId]="tableId"
+      [relation]="true">
+    </perun-web-apps-groups-list>
   </div>
   <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
   <div mat-dialog-actions>

--- a/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.html
+++ b/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.html
@@ -11,12 +11,13 @@
   {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.MANAGE_GROUPS_PAGE.ADD' | translate}}
 </button>
 <span
-  [matTooltipDisabled]="list === undefined || (list !== undefined && list.removeAuth)"
+  *ngIf="{ removeAuth: removeAuth$ | async } as auth"
+  [matTooltipDisabled]="selected.selected.length === 0 || auth.removeAuth"
   matTooltip="{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.MANAGE_GROUPS_PAGE.REMOVE_PERMISSION_HINT' | translate}}">
   <button
     (click)="removeGroup()"
     color="warn"
-    [disabled]="selected.selected.length === 0 || (list !== undefined && !list.removeAuth)"
+    [disabled]="selected.selected.length === 0 || !auth.removeAuth"
     class="mr-2"
     mat-flat-button>
     {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.MANAGE_GROUPS_PAGE.REMOVE' | translate}}
@@ -28,13 +29,11 @@
 </perun-web-apps-immediate-filter>
 <mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
 <perun-web-apps-groups-list
-  #list
   *ngIf="!loading"
-  [authType]="'application-form-manage-groups'"
   [displayedColumns]="['select', 'id', 'name', 'description']"
   [disableRouting]="true"
-  [filter]="filterValue"
   [groups]="this.groups"
+  [filter]="filterValue"
   [selection]="selected"
   [tableId]="tableId"
   theme="vo-theme">

--- a/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Group, RegistrarManagerService } from '@perun-web-apps/perun/openapi';
 import { ActivatedRoute } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
@@ -8,7 +8,8 @@ import { GuiAuthResolver } from '@perun-web-apps/perun/services';
 import { MatDialog } from '@angular/material/dialog';
 import { AddGroupToRegistrationComponent } from '../../../shared/components/dialogs/add-group-to-registration/add-group-to-registration.component';
 import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
-import { GroupsListComponent } from '@perun-web-apps/perun/components';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 
 @Component({
   selector: 'app-application-form-manage-groups',
@@ -16,9 +17,6 @@ import { GroupsListComponent } from '@perun-web-apps/perun/components';
   styleUrls: ['./application-form-manage-groups.component.css'],
 })
 export class ApplicationFormManageGroupsComponent implements OnInit {
-  @ViewChild('list', {})
-  list: GroupsListComponent;
-
   loading: boolean;
   voId: number;
   groups: Group[] = [];
@@ -26,6 +24,20 @@ export class ApplicationFormManageGroupsComponent implements OnInit {
   tableId = TABLE_APPLICATION_FORM_ITEM_MANAGE_GROUP;
   filterValue = '';
   addAuth: boolean;
+  removeAuth$: Observable<boolean> = this.selected.changed.pipe(
+    map((change) => {
+      return change.source.selected.reduce(
+        (acc, grp) =>
+          acc &&
+          this.authResolver.isAuthorized('deleteGroupsFromAutoRegistration_List<Group>_policy', [
+            { id: this.voId, beanName: 'Vo' },
+            grp,
+          ]),
+        true
+      );
+    }),
+    startWith(true)
+  );
 
   constructor(
     private registrarService: RegistrarManagerService,

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-relations/group-settings-relations.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-relations/group-settings-relations.component.html
@@ -10,10 +10,11 @@
     {{'GROUP_DETAIL.SETTINGS.RELATIONS.CREATE' | translate}}
   </button>
   <span
+    *ngIf="{removeAuth: removeAuth$ | async} as auth"
     matTooltip="{{'GROUP_DETAIL.SETTINGS.RELATIONS.DELETE_TOOLTIP' | translate}}"
-    [matTooltipDisabled]="selection.selected.length === 0 || (list !== undefined && list.removeAuth)">
+    [matTooltipDisabled]="selection.selected.length === 0 || auth.removeAuth">
     <button
-      [disabled]="selection.selected.length === 0 || (list !== undefined && !list.removeAuth) || reverse"
+      [disabled]="selection.selected.length === 0 || !auth.removeAuth || reverse"
       class="mr-2"
       color="warn"
       (click)="onDelete()"
@@ -31,8 +32,6 @@
   <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
 
   <perun-web-apps-groups-list
-    #list
-    [authType]="'group-relations'"
     *ngIf="!loading"
     [groups]="groups"
     [parentGroup]="group"

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-subgroups/group-subgroups.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-subgroups/group-subgroups.component.html
@@ -11,16 +11,13 @@
     {{'GROUP_DETAIL.SUBGROUPS.CREATE_GROUP' | translate}}
   </button>
   <span
-    [matTooltipDisabled]="(tree === undefined && list === undefined) ||
-          (tree !== undefined && tree.removeAuth) ||
-          (list !== undefined && list.removeAuth)"
+    *ngIf="{removeAuth: removeAuth$ | async} as auth"
+    [matTooltipDisabled]="selected.selected.length === 0 || auth.removeAuth"
     matTooltip="{{'GROUP_DETAIL.SUBGROUPS.DELETE_PERMISSION_HINT' | translate}}">
     <button
       (click)="deleteGroup()"
       *ngIf="deleteAuth"
-      [disabled]="selected.selected.length === 0 ||
-              (tree !== undefined && !tree.removeAuth) ||
-              (list !== undefined && !list.removeAuth)"
+      [disabled]="selected.selected.length === 0 || !auth.removeAuth"
       color="warn"
       class="mr-2"
       data-cy="delete-group-button"
@@ -45,7 +42,6 @@
   <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
   <div *ngIf="!loading" class="mt-3">
     <perun-web-apps-groups-tree
-      #tree
       *ngIf="!showGroupList"
       [disableRouting]="!routeAuth"
       [expandAll]="filtering"
@@ -57,11 +53,9 @@
       [selection]="selected">
     </perun-web-apps-groups-tree>
     <perun-web-apps-groups-list
-      #list
-      (moveGroup)="onMoveGroup($event)"
+      (groupMoved)="onMoveGroup($event)"
       (refreshTable)="refreshTable()"
       *ngIf="showGroupList"
-      [authType]="'group-subgroups'"
       [disableMembers]="true"
       [disableRouting]="!routeAuth"
       [displayedColumns]="deleteAuth ? ['select', 'id', 'name', 'description', 'menu'] : ['id', 'name', 'description', 'menu']"

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-subgroups/group-subgroups.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-subgroups/group-subgroups.component.ts
@@ -11,7 +11,8 @@ import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { GroupFlatNode } from '@perun-web-apps/perun/models';
 import { MoveGroupDialogComponent } from '../../../../shared/components/dialogs/move-group-dialog/move-group-dialog.component';
 import { EntityStorageService, GuiAuthResolver } from '@perun-web-apps/perun/services';
-import { GroupsListComponent, GroupsTreeComponent } from '@perun-web-apps/perun/components';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 
 @Component({
   selector: 'app-group-subgroups',
@@ -23,12 +24,7 @@ export class GroupSubgroupsComponent implements OnInit {
 
   // used for router animation
   @HostBinding('class.router-component') true;
-  @ViewChild('tree', {})
-  tree: GroupsTreeComponent;
-  @ViewChild('list', {})
-  list: GroupsListComponent;
-  @ViewChild('toggle', { static: true })
-  toggle: MatSlideToggle;
+  @ViewChild('toggle', { static: true }) toggle: MatSlideToggle;
 
   group: Group;
   groups: Group[] = [];
@@ -41,6 +37,16 @@ export class GroupSubgroupsComponent implements OnInit {
   createAuth: boolean;
   deleteAuth: boolean;
   routeAuth: boolean;
+  removeAuth$: Observable<boolean> = this.selected.changed.pipe(
+    map((changed) => {
+      return changed.source.selected.reduce(
+        (acc, grp) =>
+          acc && this.guiAuthResolver.isAuthorized('deleteGroup_Group_boolean_policy', [grp]),
+        true
+      );
+    }),
+    startWith(true)
+  );
 
   constructor(
     private dialog: MatDialog,

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-groups/member-groups.component.html
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-groups/member-groups.component.html
@@ -9,13 +9,14 @@
   {{'MEMBER_DETAIL.GROUPS.ADD' | translate}}
 </button>
 <span
-  [matTooltipDisabled]="list === undefined || (list !== undefined && list.removeAuth)"
+  *ngIf="{removeAuth: removeAuth$ | async} as auth"
+  [matTooltipDisabled]="auth.removeAuth"
   matTooltip="{{'MEMBER_DETAIL.GROUPS.REMOVE_PERMISSION_HINT' | translate}}">
   <button
     class="mr-2"
     color="warn"
     (click)="removeGroup()"
-    [disabled]="selection.selected.length === 0 || (list !== undefined && !list.removeAuth)"
+    [disabled]="selection.selected.length === 0 || !auth.removeAuth"
     mat-flat-button>
     {{'MEMBER_DETAIL.GROUPS.REMOVE' | translate}}
   </button>
@@ -26,15 +27,13 @@
 </perun-web-apps-immediate-filter>
 <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
 <perun-web-apps-groups-list
-  #list
-  (refreshTable)="refreshTable()"
   *ngIf="!loading"
+  (refreshTable)="refreshTable()"
   [displayedColumns]="['select', 'id', 'name', 'description', 'expiration', 'groupStatus']"
-  [authType]="'member-groups'"
-  [filter]="filterValue"
   [memberId]="memberId"
   [disableRouting]="!routeAuth"
   [groups]="groups"
+  [filter]="filterValue"
   [memberGroupStatus]="member.groupStatus"
   [selection]="selection"
   [tableId]="tableId">

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-groups/member-groups.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-groups/member-groups.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, OnInit, ViewChild } from '@angular/core';
+import { Component, HostBinding, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import {
   Group,
@@ -14,8 +14,9 @@ import { MatDialog } from '@angular/material/dialog';
 import { AddMemberGroupDialogComponent } from '../../../../shared/components/dialogs/add-member-group-dialog/add-member-group-dialog.component';
 import { RemoveMemberGroupDialogComponent } from '../../../../shared/components/dialogs/remove-member-group-dialog/remove-member-group-dialog.component';
 import { GuiAuthResolver } from '@perun-web-apps/perun/services';
-import { GroupsListComponent } from '@perun-web-apps/perun/components';
 import { Urns } from '@perun-web-apps/perun/urns';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 
 @Component({
   selector: 'app-member-groups',
@@ -28,8 +29,6 @@ export class MemberGroupsComponent implements OnInit {
   // used for router animation
   @HostBinding('class.router-component') true;
 
-  @ViewChild('list', {})
-  list: GroupsListComponent;
   groups: Group[];
   memberId: number;
   member: Member;
@@ -39,8 +38,17 @@ export class MemberGroupsComponent implements OnInit {
   tableId = TABLE_MEMBER_DETAIL_GROUPS;
   selection = new SelectionModel<Group>(true, []);
   addAuth: boolean;
-  removeAuth: boolean;
   routeAuth: boolean;
+  removeAuth$: Observable<boolean> = this.selection.changed.pipe(
+    map((change) =>
+      change.source.selected.reduce(
+        (acc, grp) =>
+          acc && this.authResolver.isAuthorized('removeMember_Member_List<Group>_policy', [grp]),
+        true
+      )
+    ),
+    startWith(true)
+  );
 
   constructor(
     private groupsService: GroupsManagerService,

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-groups/vo-groups.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-groups/vo-groups.component.html
@@ -1,6 +1,6 @@
 <div>
   <h1 class="page-subtitle">{{'VO_DETAIL.GROUPS.TITLE' | translate}}</h1>
-  <perun-web-apps-refresh-button (refresh)="loadAllGroups()"></perun-web-apps-refresh-button>
+  <perun-web-apps-refresh-button (refresh)="refresh()"></perun-web-apps-refresh-button>
   <button
     *ngIf="createAuth"
     (click)="onCreateGroup()"
@@ -11,12 +11,13 @@
     {{'VO_DETAIL.GROUPS.CREATE_GROUP' | translate}}
   </button>
   <span
-    [matTooltipDisabled]="(tree === undefined && list === undefined) || disableTooltip()"
+    *ngIf="{removeAuth: removeAuth$  | async} as auth"
+    [matTooltipDisabled]="auth.removeAuth"
     matTooltip="{{'VO_DETAIL.GROUPS.DELETE_PERMISSION_HINT' | translate}}">
     <button
       (click)="deleteGroup()"
       color="warn"
-      [disabled]="selected.selected.length === 0 || disableRemove()"
+      [disabled]="selected.selected.length === 0 || !auth.removeAuth"
       data-cy="delete-group-button"
       class="mr-2"
       mat-flat-button>
@@ -33,43 +34,46 @@
     [(ngModel)]="showGroupList"
     class="mr-1"
     color="primary"
-    labelPosition="before"
-    >{{'VO_DETAIL.GROUPS.TREE_VIEW' | translate}}</mat-slide-toggle
+    labelPosition="before">
+    {{'VO_DETAIL.GROUPS.TREE_VIEW' | translate}}</mat-slide-toggle
   >
   <label [attr.for]="toggle.inputId">{{'VO_DETAIL.GROUPS.LIST_VIEW' | translate}}</label>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading && groups.length !== 0" class="mt-3">
-    <perun-web-apps-groups-tree
-      #tree
-      (moveGroup)="onMoveGroup($event)"
-      *ngIf="!showGroupList"
-      (refreshTable)="loadAllGroups()"
-      [expandAll]="filtering"
-      [disableRouting]="!routeAuth"
-      [groups]="groups"
-      [selection]="selected"
-      [filterValue]="filterValue"
-      [vo]="vo"
-      theme="vo-theme">
-    </perun-web-apps-groups-tree>
-    <perun-web-apps-groups-list
-      #list
-      (refreshTable)="loadAllGroups()"
-      (moveGroup)="onMoveGroup($event)"
-      *ngIf="showGroupList"
-      [authType]="'vo-groups'"
-      [disableMembers]="true"
-      [displayedColumns]="['select', 'id', 'name', 'description', 'menu']"
-      [disableRouting]="!routeAuth"
-      [groups]="groups"
-      [selection]="selected"
-      [filter]="filterValue"
-      [tableId]="tableId"
-      theme="vo-theme">
-    </perun-web-apps-groups-list>
+  <div class="mt-3 position-relative">
+    <div *ngIf="!showGroupList">
+      <perun-web-apps-groups-tree
+        *perunWebAppsLoader="loading$ | async; indicator: spinner"
+        (moveGroup)="onMoveGroup($event)"
+        (refreshTable)="refresh()"
+        [expandAll]="filtering"
+        [disableRouting]="!routeAuth"
+        [groups]="groups"
+        [selection]="selected"
+        [filterValue]="filterValue"
+        [vo]="vo"
+        theme="vo-theme">
+      </perun-web-apps-groups-tree>
+    </div>
+    <div *ngIf="showGroupList">
+      <perun-web-apps-groups-list
+        *perunWebAppsLoader="loading$ | async; indicator: spinner"
+        (groupMoved)="onMoveGroup($event)"
+        (queryChanged)="nextPage.next($event)"
+        (refreshTable)="refresh()"
+        (downloadAll)="downloadAll($event)"
+        [disableMembers]="true"
+        [displayedColumns]="displayedColumns"
+        [disableRouting]="!routeAuth"
+        [groups]="groupPage$ | async"
+        [selection]="selected"
+        [filter]="filterValue"
+        [tableId]="tableId"
+        theme="vo-theme">
+      </perun-web-apps-groups-list>
+    </div>
   </div>
-
-  <perun-web-apps-alert *ngIf="groups.length === 0 && !loading" alert_type="warn">
-    {{'VO_DETAIL.GROUPS.NO_GROUPS' | translate}}
-  </perun-web-apps-alert>
 </div>
+<ng-template #spinner>
+  <div class="spinner-container">
+    <mat-spinner></mat-spinner>
+  </div>
+</ng-template>

--- a/apps/admin-gui/src/styles.scss
+++ b/apps/admin-gui/src/styles.scss
@@ -1404,7 +1404,7 @@ td.mat-cell {
   position: absolute;
   top: 0;
   left: 0;
-  bottom: 56px;
+  bottom: 0;
   right: 0;
   background: rgba(0, 0, 0, 0.15);
   z-index: 1;

--- a/apps/publications/src/app/components/authors-list/authors-list.component.ts
+++ b/apps/publications/src/app/components/authors-list/authors-list.component.ts
@@ -13,7 +13,7 @@ import {
   customDataSourceSort,
   downloadData,
   getDataForExport,
-  parseAttribute,
+  findAttribute,
   parseFullName,
   parseName,
   TABLE_ITEMS_COUNT_OPTIONS,
@@ -64,9 +64,9 @@ export class AuthorsListComponent implements AfterViewInit, OnChanges {
       case 'name':
         return parseName(data);
       case 'organization':
-        return parseAttribute(data, 'organization');
+        return findAttribute(data.attributes, 'organization');
       case 'email':
-        return parseAttribute(data, 'preferredMail');
+        return findAttribute(data.attributes, 'preferredMail');
       case 'numberOfPublications':
         return data.authorships.length.toString();
       default:
@@ -81,9 +81,9 @@ export class AuthorsListComponent implements AfterViewInit, OnChanges {
       case 'name':
         return parseFullName(data);
       case 'organization':
-        return parseAttribute(data, 'organization');
+        return findAttribute(data.attributes, 'organization');
       case 'email':
-        return parseAttribute(data, 'preferredMail');
+        return findAttribute(data.attributes, 'preferredMail');
       case 'numberOfPublications':
         return data.authorships.length.toString();
       default:
@@ -98,9 +98,9 @@ export class AuthorsListComponent implements AfterViewInit, OnChanges {
       case 'name':
         return data.lastName ? data.lastName : data.firstName ?? '';
       case 'organization':
-        return parseAttribute(data, 'organization');
+        return findAttribute(data.attributes, 'organization');
       case 'email':
-        return parseAttribute(data, 'preferredMail');
+        return findAttribute(data.attributes, 'preferredMail');
       case 'numberOfPublications':
         return data.authorships.length.toString();
       default:

--- a/libs/perun/components/src/lib/attribute-unique-toggle/attribute-unique-toggle.component.html
+++ b/libs/perun/components/src/lib/attribute-unique-toggle/attribute-unique-toggle.component.html
@@ -1,14 +1,14 @@
 <div
-  *ngIf="{disable: attDef | disableUniqueAttribute} as vm"
+  *ngIf="{disable: attDef | disableUniqueAttribute} as disabled"
   class="unique-toggle-container"
-  [matTooltipDisabled]="!vm.disable"
+  [matTooltipDisabled]="!disabled.disable"
   matTooltipPosition="above"
   matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTE_UNIQUE_TOGGLE.TOOLTIP'| translate}}">
   <mat-slide-toggle
     color="accent"
     labelPosition="before"
     [(ngModel)]="attDef.unique"
-    [disabled]="vm.disable">
+    [disabled]="disabled.disable">
     {{'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTE_UNIQUE_TOGGLE.UNIQUE' | translate}}
   </mat-slide-toggle>
 </div>

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.html
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.html
@@ -1,10 +1,8 @@
-<div
-  [hidden]="groups.length === 0 || !dataSource || dataSource.filteredData.length === 0"
-  class="card mt-2">
+<div [hidden]="dataSource.filteredData.length === 0" class="card mt-2">
   <perun-web-apps-table-wrapper
     (exportDisplayedData)="exportDisplayedData($event)"
     (exportAllData)="exportAllData($event)"
-    [dataLength]="dataSource.filteredData.length"
+    [dataLength]="dataSource['count'] ?? dataSource.filteredData.length"
     [pageSizeOptions]="pageSizeOptions"
     [tableId]="tableId">
     <table
@@ -17,29 +15,29 @@
       matSortDisableClear>
       <ng-container
         matColumnDef="select"
-        *ngIf="(dataSource | isAllSelected: selection.selected.length :canBeSelected) as selected">
+        *ngIf="{all: dataSource | isAllSelected: selection.selected.length :canBeSelected} as selected">
         <th *matHeaderCellDef mat-header-cell class="align-checkbox">
           <mat-checkbox
-            (change)="$event ? masterToggle() : null"
             *ngIf="!disableHeadCheckbox"
+            (change)="$event ? masterToggle() : null"
             [aria-label]="checkboxLabel()"
-            [checked]="selection.hasValue() && selected"
-            [indeterminate]="selection.hasValue() && !selected"
+            [checked]="selection.hasValue() && selected.all"
+            [indeterminate]="selection.hasValue() && !selected.all"
             color="primary">
           </mat-checkbox>
         </th>
-        <td *matCellDef="let row" class="static-column-size align-checkbox" mat-cell>
+        <td *matCellDef="let group" class="static-column-size align-checkbox" mat-cell>
           <span
-            matTooltip="{{getCheckboxTooltipMessage(row) | translate}}"
+            *ngIf="{disable: group | disableGroupSelect: disableMembers : disableGroups : groupsToDisableCheckbox} as groupStatus"
+            [matTooltip]="group | groupCheckboxTooltip: false | translate"
             [matTooltipPosition]="'above'"
-            [matTooltipDisabled]="!disableSelect(row)">
+            [matTooltipDisabled]="!groupStatus.disable">
             <mat-checkbox
-              (change)="$event ? itemSelectionToggle(row) : null"
+              (change)="$event ? itemSelectionToggle(group) : null"
               (click)="$event.stopPropagation()"
-              [aria-label]="checkboxLabel(row)"
-              [checked]="selection.isSelected(row)"
-              [disabled]="(row.name === 'members' && disableMembers) || disableSelect(row)"
-              attr.data-cy="{{row.name}}-checkbox"
+              [checked]="selection.isSelected(group)"
+              [disabled]="groupStatus.disable"
+              attr.data-cy="{{group.name}}-checkbox"
               color="primary">
             </mat-checkbox>
           </span>
@@ -53,8 +51,8 @@
       </ng-container>
       <ng-container matColumnDef="recent">
         <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let resource" mat-cell>
-          <perun-web-apps-recently-viewed-icon [recentIds]="recentIds" [id]="resource.id">
+        <td *matCellDef="let group" mat-cell>
+          <perun-web-apps-recently-viewed-icon [recentIds]="recentIds" [id]="group.id">
           </perun-web-apps-recently-viewed-icon>
         </td>
       </ng-container>
@@ -115,12 +113,13 @@
         </th>
         <td *matCellDef="let group" mat-cell>
           <i
-            class="material-icons {{getStatusAttribute(group) | groupStatusIconColor}}"
-            matTooltip="{{getStatusAttribute(group)}}"
+            *ngIf="{status: group.attributes | findAttribute: 'groupStatus'} as groupStatus"
+            class="material-icons {{groupStatus.status | groupStatusIconColor}}"
+            matTooltip="{{groupStatus.status}}"
             matTooltipClass="status-tooltip"
             matTooltipPosition="left">
             <span>
-              {{getStatusAttribute(group) | memberStatusIcon}}
+              {{groupStatus.status | memberStatusIcon}}
             </span>
           </i>
         </td>
@@ -138,7 +137,7 @@
         <td *matCellDef="let group" class="wrap-content" mat-cell>
           {{group | groupExpiration | parseDate}}
           <button
-            *ngIf="canManageGroup(group)"
+            *ngIf="group | canManageGroup"
             (click)="changeExpiration(group)"
             (mouseenter)="disabledRouting = true"
             (mouseleave)="disabledRouting = disableRouting"
@@ -153,9 +152,9 @@
           <perun-web-apps-group-menu
             (mouseenter)="disabledRouting = true"
             (mouseleave)="disabledRouting = disableRouting"
-            (moveGroup)="onMoveGroup(group)"
-            (changeNameDescription)="onChangeNameDescription(group)"
-            (syncGroup)="onSyncDetail(group)"
+            (moveGroup)="moveGroup(group)"
+            (changeNameDescription)="editGroup(group)"
+            (syncGroup)="openSyncDetail(group)"
             [disabled]="group.name === 'members'"
             [displayButtons]="displayButtons"
             [group]="group">
@@ -163,9 +162,9 @@
         </td>
       </ng-container>
 
-      <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
+      <tr *matHeaderRowDef="columns" mat-header-row></tr>
       <tr
-        *matRowDef="let group; columns: displayedColumns;"
+        *matRowDef="let group; columns: columns;"
         [class.cursor-pointer]="!disableRouting && !groupsToDisableRouting.has(group.id)"
         [class.disable-outline]="disabledRouting || groupsToDisableRouting.has(group.id)"
         [perunWebAppsMiddleClickRouterLink]="(disabledRouting || groupsToDisableRouting.has(group.id)) ? null : ['/organizations', group.voId, 'groups', group.id]"
@@ -176,12 +175,6 @@
   </perun-web-apps-table-wrapper>
 </div>
 
-<perun-web-apps-alert *ngIf="groups.length === 0" alert_type="warn">
+<perun-web-apps-alert *ngIf="dataSource.filteredData.length === 0" alert_type="warn">
   {{noGroupsAlert | translate}}
-</perun-web-apps-alert>
-
-<perun-web-apps-alert
-  *ngIf="dataSource.filteredData.length === 0 && groups.length !== 0"
-  alert_type="warn">
-  {{'SHARED_LIB.UI.ALERTS.NO_FILTER_RESULTS_ALERT' | translate}}
 </perun-web-apps-alert>

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.ts
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.ts
@@ -1,53 +1,77 @@
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  HostListener,
-  Input,
-  OnChanges,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, Output, ViewChild } from '@angular/core';
 import {
   ChangeGroupExpirationDialogComponent,
   EditFacilityResourceGroupVoDialogComponent,
   EditFacilityResourceGroupVoDialogOptions,
   GroupSyncDetailDialogComponent,
 } from '@perun-web-apps/perun/dialogs';
-import { Group, Member, RichGroup, Vo, VosManagerService } from '@perun-web-apps/perun/openapi';
+import {
+  Group,
+  Member,
+  PaginatedRichGroups,
+  VosManagerService,
+} from '@perun-web-apps/perun/openapi';
 import { GuiAuthResolver, TableCheckbox } from '@perun-web-apps/perun/services';
 import {
-  TABLE_ITEMS_COUNT_OPTIONS,
-  TableWrapperComponent,
   customDataSourceFilterPredicate,
   customDataSourceSort,
   downloadData,
+  findAttribute,
   getDataForExport,
   getDefaultDialogConfig,
-  getGroupExpiration,
-  parseDate,
-  isGroupSynchronized,
+  TABLE_ITEMS_COUNT_OPTIONS,
+  TableWrapperComponent,
 } from '@perun-web-apps/perun/utils';
 
-import { GroupWithStatus } from '@perun-web-apps/perun/models';
+import {
+  DynamicDataSource,
+  GroupWithStatus,
+  isDynamicDataSource,
+  PageQuery,
+} from '@perun-web-apps/perun/models';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { SelectionModel } from '@angular/cdk/collections';
-import { formatDate } from '@angular/common';
+import { DisableGroupSelectPipe } from '@perun-web-apps/perun/pipes';
+import { GroupUtilsService } from '@perun-web-apps/perun/services';
 
 @Component({
   selector: 'perun-web-apps-groups-list',
   templateUrl: './groups-list.component.html',
   styleUrls: ['./groups-list.component.scss'],
+  providers: [DisableGroupSelectPipe],
 })
-export class GroupsListComponent implements AfterViewInit, OnChanges {
+export class GroupsListComponent {
   @Input() theme = 'group-theme';
-  @Output() moveGroup = new EventEmitter<GroupWithStatus>();
-  @Input() groups: GroupWithStatus[] = [];
   @Input() selection = new SelectionModel<GroupWithStatus>(true, []);
-  @Input() displayedColumns: string[] = [
+  @Input() disableMembers: boolean;
+  @Input() disableGroups: boolean;
+  @Input() groupsToDisableCheckbox: Set<number> = new Set<number>();
+  @Input() groupsToDisableRouting: Set<number> = new Set<number>();
+  @Input() disableHeadCheckbox: boolean;
+  @Input() parentGroup: Group;
+  @Input() disableRouting = false;
+  @Input() memberId: number;
+  @Input() memberGroupStatus: string;
+  @Input() pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
+  @Input() recentIds: number[] = [];
+  @Input() resourceId: number = null;
+  @Input() tableId: string;
+  @Input() relation = false;
+  @Input() noGroupsAlert = 'SHARED_LIB.UI.ALERTS.NO_GROUPS';
+  @Output() groupMoved = new EventEmitter<GroupWithStatus>();
+  @Output() refreshTable = new EventEmitter<void>();
+  @Output() queryChanged = new EventEmitter<PageQuery>();
+  @Output() downloadAll = new EventEmitter<{ format: string; length: number }>();
+  @ViewChild(TableWrapperComponent, { static: true }) tableWrapper: TableWrapperComponent;
+  @ViewChild(MatSort, { static: true }) sort: MatSort;
+
+  displayButtons = window.innerWidth > 800;
+  dataSource: MatTableDataSource<GroupWithStatus> | DynamicDataSource<GroupWithStatus>;
+  disabledRouting = false;
+  voNames: Map<number, string> = new Map<number, string>();
+  columns: string[] = [
     'select',
     'id',
     'recent',
@@ -60,111 +84,44 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
     'expiration',
     'menu',
   ];
-  @Input() disableMembers: boolean;
-  @Input() disableGroups: boolean;
-  @Input() groupsToDisableCheckbox: Set<number> = new Set<number>();
-  @Input() groupsToDisableRouting: Set<number> = new Set<number>();
-  @Input() filter = '';
-  @Input() disableHeadCheckbox: boolean;
-  @Input() parentGroup: Group;
-  @Input() disableRouting = false;
-  @Input() authType: string;
-  @Input() memberId: number;
-  @Input() memberGroupStatus: string;
-  @Input() pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
-  @Input() recentIds: number[] = [];
-  @Input() resourceId: number = null;
-  @Input() tableId: string;
-  @Input() noGroupsAlert = 'SHARED_LIB.UI.ALERTS.NO_GROUPS';
-  @Output() refreshTable = new EventEmitter<void>();
-  @ViewChild(TableWrapperComponent, { static: true }) child: TableWrapperComponent;
-
-  displayButtons = window.innerWidth > 800;
-  dataSource: MatTableDataSource<GroupWithStatus>;
-  disabledRouting = false;
-  vo: Vo;
-  voIds: Set<number> = new Set<number>();
-  voNames: Map<number, string> = new Map<number, string>();
-  removeAuth: boolean;
-
-  private sort: MatSort;
-  private hasMembersGroup = false;
 
   constructor(
     private dialog: MatDialog,
     private authResolver: GuiAuthResolver,
     private voService: VosManagerService,
     private tableCheckbox: TableCheckbox,
-    private changeDetector: ChangeDetectorRef
+    private disableGroupSelect: DisableGroupSelectPipe,
+    private groupUtils: GroupUtilsService
   ) {}
 
-  @ViewChild(MatSort, { static: true }) set matSort(ms: MatSort) {
-    this.sort = ms;
+  @Input() set groups(groups: GroupWithStatus[] | PaginatedRichGroups) {
+    // Initialize data source with first group object passed
+    // One table instance can NOT alternate between paginated and not paginated groups
+    if (!this.dataSource) {
+      this.dataSourceInit(groups);
+    }
+
+    // Set up data correctly on each change
+    const paginated = this.isPaginated(groups);
+    if (isDynamicDataSource(this.dataSource) && paginated) {
+      this.dataSource.data = groups.data;
+      this.dataSource.count = groups.totalCount;
+    } else if (!isDynamicDataSource(this.dataSource) && !paginated) {
+      this.dataSource.data = groups;
+    }
+
+    this.updateVoNames();
   }
 
-  static getDataForColumn(
-    data: GroupWithStatus,
-    column: string,
-    voNames: Map<number, string>
-  ): string {
-    switch (column) {
-      case 'id':
-        return data.id.toString();
-      case 'vo':
-        return voNames.get(data.voId);
-      case 'name':
-        return data.name;
-      case 'description':
-        return data.description;
-      case 'expiration': {
-        const expirationStr = getGroupExpiration(data);
-        return parseDate(expirationStr);
-      }
-      case 'recent':
-        return '';
-      case 'status':
-        return data.status;
-      case 'uuid':
-        return data.uuid;
-      default:
-        return data[column] as string;
-    }
+  @Input() set filter(value: string) {
+    this.dataSource.filter = value;
   }
 
-  static getSortDataForColumn(
-    data: GroupWithStatus,
-    column: string,
-    voNames: Map<number, string>,
-    recentIds: number[]
-  ): string {
-    switch (column) {
-      case 'id':
-        return data.id.toString();
-      case 'vo':
-        return voNames.get(data.voId);
-      case 'name':
-        return data.name;
-      case 'description':
-        return data.description;
-      case 'expiration': {
-        const expirationStr = getGroupExpiration(data);
-        if (!expirationStr || expirationStr.toLowerCase() === 'never') {
-          return expirationStr;
-        }
-        return formatDate(expirationStr, 'yyyy.MM.dd', 'en');
-      }
-      case 'recent':
-        if (recentIds) {
-          if (recentIds.includes(data.id)) {
-            return '#'.repeat(recentIds.indexOf(data.id));
-          }
-        }
-        return data['name'];
-      case 'status':
-        return data.status;
-      default:
-        return data[column] as string;
+  @Input() set displayedColumns(columns: string[]) {
+    if (!this.authResolver.isPerunAdminOrObserver()) {
+      columns = columns.filter((column) => column !== 'id');
     }
+    this.columns = columns;
   }
 
   @HostListener('window:resize', ['$event'])
@@ -172,155 +129,108 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
     this.displayButtons = window.innerWidth > 800;
   }
 
+  isPaginated(data: GroupWithStatus[] | PaginatedRichGroups): data is PaginatedRichGroups {
+    return 'data' in data;
+  }
+
   getDataForColumnFun = (data: GroupWithStatus, column: string): string => {
-    return GroupsListComponent.getDataForColumn(data, column, this.voNames);
+    return this.groupUtils.getDataForColumn(data, column, this.voNames);
   };
 
   getSortDataForColumnFun = (data: GroupWithStatus, column: string): string => {
-    return GroupsListComponent.getSortDataForColumn(data, column, this.voNames, this.recentIds);
+    return this.groupUtils.getSortDataForColumn(data, column, this.voNames, this.recentIds);
   };
 
-  ngOnChanges(): void {
-    this.disabledRouting = this.disableRouting;
-    this.hasMembersGroup = this.checkIfHasMembersGroup();
-    this.updateVoNames();
-    this.setDataSource();
-    if (this.authType) {
-      this.removeAuth = this.setAuth();
-    }
-  }
-
-  checkIfHasMembersGroup(): boolean {
-    for (const group of this.groups) {
-      if (group.name === 'members') {
-        return true;
-      }
-    }
-    return false;
-  }
-
   exportAllData(format: string): void {
-    downloadData(
-      getDataForExport(
-        this.dataSource.filteredData,
-        this.displayedColumns,
-        this.getDataForColumnFun
-      ),
-      format
-    );
+    if (isDynamicDataSource(this.dataSource)) {
+      this.downloadAll.emit({ format: format, length: this.dataSource.paginator.length });
+    } else {
+      downloadData(
+        getDataForExport(this.dataSource.filteredData, this.columns, this.getDataForColumnFun),
+        format
+      );
+    }
   }
 
   exportDisplayedData(format: string): void {
-    const start = this.dataSource.paginator.pageIndex * this.dataSource.paginator.pageSize;
-    const end = start + this.dataSource.paginator.pageSize;
-    downloadData(
-      getDataForExport(
-        this.dataSource
-          .sortData(this.dataSource.filteredData, this.dataSource.sort)
-          .slice(start, end),
-        this.displayedColumns,
-        this.getDataForColumnFun
-      ),
-      format
-    );
-  }
-
-  setDataSource(): void {
-    if (!this.dataSource) {
-      this.dataSource = new MatTableDataSource<GroupWithStatus>();
-      this.dataSource.sort = this.sort;
-      this.dataSource.paginator = this.child.paginator;
-      this.dataSource.filterPredicate = (data: Group | RichGroup, filter: string): boolean =>
-        customDataSourceFilterPredicate(
-          data,
-          filter,
-          this.displayedColumns,
-          this.getDataForColumnFun,
-          true
-        );
-      this.dataSource.sortData = (
-        data: Group[] | RichGroup[],
-        sort: MatSort
-      ): Group[] | RichGroup[] => customDataSourceSort(data, sort, this.getSortDataForColumnFun);
+    if (isDynamicDataSource(this.dataSource)) {
+      downloadData(
+        getDataForExport(this.dataSource.data, this.columns, this.getDataForColumnFun),
+        format
+      );
+    } else {
+      const start = this.dataSource.paginator.pageIndex * this.dataSource.paginator.pageSize;
+      const end = start + this.dataSource.paginator.pageSize;
+      downloadData(
+        getDataForExport(
+          this.dataSource
+            .sortData(this.dataSource.filteredData, this.dataSource.sort)
+            .slice(start, end),
+          this.columns,
+          this.getDataForColumnFun
+        ),
+        format
+      );
     }
-    this.dataSource.filter = this.filter;
-    this.dataSource.data = this.groups;
   }
-
-  canBeSelected = (group: GroupWithStatus): boolean =>
-    (group.name !== 'members' || !this.disableMembers) && !this.disableSelect(group);
 
   isAllSelected(): boolean {
-    return this.tableCheckbox.isAllSelected(
-      this.selection.selected.length,
-      this.dataSource,
-      this.canBeSelected
-    );
+    if (isDynamicDataSource(this.dataSource)) {
+      return this.tableCheckbox.isAllSelectedPaginated(
+        this.dataSource,
+        this.selection.selected.length,
+        this.canBeSelected
+      );
+    } else {
+      return this.tableCheckbox.isAllSelected(
+        this.selection.selected.length,
+        this.dataSource,
+        this.canBeSelected
+      );
+    }
   }
 
   masterToggle(): void {
-    this.tableCheckbox.masterToggle(
-      this.isAllSelected(),
-      this.selection,
-      this.filter,
-      this.dataSource,
-      this.sort,
-      this.child.paginator.pageSize,
-      this.child.paginator.pageIndex,
-      true,
-      this.canBeSelected
-    );
-
-    if (this.authType) {
-      this.removeAuth = this.setAuth();
+    if (isDynamicDataSource(this.dataSource)) {
+      this.tableCheckbox.masterTogglePaginated(
+        this.dataSource,
+        this.selection,
+        !this.isAllSelected(),
+        this.canBeSelected
+      );
+    } else {
+      this.tableCheckbox.masterToggle(
+        this.isAllSelected(),
+        this.selection,
+        this.dataSource.filter,
+        this.dataSource,
+        this.dataSource.sort,
+        this.dataSource.paginator.pageSize,
+        this.dataSource.paginator.pageIndex,
+        true,
+        this.canBeSelected
+      );
     }
   }
 
-  checkboxLabel(row?: GroupWithStatus): string {
-    if (!row) {
-      return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
-    }
-    return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.id + 1}`;
+  moveGroup(group: GroupWithStatus): void {
+    this.groupMoved.emit(group);
   }
 
-  disableSelect(grp: GroupWithStatus): boolean {
-    return (
-      this.disableGroups && (this.groupsToDisableCheckbox.has(grp.id) || isGroupSynchronized(grp))
-    );
-  }
-
-  ngAfterViewInit(): void {
-    if (this.vo === undefined && this.groups.length !== 0) {
-      this.vo = {
-        id: this.groups[0].voId,
-        beanName: 'Vo',
-      };
-    }
-    this.shouldHideButtons();
-    if (!this.authResolver.isPerunAdminOrObserver()) {
-      this.displayedColumns = this.displayedColumns.filter((column) => column !== 'id');
-      this.changeDetector.detectChanges();
-    }
-  }
-
-  onMoveGroup(group: GroupWithStatus): void {
-    this.moveGroup.emit(group);
-  }
-
-  onSyncDetail(rg: RichGroup): void {
+  openSyncDetail(group: GroupWithStatus): void {
     const config = getDefaultDialogConfig();
     config.data = {
-      groupId: rg.id,
+      groupId: group.id,
       theme: this.theme,
     };
     this.dialog.open(GroupSyncDetailDialogComponent, config);
   }
 
-  onChangeNameDescription(rg: RichGroup): void {
+  editGroup(group: GroupWithStatus): void {
     const config = getDefaultDialogConfig();
     config.data = {
       theme: 'group-theme',
-      group: rg,
+      group: group,
       dialogType: EditFacilityResourceGroupVoDialogOptions.GROUP,
     };
     const dialogRef = this.dialog.open(EditFacilityResourceGroupVoDialogComponent, config);
@@ -330,82 +240,6 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
         this.refreshTable.emit();
       }
     });
-  }
-
-  setAuth(): boolean {
-    if (this.authType === 'group-subgroups') {
-      return this.selection.selected.reduce(
-        (acc, grp) =>
-          acc && this.authResolver.isAuthorized('deleteGroup_Group_boolean_policy', [grp]),
-        true
-      );
-    } else if (this.authType === 'group-relations') {
-      return this.selection.selected.reduce(
-        (acc, grp) =>
-          acc &&
-          this.authResolver.isAuthorized('result-removeGroupUnion_Group_Group_policy', [
-            this.parentGroup,
-          ]) &&
-          this.authResolver.isAuthorized('operand-removeGroupUnion_Group_Group_policy', [grp]),
-        true
-      );
-    } else if (this.authType === 'vo-groups') {
-      return this.selection.selected.reduce(
-        (acc, grp) =>
-          acc && this.authResolver.isAuthorized('deleteGroup_Group_boolean_policy', [this.vo, grp]),
-        true
-      );
-    } else if (this.authType === 'member-groups') {
-      return this.selection.selected.reduce(
-        (acc, grp) =>
-          acc && this.authResolver.isAuthorized('removeMember_Member_List<Group>_policy', [grp]),
-        true
-      );
-    } else if (this.authType === 'application-form-manage-groups') {
-      return this.selection.selected.reduce(
-        (acc, grp) =>
-          acc &&
-          this.authResolver.isAuthorized('deleteGroupsFromAutoRegistration_List<Group>_policy', [
-            this.vo,
-            grp,
-          ]),
-        true
-      );
-    }
-  }
-
-  itemSelectionToggle(item: GroupWithStatus): void {
-    this.selection.toggle(item);
-    this.removeAuth = this.setAuth();
-  }
-
-  getCheckboxTooltipMessage(row: GroupWithStatus): string {
-    if (this.authType === 'create-relation-dialog') {
-      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.CREATE_RELATION_AUTH_TOOLTIP';
-    } else if (isGroupSynchronized(row)) {
-      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.SYNCHRONIZED_GROUP';
-    } else if (row.sourceGroupId) {
-      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.INDIRECT_GROUP';
-    } else {
-      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.ALREADY_MEMBER_TOOLTIP';
-    }
-  }
-
-  updateVoNames(): void {
-    if (this.displayedColumns.includes('vo')) {
-      this.groups.forEach((grp) => {
-        if (!this.voIds.has(grp.voId)) {
-          this.voIds.add(grp.voId);
-        }
-      });
-      if (this.voIds.size > 0) {
-        this.voService.getVosByIds([...this.voIds]).subscribe((vos) => {
-          vos.forEach((vo) => {
-            this.voNames.set(vo.id, vo.name);
-          });
-        });
-      }
-    }
   }
 
   changeExpiration(group: GroupWithStatus): void {
@@ -418,7 +252,7 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
       memberId: this.memberId,
       groupId: group.id,
       expirationAttr: expirationAtt,
-      status: this.getStatusAttribute(group),
+      status: findAttribute(group.attributes, 'groupStatus'),
     };
 
     const dialogRef = this.dialog.open(ChangeGroupExpirationDialogComponent, config);
@@ -429,14 +263,67 @@ export class GroupsListComponent implements AfterViewInit, OnChanges {
     });
   }
 
-  canManageGroup(group: GroupWithStatus): boolean {
-    return (
-      this.authResolver.isThisGroupAdmin(group.id) || this.authResolver.isThisVoAdmin(group.voId)
-    );
+  checkboxLabel(row?: GroupWithStatus): string {
+    if (!row) {
+      return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
+    }
+    return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.id + 1}`;
   }
 
-  getStatusAttribute(grp: RichGroup): string {
-    const filter = grp.attributes.find((att) => att.baseFriendlyName === 'groupStatus');
-    return filter?.value ? (filter.value as string) : '';
+  itemSelectionToggle(item: GroupWithStatus): void {
+    this.selection.toggle(item);
+  }
+
+  canBeSelected = (group: GroupWithStatus): boolean =>
+    !this.disableGroupSelect.transform(
+      group,
+      this.disableMembers,
+      this.disableGroups,
+      this.groupsToDisableCheckbox
+    );
+
+  private dataSourceInit(groups: GroupWithStatus[] | PaginatedRichGroups): void {
+    const paginated = this.isPaginated(groups);
+
+    // Create data source based on input type
+    this.dataSource = paginated
+      ? new DynamicDataSource(
+          groups.data,
+          groups.totalCount,
+          this.sort,
+          this.tableWrapper.paginator
+        )
+      : new MatTableDataSource(groups);
+
+    if (isDynamicDataSource(this.dataSource)) {
+      // Subscribe to data source changes and pass them to parent
+      this.dataSource.pageQuery$.subscribe((query) => this.queryChanged.emit(query));
+    } else {
+      // Initialize client-side data source
+      this.dataSource.sort = this.sort;
+      this.dataSource.paginator = this.tableWrapper.paginator;
+      this.dataSource.filterPredicate = (data: GroupWithStatus, filter: string): boolean =>
+        customDataSourceFilterPredicate(data, filter, this.columns, this.getDataForColumnFun, true);
+      this.dataSource.sortData = (data: GroupWithStatus[], sort: MatSort): GroupWithStatus[] =>
+        customDataSourceSort(data, sort, this.getSortDataForColumnFun);
+    }
+  }
+
+  private updateVoNames(): void {
+    if (this.columns.includes('vo')) {
+      const voIds = new Set<number>();
+      this.dataSource.filteredData.forEach((grp) => {
+        if (!voIds.has(grp.voId) && !this.voNames.has(grp.voId)) {
+          voIds.add(grp.voId);
+        }
+      });
+      if (voIds.size > 0) {
+        this.voService.getVosByIds([...voIds]).subscribe((vos) => {
+          vos.forEach((vo) => {
+            this.voNames.set(vo.id, vo.name);
+          });
+        });
+      }
+    }
   }
 }

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -99,6 +99,7 @@ import { AttributeRightsItemComponent } from './attribute-rights-item/attribute-
 import { AttributeRightsTabGroupComponent } from './attribute-rights-tab-group/attribute-rights-tab-group.component';
 import { AttributeUniqueToggleComponent } from './attribute-unique-toggle/attribute-unique-toggle.component';
 import { AttributeCriticalOperationsTogglesComponent } from './attribute-critical-operations-toggles/attribute-critical-operations-toggles.component';
+import { LoaderDirective } from '@perun-web-apps/perun/directives';
 
 @Injectable()
 export class AppDateAdapter extends NativeDateAdapter {
@@ -230,6 +231,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     AttributeRightsTabGroupComponent,
     AttributeUniqueToggleComponent,
     AttributeCriticalOperationsTogglesComponent,
+    LoaderDirective,
   ],
   exports: [
     VosListComponent,
@@ -289,6 +291,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     AttributeRightsTabGroupComponent,
     AttributeUniqueToggleComponent,
     AttributeCriticalOperationsTogglesComponent,
+    LoaderDirective,
   ],
   providers: [
     { provide: DateAdapter, useClass: AppDateAdapter },

--- a/libs/perun/directives/src/index.ts
+++ b/libs/perun/directives/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/auto-focus.directive';
 export * from './lib/force-router-link.directive';
 export * from './lib/middle-click-router-link';
+export * from './lib/loader.directive';

--- a/libs/perun/directives/src/lib/loader.directive.ts
+++ b/libs/perun/directives/src/lib/loader.directive.ts
@@ -1,0 +1,42 @@
+import {
+  Directive,
+  EmbeddedViewRef,
+  Input,
+  OnChanges,
+  OnInit,
+  TemplateRef,
+  ViewContainerRef,
+} from '@angular/core';
+
+@Directive({
+  selector: '[perunWebAppsLoader]',
+})
+/**
+ * Similar to `ngIf` but instead of hiding the template
+ * shows provided loading indicator.
+ *
+ * Can be applied to any component.
+ */
+export class LoaderDirective<T> implements OnInit, OnChanges {
+  @Input('perunWebAppsLoader') loading = false;
+  /* eslint-disable @angular-eslint/no-input-rename */
+  @Input('perunWebAppsLoaderIndicator') loadingIndicator: TemplateRef<Element>;
+  loadingIndicatorRef: EmbeddedViewRef<Element> = null;
+
+  constructor(private viewContainerRef: ViewContainerRef, private template: TemplateRef<T>) {}
+
+  ngOnInit(): void {
+    // Templates are not rendered by default
+    this.viewContainerRef.createEmbeddedView(this.template);
+  }
+
+  ngOnChanges(): void {
+    if (this.loading) {
+      this.loadingIndicatorRef = this.viewContainerRef.createEmbeddedView(this.loadingIndicator);
+    }
+
+    if (!this.loading && this.loadingIndicatorRef) {
+      this.loadingIndicatorRef.destroy();
+    }
+  }
+}

--- a/libs/perun/models/src/index.ts
+++ b/libs/perun/models/src/index.ts
@@ -12,3 +12,4 @@ export * from './lib/GroupWithStatus';
 export * from './lib/ResourceWithStatus';
 export * from './lib/AttributeForm';
 export * from './lib/ConfigProperties';
+export * from './lib/DynamicDataSource';

--- a/libs/perun/models/src/lib/DynamicDataSource.ts
+++ b/libs/perun/models/src/lib/DynamicDataSource.ts
@@ -1,0 +1,143 @@
+import { DataSource } from '@angular/cdk/collections';
+import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
+import { MatSort, Sort } from '@angular/material/sort';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+import { startWith, switchMap } from 'rxjs/operators';
+
+export interface PageQuery {
+  pageSize?: number;
+  offset?: number;
+  order?: 'ASCENDING' | 'DESCENDING';
+  sortColumn?: string;
+  searchString?: string;
+}
+
+export function isDynamicDataSource<T>(
+  source: MatTableDataSource<T> | DynamicDataSource<T>
+): source is DynamicDataSource<T> {
+  return `_count` in source;
+}
+
+/**
+ * Data source that supports server-side filtering, sorting and pagination.
+ * This data source does NOT implement these operations but emits filter, sort and page changes.
+ *
+ * Dependent on `@angular/material`
+ */
+export class DynamicDataSource<T> implements DataSource<T> {
+  pageQuery$ = new BehaviorSubject<PageQuery>({});
+  updateSubscription: Subscription | null = null;
+
+  private data$ = new BehaviorSubject<T[]>([]);
+  private _count: number;
+  private _filter = new BehaviorSubject<string>('');
+  private _sort: MatSort;
+  private _paginator: MatPaginator;
+
+  constructor(data: T[], count: number, ms: MatSort, mp: MatPaginator) {
+    this.data$.next(data);
+    this._count = count;
+    this._sort = ms;
+    this._paginator = mp;
+    this.update();
+  }
+
+  /* eslint-disable @typescript-eslint/member-ordering */
+  // Here ordering is disabled since it has unwanted interaction, setters and getters should be adjacent
+  get data(): T[] {
+    return this.data$.value;
+  }
+  set data(data: T[]) {
+    this.data$.next(data);
+  }
+
+  get filteredData(): T[] {
+    return this.data$.value;
+  }
+
+  get count(): number {
+    return this._count;
+  }
+  set count(count: number) {
+    this._count = count;
+  }
+
+  get sort(): MatSort {
+    return this._sort;
+  }
+  set sort(ms: MatSort) {
+    this._sort = ms;
+    this.update();
+  }
+
+  get paginator(): MatPaginator {
+    return this._paginator;
+  }
+  set paginator(mp: MatPaginator) {
+    this._paginator = mp;
+    this.update();
+  }
+
+  set filter(value: string) {
+    this._filter.next(value);
+  }
+  /* eslint-enable @typescript-eslint/member-ordering */
+
+  connect(): Observable<T[]> {
+    return this.data$.asObservable();
+  }
+
+  disconnect(): void {
+    this.data$.complete();
+    this.updateSubscription?.unsubscribe();
+  }
+
+  // For compatibility with MatTableDataSource
+  sortData(filteredData: T[], sort: MatSort): T[] {
+    this.sort = sort;
+    return filteredData;
+  }
+
+  /**
+   * Updates all streams combined to get query page.
+   * Triggers when sort or paginator is changed.
+   */
+  update(): void {
+    // React to sort changes
+    const sortChange: Observable<Sort> = this._sort.sortChange.pipe(
+      startWith({ active: 'NAME', direction: this._sort.direction })
+    );
+
+    // React to page changes
+    const pageChange: Observable<PageEvent> = this._paginator.page.pipe(
+      startWith({
+        pageSize: 5,
+        pageIndex: this._paginator.pageIndex,
+        length: this._paginator.length,
+      })
+    );
+
+    // Combine sort, page and filter state
+    // Each stream has to emit at least once for `combineLatest` to emit
+    const query: Observable<PageQuery> = combineLatest([sortChange, pageChange, this._filter]).pipe(
+      // Switch map ensures that with new changes, old request is canceled
+      // Prevents older long request to override shorter new one
+      switchMap(([sort, page, filter]) => {
+        return of({
+          order: sort.direction === 'asc' ? 'ASCENDING' : 'DESCENDING',
+          sortColumn: sort.active.toUpperCase(),
+          pageSize: page.pageSize,
+          offset: page.pageIndex * page.pageSize,
+          searchString: filter,
+        } as PageQuery);
+      })
+    );
+
+    // Dispose of old subscription and set up new one
+    this.updateSubscription?.unsubscribe();
+    this.updateSubscription = query.subscribe((searchQuery) => {
+      this.pageQuery$.next(searchQuery);
+    });
+  }
+}

--- a/libs/perun/pipes/src/index.ts
+++ b/libs/perun/pipes/src/index.ts
@@ -26,3 +26,4 @@ export * from './lib/localised-text.pipe';
 export * from './lib/delete-dialog-type.pipe';
 export * from './lib/disabled-candidate-tooltip.pipe';
 export * from './lib/disable-unique-attribute.pipe';
+export * from './lib/disable-group-select.pipe';

--- a/libs/perun/pipes/src/lib/can-manage-group.pipe.ts
+++ b/libs/perun/pipes/src/lib/can-manage-group.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Group } from '@perun-web-apps/perun/openapi';
+import { GuiAuthResolver } from '@perun-web-apps/perun/services';
+
+@Pipe({
+  name: 'canManageGroup',
+})
+export class CanManageGroupPipe implements PipeTransform {
+  constructor(private authResolver: GuiAuthResolver) {}
+
+  transform(group: Group): boolean {
+    return (
+      this.authResolver.isThisGroupAdmin(group.id) || this.authResolver.isThisVoAdmin(group.voId)
+    );
+  }
+}

--- a/libs/perun/pipes/src/lib/disable-group-select.pipe.ts
+++ b/libs/perun/pipes/src/lib/disable-group-select.pipe.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Group } from '@perun-web-apps/perun/openapi';
+import { isGroupSynchronized } from '@perun-web-apps/perun/utils';
+
+@Pipe({
+  name: 'disableGroupSelect',
+})
+export class DisableGroupSelectPipe implements PipeTransform {
+  transform(
+    group: Group,
+    disableMemberGroup: boolean,
+    disableGroup: boolean,
+    disableSet: Set<number>
+  ): boolean {
+    return (
+      (disableMemberGroup && group.name === 'members') ||
+      (disableGroup && (disableSet.has(group.id) || isGroupSynchronized(group)))
+    );
+  }
+}

--- a/libs/perun/pipes/src/lib/find-attribute.pipe.ts
+++ b/libs/perun/pipes/src/lib/find-attribute.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { findAttribute } from '@perun-web-apps/perun/utils';
+import { Attribute } from '@perun-web-apps/perun/openapi';
+
+@Pipe({
+  name: 'findAttribute',
+})
+export class FindAttributePipe implements PipeTransform {
+  transform(attributes: Attribute[], friendlyName: string): string {
+    return findAttribute(attributes, friendlyName);
+  }
+}

--- a/libs/perun/pipes/src/lib/group-checkbox-tooltip.pipe.ts
+++ b/libs/perun/pipes/src/lib/group-checkbox-tooltip.pipe.ts
@@ -1,0 +1,22 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { GroupWithStatus } from '@perun-web-apps/perun/models';
+import { isGroupSynchronized } from '@perun-web-apps/perun/utils';
+
+@Pipe({
+  name: 'groupCheckboxTooltip',
+})
+export class GroupCheckboxTooltipPipe implements PipeTransform {
+  transform(group: GroupWithStatus, relation: boolean): string {
+    if (relation) {
+      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.CREATE_RELATION_AUTH_TOOLTIP';
+    } else if (isGroupSynchronized(group)) {
+      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.SYNCHRONIZED_GROUP';
+    } else if (group.sourceGroupId) {
+      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.INDIRECT_GROUP';
+    } else if (group.name === 'members') {
+      return '';
+    } else {
+      return 'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.ALREADY_MEMBER_TOOLTIP';
+    }
+  }
+}

--- a/libs/perun/pipes/src/lib/perun-pipes.module.ts
+++ b/libs/perun/pipes/src/lib/perun-pipes.module.ts
@@ -41,6 +41,10 @@ import { DisplayedRolePipe } from './displayed-role.pipe';
 import { DisableUniqueAttributePipe } from './disable-unique-attribute.pipe';
 import { GroupStatusIconColorPipe } from './group-status-icon-color';
 import { IsAllSelectedPipe } from './is-all-selected.pipe';
+import { FindAttributePipe } from './find-attribute.pipe';
+import { CanManageGroupPipe } from './can-manage-group.pipe';
+import { DisableGroupSelectPipe } from './disable-group-select.pipe';
+import { GroupCheckboxTooltipPipe } from './group-checkbox-tooltip.pipe';
 
 @NgModule({
   declarations: [
@@ -86,6 +90,10 @@ import { IsAllSelectedPipe } from './is-all-selected.pipe';
     DisplayedRolePipe,
     DisableUniqueAttributePipe,
     IsAllSelectedPipe,
+    FindAttributePipe,
+    CanManageGroupPipe,
+    DisableGroupSelectPipe,
+    GroupCheckboxTooltipPipe,
   ],
   exports: [
     ResourceTagsToStringPipe,
@@ -130,6 +138,10 @@ import { IsAllSelectedPipe } from './is-all-selected.pipe';
     DisplayedRolePipe,
     DisableUniqueAttributePipe,
     IsAllSelectedPipe,
+    FindAttributePipe,
+    CanManageGroupPipe,
+    DisableGroupSelectPipe,
+    GroupCheckboxTooltipPipe,
   ],
   imports: [CommonModule],
 })

--- a/libs/perun/services/src/index.ts
+++ b/libs/perun/services/src/index.ts
@@ -23,3 +23,4 @@ export { RoutePolicyService } from './lib/route-policy.service';
 export { AttributeRightsService } from './lib/attribute-rights.service';
 export { MfaApiService } from './lib/mfa-api.service';
 export { MfaHandlerService } from './lib/mfa-handler.service';
+export { GroupUtilsService } from './lib/group-utils.service';

--- a/libs/perun/services/src/lib/group-utils.service.ts
+++ b/libs/perun/services/src/lib/group-utils.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import { GroupWithStatus } from '@perun-web-apps/perun/models';
+import { getGroupExpiration, parseDate } from '@perun-web-apps/perun/utils';
+import { formatDate } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GroupUtilsService {
+  getDataForColumn: (
+    data: GroupWithStatus,
+    column: string,
+    voNames?: Map<number, string>
+  ) => string = (data, column, voNames) => {
+    switch (column) {
+      case 'id':
+        return data.id.toString();
+      case 'vo':
+        return voNames.get(data.voId);
+      case 'name':
+        return data.name;
+      case 'description':
+        return data.description;
+      case 'expiration': {
+        const expirationStr = getGroupExpiration(data);
+        return parseDate(expirationStr);
+      }
+      case 'recent':
+        return '';
+      case 'status':
+        return data.status;
+      case 'uuid':
+        return data.uuid;
+      default:
+        return data[column] as string;
+    }
+  };
+
+  getSortDataForColumn: (
+    data: GroupWithStatus,
+    column: string,
+    voNames: Map<number, string>,
+    recentIds: number[]
+  ) => string = (data, column, voNames, recentIds) => {
+    switch (column) {
+      case 'id':
+        return data.id.toString();
+      case 'vo':
+        return voNames.get(data.voId);
+      case 'name':
+        return data.name;
+      case 'description':
+        return data.description;
+      case 'expiration': {
+        const expirationStr = getGroupExpiration(data);
+        if (!expirationStr || expirationStr.toLowerCase() === 'never') {
+          return expirationStr;
+        }
+        return formatDate(expirationStr, 'yyyy.MM.dd', 'en');
+      }
+      case 'recent':
+        if (recentIds) {
+          if (recentIds.includes(data.id)) {
+            return '#'.repeat(recentIds.indexOf(data.id));
+          }
+        }
+        return data['name'];
+      case 'status':
+        return data.status;
+      default:
+        return data[column] as string;
+    }
+  };
+}

--- a/libs/perun/services/src/lib/gui-auth-resolver.service.ts
+++ b/libs/perun/services/src/lib/gui-auth-resolver.service.ts
@@ -85,7 +85,7 @@ export class GuiAuthResolver {
     if (this.principal.roles[role]) {
       //console.log(this.principal.roles[role]);
       if (this.principal.roles[role][convertedBeanName]) {
-        return this.principal.roles[role][convertedBeanName].includes(Number(id.toString()));
+        return this.principal.roles[role][convertedBeanName].includes(id);
       }
     }
     return false;

--- a/libs/perun/services/src/lib/table-checkbox.service.ts
+++ b/libs/perun/services/src/lib/table-checkbox.service.ts
@@ -1,7 +1,8 @@
-import { SelectionModel } from '@angular/cdk/collections';
 import { Injectable } from '@angular/core';
-import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
+import { MatSort } from '@angular/material/sort';
+import { SelectionModel } from '@angular/cdk/collections';
+import { DynamicDataSource } from '@perun-web-apps/perun/models';
 
 @Injectable({
   providedIn: 'root',
@@ -88,6 +89,48 @@ export class TableCheckbox {
         }
 
         this.pageIterator++;
+      });
+    }
+  }
+
+  /**
+   * Determines if all rendered rows are selected.
+   *
+   * @param dataSource Dynamic data source
+   * @param selectedCount number of selected rows
+   * @param canBeSelected By default all rows can be selected
+   */
+  isAllSelectedPaginated<T>(
+    dataSource: DynamicDataSource<T>,
+    selectedCount: number,
+    canBeSelected: (T) => boolean = (): boolean => true
+  ): boolean {
+    return (
+      selectedCount ===
+      dataSource.data.reduce((acc: number, val: T) => acc + Number(canBeSelected(val)), 0)
+    );
+  }
+
+  /**
+   * Handles the (de)select all actions
+   *
+   * @param dataSource Dynamic data source
+   * @param selection Selection model
+   * @param selectAll Flag, all rows to be selected
+   * @param canBeSelected By default all rows can be selected
+   */
+  masterTogglePaginated<T>(
+    dataSource: DynamicDataSource<T>,
+    selection: SelectionModel<T>,
+    selectAll: boolean,
+    canBeSelected: (T) => boolean = (): boolean => true
+  ): void {
+    selection.clear();
+    if (selectAll) {
+      dataSource.data.forEach((row) => {
+        if (canBeSelected(row)) {
+          selection.select(row);
+        }
       });
     }
   }

--- a/libs/perun/utils/src/lib/perun-utils.ts
+++ b/libs/perun/utils/src/lib/perun-utils.ts
@@ -13,7 +13,6 @@ import {
   ApplicationMail,
   ApplicationFormItem,
   RichGroup,
-  Author,
   Facility,
   Vo,
   Resource,
@@ -723,15 +722,13 @@ export function customDataSourceFilterPredicate<T>(
   return dataStr.toLowerCase().includes(filter);
 }
 
-export function parseAttribute(data: Author, nameOfAttribute: string): string {
+export function findAttribute(attributes: Attribute[], friendlyName: string): string {
   let attribute = '';
-  if (data.attributes) {
-    data.attributes.forEach((attr) => {
-      if (attr.friendlyName === nameOfAttribute) {
-        attribute = attr.value as string;
-      }
-    });
-  }
+  attributes?.forEach((attr) => {
+    if (attr.friendlyName === friendlyName) {
+      attribute = attr.value as string;
+    }
+  });
   return attribute;
 }
 

--- a/libs/perun/utils/src/lib/table-wrapper/table-wrapper.component.ts
+++ b/libs/perun/utils/src/lib/table-wrapper/table-wrapper.component.ts
@@ -40,6 +40,8 @@ export class TableWrapperComponent implements OnInit {
     if (this.pageSizeOptions === null) {
       this.pageSize = 5;
     }
+
+    this.paginator._changePageSize(this.pageSize); // Ensures that any subscriber to MatPaginator page event will get correct initial page size
   }
 
   pageChangedTop(event: PageEvent): void {


### PR DESCRIPTION
Within the group-list
* replaced function calls with pipes
* no redundant reactions to changes
* moved the remove authorization to corresponding components
* removed unused code

Created DynamicDataSource in `perun-models` to handle filter, sort and pagination changes, this data source should be used instead of the existing one. Example usage of new data source was implemented in group-list, it does not require to duplicate table logic as the existing one.