### PR TITLE
feat(admin): warning on consents hub page when global consent enforcing is disabled

### DIFF
--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-consent-hubs/admin-consent-hubs.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-consent-hubs/admin-consent-hubs.component.html
@@ -1,16 +1,22 @@
 <div>
   <h1 class="page-subtitle">{{'ADMIN.CONSENT_HUBS.TITLE' | translate}}</h1>
-
+  <perun-web-apps-alert *ngIf="!globalForceConsents" alert_type="warn">
+    {{'ADMIN.CONSENT_HUBS.GLOBAL_DISABLED' | translate}}
+  </perun-web-apps-alert>
   <perun-web-apps-refresh-button (refresh)="refreshTable()"></perun-web-apps-refresh-button>
-  <button
-    *ngIf="authResolver.isPerunAdmin()"
-    (click)="evaluateConsents()"
-    [disabled]="selection.selected.length === 0"
-    color="accent"
-    class="action-button mr-2"
-    mat-flat-button>
-    {{'ADMIN.CONSENT_HUBS.EVALUATE_CONSENTS' | translate}}
-  </button>
+  <span
+    [matTooltipDisabled]="globalForceConsents"
+    matTooltip="{{'ADMIN.CONSENT_HUBS.TOOLTIP' | translate}}">
+    <button
+      *ngIf="authResolver.isPerunAdmin()"
+      (click)="evaluateConsents()"
+      [disabled]="!globalForceConsents || selection.selected.length === 0"
+      color="accent"
+      class="action-button mr-2"
+      mat-flat-button>
+      {{'ADMIN.CONSENT_HUBS.EVALUATE_CONSENTS' | translate}}
+    </button>
+  </span>
   <perun-web-apps-immediate-filter
     [placeholder]="'ADMIN.CONSENT_HUBS.SEARCH'"
     (filter)="applyFilter($event)">

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-consent-hubs/admin-consent-hubs.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-consent-hubs/admin-consent-hubs.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ConsentHub, ConsentsManagerService } from '@perun-web-apps/perun/openapi';
 import { TABLE_CONSENT_HUBS } from '@perun-web-apps/config/table-config';
 import { SelectionModel } from '@angular/cdk/collections';
-import { GuiAuthResolver, NotificatorService } from '@perun-web-apps/perun/services';
+import { GuiAuthResolver, NotificatorService, StoreService } from '@perun-web-apps/perun/services';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { TranslateService } from '@ngx-translate/core';
@@ -19,16 +19,19 @@ export class AdminConsentHubsComponent implements OnInit {
   selection = new SelectionModel<ConsentHub>(true, []);
   filterValue = '';
   consentHubs: ConsentHub[] = [];
+  globalForceConsents: boolean;
 
   constructor(
     private consentsManager: ConsentsManagerService,
     public authResolver: GuiAuthResolver,
     private notificator: NotificatorService,
     private translate: TranslateService,
+    private store: StoreService,
     private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
+    this.globalForceConsents = this.store.getProperty('enforce_consents');
     this.refreshTable();
   }
 

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2296,7 +2296,9 @@
       "CONFIRM_DIALOG_TITLE": "Evaluate consents confirmation",
       "CONFIRM_DIALOG_DESCRIPTION": "Are you sure you want to evaluate consents for all selected consent hubs?",
       "EVALUATION_FINISH": "Consents evaluation completed",
-      "SEARCH": "Search by Id, Name or Facilities"
+      "SEARCH": "Search by Id, Name or Facilities",
+      "GLOBAL_DISABLED": "Global consent enforcing is disabled on this Perun instance, any following changes will have no effect.",
+      "TOOLTIP": "Global consent enforcing is disabled."
     },
     "SEARCHER": {
       "TITLE": "Searcher",

--- a/libs/perun/models/src/lib/ConfigProperties.ts
+++ b/libs/perun/models/src/lib/ConfigProperties.ts
@@ -128,6 +128,7 @@ export interface PerunConfig {
   // Optional
   auto_auth_redirect?: boolean;
   supported_languages?: string[];
+  enforce_consents?: boolean;
   is_devel?: boolean;
   instance_favicon?: boolean;
   log_out_enabled?: boolean;


### PR DESCRIPTION

* if enforce_consents is false on the instance, display a warning informing the user that any changes on the consent hubs page will have no effect
* when consents globally disabled, disabled the 'Evaluate consents' button and added a tooltip