### PR TITLE
feat(profile): add advanced MFA settings

### DIFF
--- a/apps/user-profile/src/app/app.module.ts
+++ b/apps/user-profile/src/app/app.module.ts
@@ -81,6 +81,7 @@ import { ConsentsPreviewComponent } from './pages/consents-page/consents-preview
 import { SettingsLocalAccountComponent } from './pages/settings-page/settings-local-account/settings-local-account.component';
 import { ActivateLocalAccountDialogComponent } from './components/dialogs/activate-local-account-dialog/activate-local-account-dialog.component';
 import { PerunNamespacePasswordFormModule } from '@perun-web-apps/perun/namespace-password-form';
+import { MfaSettingsComponent } from './pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component';
 
 export const API_INTERCEPTOR_PROVIDER: Provider = {
   provide: HTTP_INTERCEPTORS,
@@ -142,6 +143,7 @@ const loadConfigs: (appConfig: UserProfileConfigService) => () => Promise<void> 
     ConsentsPreviewComponent,
     SettingsLocalAccountComponent,
     ActivateLocalAccountDialogComponent,
+    MfaSettingsComponent,
   ],
   imports: [
     BrowserModule,

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component.html
@@ -1,0 +1,49 @@
+<mat-spinner class="ml-auto mr-auto mt-2" *ngIf="loadingMfa"></mat-spinner>
+<div [hidden]="loadingMfa">
+  <span
+    [matTooltip]="'AUTHENTICATION.MFA_DISABLED' | customTranslate | translate"
+    [matTooltipDisabled]="mfaAvailable"
+    matTooltipPosition="right">
+    <mat-slide-toggle [disabled]="!mfaAvailable" (toggleChange)="toggleEnableMfa()" #toggle
+      >{{'AUTHENTICATION.MFA_TOGGLE' | customTranslate | translate}}
+      <button
+        mat-icon-button
+        class="ml-2 mr-3"
+        (click)="showDetailSettings()"
+        [disabled]="!mfaAvailable">
+        <mat-icon>{{showDetail ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}}</mat-icon>
+      </button>
+    </mat-slide-toggle>
+  </span>
+  <button
+    mat-flat-button
+    color="accent"
+    (click)="saveSettings()"
+    [disabled]="unchangedSettings && unchangedEnforce">
+    {{'AUTHENTICATION.MFA_SAVE'|translate}}
+  </button>
+  <div *ngIf="showDetail">
+    <div *ngFor="let category of categories | keyvalue">
+      <mat-slide-toggle
+        [checked]="category.value.value"
+        class="ml-4"
+        (toggleChange)="toggleCategory(category.value)">
+        {{category.value.label[this.translate.currentLang]}}
+        <button mat-icon-button (click)="category.value.show = !category.value.show">
+          <mat-icon>{{category.value.show ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}}</mat-icon>
+        </button>
+      </mat-slide-toggle>
+      <div *ngIf="category.value.show">
+        <div *ngFor="let rps of category?.value['rps'] | keyvalue">
+          <mat-slide-toggle
+            [checked]="category?.value['rps_value'][rps.key]"
+            (toggleChange)="toggleRps(category, rps.key)"
+            class="ml-5">
+            {{rps.value[this.translate.currentLang]}}
+          </mat-slide-toggle>
+        </div>
+      </div>
+    </div>
+  </div>
+  <mat-spinner class="ml-auto mr-auto mt-2" *ngIf="loadingCategories"></mat-spinner>
+</div>

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component.ts
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component.ts
@@ -1,0 +1,428 @@
+/* eslint-disable
+   @typescript-eslint/no-explicit-any,
+   @typescript-eslint/explicit-module-boundary-types,
+   @typescript-eslint/no-unsafe-member-access,
+   @typescript-eslint/no-unsafe-assignment */
+
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { now } from 'moment-timezone';
+import { AttributesManagerService } from '@perun-web-apps/perun/openapi';
+import { AuthService, MfaApiService, StoreService } from '@perun-web-apps/perun/services';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { HttpClient } from '@angular/common/http';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'perun-web-apps-mfa-settings',
+  templateUrl: './mfa-settings.component.html',
+  styleUrls: ['./mfa-settings.component.scss'],
+})
+export class MfaSettingsComponent implements OnInit {
+  @ViewChild('toggle') toggle: MatSlideToggle;
+
+  mfaAvailable = false;
+  loadingMfa = false;
+
+  enforceMfa: boolean;
+  showDetail = false;
+  loadingCategories = false;
+  includeCategories: string[] = [];
+  excludeRps: string[] = [];
+  allCategories = false;
+  unchangedSettings = true;
+  unchangedEnforce = true;
+
+  categories = {};
+
+  constructor(
+    public translate: TranslateService,
+    private attributesManagerService: AttributesManagerService,
+    private store: StoreService,
+    private oauthService: OAuthService,
+    private authService: AuthService,
+    private httpClient: HttpClient,
+    private mfaApiService: MfaApiService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadingMfa = true;
+    this.mfaApiService.isMfaAvailable().subscribe(
+      (isAvailable) => {
+        this.mfaAvailable = isAvailable;
+        if (isAvailable) {
+          this.loadMfa();
+        } else {
+          this.loadingMfa = false;
+        }
+      },
+      (err) => {
+        console.error(err);
+        this.loadingMfa = false;
+      }
+    );
+  }
+
+  /**
+   * If mfa_route has value in the session storage, it means that application was reloaded
+   * and now the application should finish some PUT action which requires valid id token
+   */
+  loadMfa(): void {
+    const mfaRoute = sessionStorage.getItem('mfa_route');
+    if (mfaRoute) {
+      const enforceMfa = sessionStorage.getItem('enforce_mfa');
+      if (enforceMfa) {
+        this.changeEnforceMfa(enforceMfa === 'true');
+      }
+
+      const settingsMfa = sessionStorage.getItem('settings_mfa');
+      if (settingsMfa) {
+        this.updateDetailSettings();
+      }
+    } else {
+      // load enforce_mfa from attribute
+      const enforceMfaAttributeName = this.store.get('mfa', 'enforce_mfa_attribute') as string;
+      this.attributesManagerService
+        .getUserAttributeByName(this.store.getPerunPrincipal().userId, enforceMfaAttributeName)
+        .subscribe(
+          (attr) => {
+            if (attr.value) {
+              this.enforceMfa = true;
+              this.toggle.toggle();
+            } else {
+              this.enforceMfa = false;
+            }
+            this.loadingMfa = false;
+          },
+          (e) => {
+            console.error(e);
+            this.loadingMfa = false;
+          }
+        );
+    }
+  }
+
+  /**
+   * This method loads all available categories from the mfa api and current settings
+   */
+  getCategoriesAndSettings(): void {
+    this.loadingCategories = true;
+    this.mfaApiService.getCategories().subscribe(
+      (categories) => {
+        this.categories = categories;
+        this.getSettings();
+      },
+      (err) => {
+        console.error(err);
+        this.loadingCategories = false;
+      }
+    );
+  }
+
+  /**
+   * This method loads current categories/rps mfa settings
+   */
+  getSettings(): void {
+    if (!this.unchangedEnforce) {
+      // if enforce mfa for all services is changed before categories and settings are loaded
+      this.includeCategories = [];
+      this.allCategories = this.toggle.checked;
+      this.setValuesFromSetting();
+      this.showDetail = !this.showDetail;
+      this.loadingCategories = false;
+    } else {
+      this.mfaApiService.getSettings().subscribe(
+        (settings) => {
+          if (settings.length !== 0) {
+            if (settings.all) {
+              this.allCategories = true;
+            } else {
+              this.includeCategories = settings['include_categories']
+                ? settings['include_categories']
+                : [];
+              this.excludeRps = settings['exclude_rps'] ? settings['exclude_rps'] : [];
+            }
+          }
+          this.setValuesFromSetting();
+          this.showDetail = !this.showDetail;
+          this.loadingCategories = false;
+        },
+        (err) => {
+          console.error(err);
+          this.loadingCategories = false;
+        }
+      );
+    }
+  }
+
+  /**
+   * Sets values for mfa api to object - these values in object are represented by toggles
+   */
+  setValuesFromSetting(): void {
+    if (this.includeCategories.length === 0) {
+      // for all categories and for no category in the settings
+      const value = this.allCategories;
+      for (const category in this.categories) {
+        this.categories[category].value = value;
+        this.categories[category].show = false; // if the sub toggles are showed in GUI or not
+        this.categories[category].rps_value = {};
+        for (const service in this.categories[category].rps) {
+          this.categories[category].rps_value[service] = value;
+        }
+      }
+    } else {
+      // for some included categories with some excluded rps
+      for (const category in this.categories) {
+        this.categories[category].value = this.includeCategories.includes(category);
+        this.categories[category].show = false;
+        this.categories[category].rps_value = {};
+        for (const rps in this.categories[category].rps) {
+          this.categories[category].rps_value[rps] = this.categories[category].value
+            ? !this.excludeRps.includes(rps)
+            : false;
+        }
+      }
+    }
+  }
+
+  /**
+   * Shows all categories and services (rps) and allow to change their values
+   * If user clicks on more detail button (arrow button) first time, this method will load all categories and settings
+   */
+  showDetailSettings(): void {
+    if (!this.showDetail && Object.keys(this.categories).length === 0) {
+      this.getCategoriesAndSettings();
+    } else {
+      this.showDetail = !this.showDetail;
+    }
+  }
+
+  toggleEnableMfa(): void {
+    this.unchangedEnforce = false;
+    this.includeCategories = [];
+    this.allCategories = !this.toggle.checked;
+    this.setValuesFromSetting();
+  }
+
+  toggleCategory(categoryValue: any, skipServices = false): void {
+    this.unchangedSettings = false;
+    // deselect toggle mfa for all categories
+    if (this.checkAllCategoriesSelected() && this.toggle.checked && !skipServices) {
+      this.toggle.toggle();
+    }
+
+    categoryValue.value = !categoryValue.value;
+    if (!skipServices) {
+      for (const rps in categoryValue.rps_value) {
+        categoryValue.rps_value[rps] = categoryValue.value;
+      }
+    }
+
+    // select toggle mfa for all categories
+    if (this.checkAllCategoriesSelected() && !this.toggle.checked && !skipServices) {
+      this.toggle.toggle();
+    }
+  }
+
+  checkAllCategoriesSelected(): boolean {
+    let allTrueCheck = true;
+    for (const category in this.categories) {
+      if (!this.categories[category].value) {
+        allTrueCheck = false;
+      }
+    }
+    return allTrueCheck;
+  }
+
+  toggleRps(category: any, rps: any): void {
+    rps = String(rps);
+    this.unchangedSettings = false;
+    // select toggle mfa for category
+    if (this.checkAllRpsDeselectedForCategory(String(category.key))) {
+      this.toggleCategory(category.value, true);
+    }
+
+    // deselect toggle mfa for all categories
+    if (this.checkAllRpsSelected()) {
+      this.toggle.toggle();
+    }
+
+    category.value['rps_value'][rps] = !category.value['rps_value'][rps];
+
+    // deselect toggle mfa for category
+    if (this.checkAllRpsDeselectedForCategory(String(category.key))) {
+      this.toggleCategory(category.value, true);
+    }
+
+    // select toggle mfa for all categories
+    if (this.checkAllRpsSelected()) {
+      this.toggle.toggle();
+    }
+  }
+
+  checkAllRpsDeselectedForCategory(category: string): boolean {
+    let allFalseCheck = true;
+    for (const rps in this.categories[category]['rps']) {
+      if (this.categories[category].rps_value[rps]) {
+        allFalseCheck = false;
+      }
+    }
+    return allFalseCheck;
+  }
+
+  checkAllRpsSelected(): boolean {
+    let allTrueCheck = true;
+
+    for (const category in this.categories) {
+      if (!this.categories[category].value) {
+        return false;
+      }
+      for (const rps in this.categories[category]['rps']) {
+        if (!this.categories[category].rps_value[rps]) {
+          allTrueCheck = false;
+        }
+      }
+    }
+
+    return allTrueCheck;
+  }
+
+  /**
+   * This method fires logic for setting new values of enforceMfa and settings
+   */
+  saveSettings(enforceFirstMfa = false): void {
+    if (this.oauthService.getIdTokenExpiration() - now() > 0 && !enforceFirstMfa) {
+      if (this.enforceMfa !== this.toggle.checked) {
+        this.loadingMfa = true;
+        this.changeEnforceMfa(this.toggle.checked);
+      }
+      if (!this.unchangedSettings) {
+        this.loadingMfa = true;
+        this.saveDetailSettings();
+        this.updateDetailSettings();
+      }
+    } else {
+      this.saveEnforceMfa();
+      if (!this.unchangedSettings) {
+        this.saveDetailSettings();
+      }
+      this.reAuthenticate();
+    }
+  }
+
+  saveEnforceMfa(): void {
+    if (this.enforceMfa !== this.toggle.checked) {
+      sessionStorage.setItem('enforce_mfa', this.toggle.checked.toString());
+    }
+  }
+
+  /**
+   * This method creates request body for new settings according to toggles
+   */
+  saveDetailSettings(): void {
+    let allTrueCheck = true;
+    let allFalseCheck = false;
+    this.includeCategories = [];
+    this.excludeRps = [];
+
+    for (const category in this.categories) {
+      if (this.categories[category].value) {
+        allFalseCheck = true;
+        this.includeCategories.push(category);
+      } else {
+        allTrueCheck = false;
+        continue;
+      }
+      for (const rps in this.categories[category]['rps']) {
+        if (this.categories[category].rps_value[rps]) {
+          allFalseCheck = true;
+        } else {
+          allTrueCheck = false;
+          this.excludeRps.push(rps);
+        }
+      }
+    }
+
+    let body: string;
+
+    if (allTrueCheck === allFalseCheck) {
+      if (allTrueCheck) {
+        body = JSON.stringify({ all: true });
+      } else {
+        body = '{}';
+      }
+    } else {
+      body = JSON.stringify({
+        include_categories: this.includeCategories,
+        exclude_rps: this.excludeRps,
+      });
+    }
+
+    sessionStorage.setItem('settings_mfa', body);
+  }
+
+  /**
+   * This method is used when we want to do some PUT operation, but we need new (not expired) id token
+   */
+  reAuthenticate(): void {
+    sessionStorage.setItem('mfa_route', '/profile/settings/auth');
+    this.oauthService.logOut(true);
+    sessionStorage.setItem('auth:redirect', location.pathname);
+    sessionStorage.setItem('auth:queryParams', location.search.substring(1));
+    this.authService.loadConfigData();
+    void this.oauthService.loadDiscoveryDocumentAndLogin();
+  }
+
+  /**
+   * This method turns on/off enforceMfa flag
+   * @param enforceMfa turn on/off mfa for all services according to toggle
+   */
+  changeEnforceMfa(enforceMfa: boolean): void {
+    this.mfaApiService.enforceMfaForAllServices(enforceMfa).subscribe(
+      () => {
+        if (enforceMfa) {
+          this.enforceMfa = true;
+          if (!this.toggle.checked) {
+            this.toggle.toggle();
+          }
+        } else {
+          this.enforceMfa = false;
+        }
+        this.unchangedSettings = true;
+        this.unchangedEnforce = true;
+        sessionStorage.removeItem('enforce_mfa');
+        sessionStorage.removeItem('mfa_route');
+        this.loadingMfa = false;
+      },
+      (err) => {
+        // when token is valid, but user is logged in without MFA -> enforce MFA
+        if (err.error.error === 'MFA is required') {
+          this.saveSettings(true);
+        }
+      }
+    );
+  }
+
+  /**
+   * This method updates settings of enforced mfa for categories and services
+   */
+  updateDetailSettings(): void {
+    const body = sessionStorage.getItem('settings_mfa');
+
+    this.mfaApiService.updateDetailSettings(body).subscribe(
+      () => {
+        this.unchangedSettings = true;
+        this.unchangedEnforce = true;
+        sessionStorage.removeItem('settings_mfa');
+        sessionStorage.removeItem('mfa_route');
+        this.loadingMfa = false;
+      },
+      (err) => {
+        // when token is valid, but user is logged in without MFA -> enforce MFA
+        if (err.error.error === 'MFA is required') {
+          this.saveSettings(true);
+        }
+      }
+    );
+  }
+}

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
@@ -1,4 +1,4 @@
-<div [hidden]="loadingMfa || loadingImg">
+<div [hidden]="loadingImg">
   <div class="mb-5" *ngIf="displayImageBlock">
     <h1 class="page-subtitle">{{'AUTHENTICATION.TITLE' | customTranslate | translate}}</h1>
     <p>{{'AUTHENTICATION.ANTI_PHISHING_INFO' | customTranslate | translate}}</p>
@@ -18,21 +18,11 @@
   </div>
 
   <h1 class="page-subtitle">{{'AUTHENTICATION.MFA' | customTranslate | translate}}</h1>
-  <span
-    [matTooltip]="'AUTHENTICATION.MFA_DISABLED' | customTranslate | translate"
-    [matTooltipDisabled]="mfaAvailable"
-    matTooltipPosition="right">
-    <mat-slide-toggle
-      [disabled]="!mfaAvailable"
-      #toggle
-      color="primary"
-      >{{'AUTHENTICATION.MFA_TOGGLE' | customTranslate | translate}}</mat-slide-toggle
-    >
-  </span>
 
-  <br />
-  <button mat-flat-button class="mt-3" (click)="redirectToMfa()" color="accent">
+  <button mat-flat-button (click)="redirectToMfa()" color="accent" class="mb-2">
     {{'AUTHENTICATION.MFA_INFO'|translate}}
   </button>
+  <br />
+  <perun-web-apps-mfa-settings></perun-web-apps-mfa-settings>
 </div>
-<mat-spinner class="ml-auto mr-auto" *ngIf="loadingMfa || loadingImg"></mat-spinner>
+<mat-spinner class="ml-auto mr-auto" *ngIf="loadingImg"></mat-spinner>

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -164,6 +164,7 @@
     "MFA": "Vícefázové ověření",
     "MFA_TOGGLE": "Zapnout vícefázové ověření pro všechny služby",
     "MFA_DISABLED": "Potřebujete mít alespoň jeden aktivní MFA token.",
+    "MFA_SAVE": "Uložit nastavení",
     "NEW_IMG": "Nový obrázek",
     "DELETE_IMG": "Vymazat obrázek",
     "ANTI_PHISHING_INFO": "Tento bezpečnostní obrázek se vám ukáže před tím, než zadáte heslo, ujistíte se tak, že se nepřihlašujete na podvrženou stránku",

--- a/apps/user-profile/src/assets/i18n/en.json
+++ b/apps/user-profile/src/assets/i18n/en.json
@@ -164,6 +164,7 @@
     "MFA": "Multi-factor authentication",
     "MFA_TOGGLE": "Turn on multi-factor authentication for all services",
     "MFA_DISABLED": "You need to have at least one active MFA token.",
+    "MFA_SAVE": "Save settings",
     "NEW_IMG": "New image",
     "DELETE_IMG": "Delete image",
     "ANTI_PHISHING_INFO": "You will be shown this security image before you enter your password so you will know that you are visiting the right site",

--- a/libs/perun/services/src/index.ts
+++ b/libs/perun/services/src/index.ts
@@ -21,3 +21,4 @@ export { CustomMatPaginator } from './lib/custom-mat-paginator';
 export { EntityStorageService } from './lib/entity-storage.service';
 export { RoutePolicyService } from './lib/route-policy.service';
 export { AttributeRightsService } from './lib/attribute-rights.service';
+export { MfaApiService } from './lib/mfa-api.service';

--- a/libs/perun/services/src/lib/mfa-api.service.ts
+++ b/libs/perun/services/src/lib/mfa-api.service.ts
@@ -1,0 +1,86 @@
+/* eslint-disable
+   @typescript-eslint/no-explicit-any */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { StoreService } from './store.service';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MfaApiService {
+  mfaApiUrl = this.store.getProperty('mfa').api_url;
+  constructor(
+    private store: StoreService,
+    private oauthService: OAuthService,
+    private httpClient: HttpClient
+  ) {}
+
+  /**
+   * Checks if MFA is available for current user (if user has any MFA token)
+   */
+  isMfaAvailable(): Observable<boolean> {
+    return this.httpClient.get<boolean>(this.mfaApiUrl + 'mfaAvailable', {
+      headers: { Authorization: 'Bearer ' + this.oauthService.getAccessToken() },
+    });
+  }
+
+  /**
+   * This method loads all available categories from the mfa api
+   * NOTE: Each service (rps) belongs to exactly one category.
+   * If some service doesn't have some category in Perun, then belongs to universal category "other".
+   */
+  getCategories(): Observable<any> {
+    return this.httpClient.get<any>(this.mfaApiUrl + 'categories', {
+      headers: { Authorization: 'Bearer ' + this.oauthService.getAccessToken() },
+    });
+  }
+
+  /**
+   * This method loads current categories/rps settings
+   * There are three types of responses, which you can get from mfa api:
+   *    - If all categories and all services (rps) requires mfa
+   *        -> { "all": true }
+   *    - If no category (it means also no rps) require mfa
+   *        -> []
+   *    - Some categories/services (rps) require mfa
+   *        -> {"include_categories": ["category1"]}
+   *        -> {"include_categories": ["category1"], "exclude_rps": ["rps1"]}
+   */
+  getSettings(): Observable<any> {
+    return this.httpClient.get<any>(this.mfaApiUrl + 'settings', {
+      headers: { Authorization: 'Bearer ' + this.oauthService.getAccessToken() },
+    });
+  }
+
+  /**
+   * Enforce MFA for all services (settings = { "all": true })
+   *
+   * NOTE for devel: this method will set also attr value of mfaEnforced:mu,
+   * but currently we need to test this functionality only with production client_id,
+   * so this value will change only on production, not on devel
+   * @param value true/false
+   */
+  enforceMfaForAllServices(value: boolean): Observable<any> {
+    const body = `value=${String(value)}`;
+    return this.httpClient.put(this.mfaApiUrl + 'mfaEnforced', body, {
+      headers: { Authorization: 'Bearer ' + this.oauthService.getAccessToken() },
+    });
+  }
+
+  /**
+   * Updates current settings for categories and services
+   * @param body the same asi getSettings() -> 3 types of possible bodies
+   */
+  updateDetailSettings(body: string): Observable<any> {
+    return this.httpClient.put(this.mfaApiUrl + 'settings', body, {
+      headers: {
+        Authorization: 'Bearer ' + this.oauthService.getAccessToken(),
+        // FIXME: at this time mfa api checks exact match on 'application/json' (without ; at the end)
+        'content-type': 'application/json',
+      },
+    });
+  }
+}


### PR DESCRIPTION
* To the authentication page was added advanced MFA settings. Now is possible to select categories
and services (rps) which requires mfa.
* If enforce mfa is set to true, then all categories are selected and they are not allowed for disabling.
* If enforce mfa (for all services) is set to false, then user can select particular categories and services.

BREAKING CHANGE: For this functionality is required new oauh scope - authn_details in instance
config. Also new version of MFA API which supports this functionality is required.