### PR TITLE
fix: prevent mat icons from being clipped

### DIFF
--- a/apps/admin-gui/src/styles.scss
+++ b/apps/admin-gui/src/styles.scss
@@ -1565,3 +1565,7 @@ td.mat-cell {
 .align-checkbox mat-checkbox {
   margin-top: 7px !important;
 }
+
+mat-icon {
+  overflow: inherit !important;
+}

--- a/apps/consolidator/src/styles.scss
+++ b/apps/consolidator/src/styles.scss
@@ -215,3 +215,7 @@ button:focus {
 mat-chip-list {
   pointer-events: none;
 }
+
+mat-icon {
+  overflow: inherit !important;
+}

--- a/apps/linker/src/styles.scss
+++ b/apps/linker/src/styles.scss
@@ -181,3 +181,7 @@ button {
 button:focus {
   outline: none !important;
 }
+
+mat-icon {
+  overflow: inherit !important;
+}

--- a/apps/password-reset/src/styles.scss
+++ b/apps/password-reset/src/styles.scss
@@ -90,3 +90,7 @@ $password-reset-theme: mat.define-light-theme(
 .mat-tooltip {
   font-size: 13px !important;
 }
+
+mat-icon {
+  overflow: inherit !important;
+}

--- a/apps/publications/src/styles.scss
+++ b/apps/publications/src/styles.scss
@@ -320,3 +320,7 @@ $i: 0;
     fill: currentColor;
   }
 }
+
+mat-icon {
+  overflow: inherit !important;
+}

--- a/apps/user-profile/src/styles.scss
+++ b/apps/user-profile/src/styles.scss
@@ -212,3 +212,7 @@ td.mat-cell {
 .noBorderDialog .mat-dialog-container {
   background-color: black;
 }
+
+mat-icon {
+  overflow: inherit !important;
+}


### PR DESCRIPTION
* mat icons now inherit overflow instead of default hidden across all apps