### PR TITLE
fix(admin): fixed a bug where checkboxes were disabled in group members page

### DIFF
--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
@@ -34,7 +34,7 @@
             [aria-label]="checkboxLabel(member)"
             [checked]="selection.isSelected(member)"
             attr.data-cy="{{member.user.firstName | lowercase}}-checkbox"
-            [disabled]="(member | memberListCheckboxDisabled)"
+            [disabled]="(groupId === undefined) && (member | memberListCheckboxDisabled)"
             [matTooltip]="(member | memberCheckboxLabel)"
             color="primary">
           </mat-checkbox>


### PR DESCRIPTION
Previous solution didn't cause problems, since the group members page didn't provide the Lifecycle attribute to dynamic members list, however with https://github.com/CESNET/perun-web-apps/pull/1083 its now necessary and this bug was revealed.