### PR TITLE
fix: remove redundant symbols

### DIFF
--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
@@ -16,7 +16,6 @@
   color="warn"
   mat-flat-button
   data-cy="remove-group-button">
-  >
   <span
     [matTooltipDisabled]="canRemoveGroups()"
     matTooltip="{{'RESOURCE_DETAIL.ASSIGNED_GROUPS.REMOVE_TOOLTIP' | translate}}">

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-group-from-resource-dialog/remove-group-from-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-group-from-resource-dialog/remove-group-from-resource-dialog.component.html
@@ -31,7 +31,6 @@
       color="warn"
       mat-flat-button
       data-cy="delete-button">
-      >
       {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.DELETE' | translate}}
     </button>
   </div>


### PR DESCRIPTION
Redundant > symbols from html files were removed.