### PR TITLE
fix(admin): vo/group add member dialog now correctly displays logins …

### DIFF
--- a/apps/admin-gui/src/app/vos/components/group-add-member-dialog/group-add-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/vos/components/group-add-member-dialog/group-add-member-dialog.component.ts
@@ -49,7 +49,9 @@ export class GroupAddMemberDialogComponent implements OnInit {
   );
   failed: FailedCandidate[] = [];
   selection: SelectionModel<MemberCandidate> = new SelectionModel<MemberCandidate>(true, []);
-  attrNames: string[] = [Urns.USER_DEF_ORGANIZATION, Urns.USER_DEF_PREFERRED_MAIL];
+  attrNames: string[] = [Urns.USER_DEF_ORGANIZATION, Urns.USER_DEF_PREFERRED_MAIL].concat(
+    this.store.getLoginAttributeNames()
+  );
   languages: string[] = this.store.get('supported_languages') as string[];
 
   constructor(

--- a/apps/admin-gui/src/app/vos/components/vo-add-member-dialog/vo-add-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/vos/components/vo-add-member-dialog/vo-add-member-dialog.component.ts
@@ -40,7 +40,9 @@ export class VoAddMemberDialogComponent {
   );
   failed: FailedCandidate[] = [];
   selection: SelectionModel<MemberCandidate> = new SelectionModel<MemberCandidate>(true, []);
-  attrNames: string[] = [Urns.USER_DEF_ORGANIZATION, Urns.USER_DEF_PREFERRED_MAIL];
+  attrNames: string[] = [Urns.USER_DEF_ORGANIZATION, Urns.USER_DEF_PREFERRED_MAIL].concat(
+    this.store.getLoginAttributeNames()
+  );
   languages: string[] = this.store.get('supported_languages') as string[];
 
   constructor(


### PR DESCRIPTION
…of candidates

* fixed a bug where the 'logins' column in the add member dialog was always empty
* now the 'logins' column displays logins from login attributes defined by 'login_namespace_attributes' in instanceConfig/defaultConfig