### PR TITLE
feat: catch mfa required error and handle mfa

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -952,6 +952,32 @@
       },
       "tags": []
     },
+    "perun-multi-factor-authentication": {
+      "projectType": "library",
+      "root": "libs/perun/multi-factor-authentication",
+      "sourceRoot": "libs/perun/multi-factor-authentication/src",
+      "prefix": "perun-web-apps",
+      "architect": {
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/perun/multi-factor-authentication"],
+          "options": {
+            "jestConfig": "libs/perun/multi-factor-authentication/jest.config.ts",
+            "passWithNoTests": true
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/perun/multi-factor-authentication/**/*.ts",
+              "libs/perun/multi-factor-authentication/**/*.html"
+            ]
+          }
+        }
+      },
+      "tags": []
+    },
     "perun-namespace-password-form": {
       "$schema": "../../../node_modules/nx/schemas/project-schema.json",
       "projectType": "library",

--- a/apps/admin-gui/src/app/core/services/common/admin-gui-config.service.ts
+++ b/apps/admin-gui/src/app/core/services/common/admin-gui-config.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core';
-import { GuiAuthResolver, InitAuthService } from '@perun-web-apps/perun/services';
+import {
+  GuiAuthResolver,
+  InitAuthService,
+  MfaHandlerService,
+} from '@perun-web-apps/perun/services';
 import { AppConfigService, ColorConfig, EntityColorConfig } from '@perun-web-apps/config';
 import { AuthzResolverService } from '@perun-web-apps/perun/openapi';
 import { MatDialog } from '@angular/material/dialog';
@@ -83,7 +87,8 @@ export class AdminGuiConfigService {
     private authzSevice: AuthzResolverService,
     private dialog: MatDialog,
     private location: Location,
-    private guiAuthResolver: GuiAuthResolver
+    private guiAuthResolver: GuiAuthResolver,
+    private mfaHandlerService: MfaHandlerService
   ) {}
 
   initialize(): Promise<void> {
@@ -100,6 +105,8 @@ export class AdminGuiConfigService {
         if (err === 'Invalid path') {
           this.handleErr(err as string & HttpErrorResponse);
         } else {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+          this.mfaHandlerService.catchNoMfaTokenError(err?.params?.error);
           // if there is another error, it means user probably navigated to /api-callback without logging in
           console.error(err);
           this.location.go('/');
@@ -110,6 +117,9 @@ export class AdminGuiConfigService {
       .then((isAuthenticated) => {
         // if the authentication is successful, continue
         if (isAuthenticated) {
+          // if this application is opened just for MFA, then close the window after MFA is successfully done
+          this.mfaHandlerService.closeMfaWindow();
+
           return this.initAuthService
             .loadPrincipal()
             .catch((err) => this.handleErr(err as string & HttpErrorResponse))

--- a/apps/admin-gui/src/app/facilities/pages/facility-configuration-page/facility-configuration-page.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/facility-configuration-page/facility-configuration-page.component.ts
@@ -240,10 +240,13 @@ export class FacilityConfigurationPageComponent implements OnInit, AfterViewInit
   onRemoveAttributes(): void {
     this.processing = true;
     const ids = this.attSelection.selected.map((att) => att.id);
-    this.attributesManager.removeFacilityAttributes(this.facility.id, ids).subscribe(() => {
-      this.notificator.showSuccess(this.removeMsg);
-      this.getRequiredAttributes();
-      this.processing = false;
+    this.attributesManager.removeFacilityAttributes(this.facility.id, ids).subscribe({
+      next: () => {
+        this.notificator.showSuccess(this.removeMsg);
+        this.getRequiredAttributes();
+        this.processing = false;
+      },
+      error: () => (this.processing = false),
     });
   }
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/connect-identity-dialog/connect-identity-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/connect-identity-dialog/connect-identity-dialog.component.ts
@@ -66,11 +66,14 @@ export class ConnectIdentityDialogComponent implements OnInit {
       specificUser = this.selection.selected[0].id;
     }
 
-    this.userManager.addSpecificUserOwner(owner, specificUser).subscribe(() => {
-      this.notificator.showSuccess(
-        this.translate.instant('DIALOGS.CONNECT_IDENTITY.SUCCESS') as string
-      );
-      this.dialogRef.close(true);
+    this.userManager.addSpecificUserOwner(owner, specificUser).subscribe({
+      next: () => {
+        this.notificator.showSuccess(
+          this.translate.instant('DIALOGS.CONNECT_IDENTITY.SUCCESS') as string
+        );
+        this.dialogRef.close(true);
+      },
+      error: () => (this.loading = false),
     });
   }
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-facility-dialog/create-facility-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-facility-dialog/create-facility-dialog.component.ts
@@ -52,14 +52,17 @@ export class CreateFacilityDialogComponent implements OnInit {
     this.configure = configure;
     this.facilitiesManager
       .createFacility(this.nameControl.value as string, this.descControl.value as string)
-      .subscribe((facility) => {
-        this.entityStorageService.setEntity({ id: facility.id, beanName: facility.beanName });
-        sessionStorage.setItem('newFacilityId', String(facility.id));
-        if (this.srcFacility !== null) {
-          this.copyFacilitySettings(facility.id);
-        } else {
-          this.handleSuccess(facility.id);
-        }
+      .subscribe({
+        next: (facility) => {
+          this.entityStorageService.setEntity({ id: facility.id, beanName: facility.beanName });
+          sessionStorage.setItem('newFacilityId', String(facility.id));
+          if (this.srcFacility !== null) {
+            this.copyFacilitySettings(facility.id);
+          } else {
+            this.handleSuccess(facility.id);
+          }
+        },
+        error: () => (this.loading = false),
       });
   }
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-dialog/delete-attribute-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-dialog/delete-attribute-dialog.component.ts
@@ -158,14 +158,17 @@ export class DeleteAttributeDialogComponent implements OnInit {
         );
         break;
       case 'ues':
-        this.attributesManager.removeUesAttributes(this.data.entityId, ids).subscribe(() => {
-          this.onSuccess();
+        this.attributesManager.removeUesAttributes(this.data.entityId, ids).subscribe({
+          next: () => {
+            this.onSuccess();
+          },
+          error: () => (this.loading = false),
         });
         break;
       case 'resource':
         this.attributesManager
           .removeResourceAttributes(this.data.entityId, ids)
-          .subscribe(() => this.onSuccess());
+          .subscribe({ next: () => this.onSuccess(), error: () => (this.loading = false) });
         break;
     }
   }

--- a/apps/admin-gui/src/app/vos/components/application-detail/application-detail.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-detail/application-detail.component.ts
@@ -249,9 +249,12 @@ export class ApplicationDetailComponent implements OnInit {
           this.notificator.showSuccess(successMessage);
         });
       this.loading = true;
-      this.registrarManager.getApplicationById(this.application.id).subscribe((reloaded) => {
-        this.application = reloaded;
-        this.loading = false;
+      this.registrarManager.getApplicationById(this.application.id).subscribe({
+        next: (reloaded) => {
+          this.application = reloaded;
+          this.loading = false;
+        },
+        error: () => (this.loading = false),
       });
     });
   }

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.ts
@@ -203,11 +203,14 @@ export class GroupSettingsApplicationFormComponent implements OnInit {
   updateFormItems(): void {
     this.loading = true;
     this.refreshApplicationForm = true;
-    this.registrarManager.getFormItemsForGroup(this.group.id).subscribe((formItems) => {
-      this.applicationFormItems = formItems;
-      this.itemsChanged = false;
-      this.refreshApplicationForm = false;
-      this.loading = false;
+    this.registrarManager.getFormItemsForGroup(this.group.id).subscribe({
+      next: (formItems) => {
+        this.applicationFormItems = formItems;
+        this.itemsChanged = false;
+        this.refreshApplicationForm = false;
+        this.loading = false;
+      },
+      error: () => (this.loading = false),
     });
   }
 

--- a/apps/admin-gui/src/assets/config/defaultConfig.json
+++ b/apps/admin-gui/src/assets/config/defaultConfig.json
@@ -22,6 +22,9 @@
     "oauth_response_type": "code",
     "oauth_offline_access_consent_prompt": true
   },
+  "mfa": {
+    "url_en": "https://mfa.id.muni.cz/"
+  },
   "login_namespace_attributes": [
     "urn:perun:user:attribute-def:def:login-namespace:einfra",
     "urn:perun:user:attribute-def:def:login-namespace:einfra-services",

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2917,6 +2917,22 @@
           "CLOSE": "Close",
           "NO_PATHS": "No paths include the entered group name."
         },
+        "MFA_REQUIRED_DIALOG": {
+          "TITLE": "Step-up authentication required",
+          "INFO": "To perform this action you need to execute step-up authentication.",
+          "CANCEL": "Cancel",
+          "STEP_UP": "Step-up authentication"
+        },
+        "NO_MFA_TOKEN": {
+          "TITLE": "No MFA token",
+          "INFO": "You need to have at least one active MFA token. Please manage your MFA tokens.",
+          "CANCEL": "Cancel",
+          "MANAGE_TOKENS": "Manage tokens"
+        },
+        "FOCUS_ON_MFA_DIALOG": {
+          "MODAL": "Modal window is opened.",
+          "MODAL_WARNING": "Please check your browser settings if no modal window is open."
+        },
         "OWNERS_LIST": {
           "ID": "Id",
           "NAME": "Name",

--- a/apps/consolidator/src/assets/config/defaultConfig.json
+++ b/apps/consolidator/src/assets/config/defaultConfig.json
@@ -13,6 +13,9 @@
     "user_info_endpoint_url": "https://proxy.aai.muni.cz/OIDC/userinfo",
     "oauth_offline_access_consent_prompt": true
   },
+  "mfa": {
+    "url_en": "https://mfa.id.muni.cz/"
+  },
   "application": "Consolidator",
   "document_title": "Consolidator",
   "use_localhost_linker_url": false,

--- a/apps/consolidator/src/assets/i18n/en.json
+++ b/apps/consolidator/src/assets/i18n/en.json
@@ -38,6 +38,22 @@
           "DESCRIPTION": "Your session has expired. Please sign in to continue.",
           "SIGN_IN": "Sign in"
         },
+        "MFA_REQUIRED_DIALOG": {
+          "TITLE": "Step-up authentication required",
+          "INFO": "To perform this action you need to execute step-up authentication.",
+          "CANCEL": "Cancel",
+          "STEP_UP": "Step-up authentication"
+        },
+        "NO_MFA_TOKEN": {
+          "TITLE": "No MFA token",
+          "INFO": "You need to have at least one active MFA token. Please manage your MFA tokens.",
+          "CANCEL": "Cancel",
+          "MANAGE_TOKENS": "Manage tokens"
+        },
+        "FOCUS_ON_MFA_DIALOG": {
+          "MODAL": "Modal window is opened.",
+          "MODAL_WARNING": "Please check your browser settings if no modal window is open."
+        },
         "REPORT_ISSUE": {
           "TITLE": "Report an issue",
           "SUBJECT": "Subject",

--- a/apps/linker/src/assets/config/defaultConfig.json
+++ b/apps/linker/src/assets/config/defaultConfig.json
@@ -12,6 +12,9 @@
     "oauth_response_type": "code",
     "oauth_offline_access_consent_prompt": true
   },
+  "mfa": {
+    "url_en": "https://mfa.id.muni.cz/"
+  },
   "application": "Linker",
   "document_title": "Linker",
   "support_mail": "perun@cesnet.cz",

--- a/apps/linker/src/assets/i18n/en.json
+++ b/apps/linker/src/assets/i18n/en.json
@@ -13,10 +13,28 @@
         "SIGN_IN": "Sign in",
         "TEXT": "You must sign in to continue."
       },
-      "SESSION_EXPIRATION": {
-        "TITLE": "Session expiration",
-        "DESCRIPTION": "Your session has expired. Please sign in to continue.",
-        "SIGN_IN": "Sign in"
+      "COMPONENTS": {
+        "SESSION_EXPIRATION": {
+          "TITLE": "Session expiration",
+          "DESCRIPTION": "Your session has expired. Please sign in to continue.",
+          "SIGN_IN": "Sign in"
+        },
+        "MFA_REQUIRED_DIALOG": {
+          "TITLE": "Step-up authentication required",
+          "INFO": "To perform this action you need to execute step-up authentication.",
+          "CANCEL": "Cancel",
+          "STEP_UP": "Step-up authentication"
+        },
+        "NO_MFA_TOKEN": {
+          "TITLE": "No MFA token",
+          "INFO": "You need to have at least one active MFA token. Please manage your MFA tokens.",
+          "CANCEL": "Cancel",
+          "MANAGE_TOKENS": "Manage tokens"
+        },
+        "FOCUS_ON_MFA_DIALOG": {
+          "MODAL": "Modal window is opened.",
+          "MODAL_WARNING": "Please check your browser settings if no modal window is open."
+        }
       }
     },
     "CONSOLIDATOR": {

--- a/apps/password-reset/src/app/services/password-reset-config.service.ts
+++ b/apps/password-reset/src/app/services/password-reset-config.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { InitAuthService } from '@perun-web-apps/perun/services';
+import { InitAuthService, MfaHandlerService } from '@perun-web-apps/perun/services';
 import { AppConfigService } from '@perun-web-apps/config';
 import { Location } from '@angular/common';
 
@@ -10,7 +10,8 @@ export class PasswordResetConfigService {
   constructor(
     private initAuthService: InitAuthService,
     private appConfigService: AppConfigService,
-    private location: Location
+    private location: Location,
+    private mfaHandlerService: MfaHandlerService
   ) {}
 
   loadConfigs(): Promise<void> {
@@ -28,6 +29,9 @@ export class PasswordResetConfigService {
         }
       })
       .catch((err) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        this.mfaHandlerService.catchNoMfaTokenError(err?.params?.error);
+        console.error(err);
         this.location.go('/');
         location.reload();
         throw err;
@@ -35,6 +39,9 @@ export class PasswordResetConfigService {
       .then((isAuthenticated) => {
         // if the authentication is successful, continue
         if (isAuthenticated) {
+          // if this application is opened just for MFA, then close the window after MFA is successfully done
+          this.mfaHandlerService.closeMfaWindow();
+
           const queryParams = location.search.substr(1);
           if (!queryParams.includes('token')) {
             return this.initAuthService.loadPrincipal();

--- a/apps/password-reset/src/assets/config/defaultConfig.json
+++ b/apps/password-reset/src/assets/config/defaultConfig.json
@@ -14,6 +14,9 @@
     "oauth_response_type": "code",
     "oauth_offline_access_consent_prompt": true
   },
+  "mfa": {
+    "url_en": "https://mfa.id.muni.cz/"
+  },
   "skip_oidc": false,
   "auto_auth_redirect": true,
   "is_devel": false,

--- a/apps/password-reset/src/assets/i18n/cs.json
+++ b/apps/password-reset/src/assets/i18n/cs.json
@@ -18,6 +18,22 @@
   "SHARED_LIB": {
     "PERUN": {
       "COMPONENTS": {
+        "MFA_REQUIRED_DIALOG": {
+          "TITLE": "Vyžadována step-up authentizace",
+          "INFO": "Pro vykonání této akce musíte provést step-up authentizaci.",
+          "CANCEL": "Zrušit",
+          "STEP_UP": "Step-up authentizace"
+        },
+        "NO_MFA_TOKEN": {
+          "TITLE": "Žádný MFA token",
+          "INFO": "Potřebujete mít alespoň jeden aktivní MFA token. Prosím upravte Vaše MFA tokeny.",
+          "CANCEL": "Zrušit",
+          "MANAGE_TOKENS": "Spravovat tokeny"
+        },
+        "FOCUS_ON_MFA_DIALOG": {
+          "MODAL": "Modalní okno otevřeno.",
+          "MODAL_WARNING": "Pokud se Vám žádné okno neotevřelo, zkontrolujte si prosím nastavení svého prohlížeče."
+        },
         "USER_DONT_EXIST": {
           "TITLE": "Požadovaný uživatel (dle ID nebo externí identity) neexistuje."
         },

--- a/apps/password-reset/src/assets/i18n/en.json
+++ b/apps/password-reset/src/assets/i18n/en.json
@@ -18,6 +18,22 @@
   "SHARED_LIB": {
     "PERUN": {
       "COMPONENTS": {
+        "MFA_REQUIRED_DIALOG": {
+          "TITLE": "Step-up authentication required",
+          "INFO": "To perform this action you need to execute step-up authentication.",
+          "CANCEL": "Cancel",
+          "STEP_UP": "Step-up authentication"
+        },
+        "NO_MFA_TOKEN": {
+          "TITLE": "No MFA token",
+          "INFO": "You need to have at least one active MFA token. Please manage your MFA tokens.",
+          "CANCEL": "Cancel",
+          "MANAGE_TOKENS": "Manage tokens"
+        },
+        "FOCUS_ON_MFA_DIALOG": {
+          "MODAL": "Modal window is opened.",
+          "MODAL_WARNING": "Please check your browser settings if no modal window is open."
+        },
         "USER_DONT_EXIST": {
           "TITLE": "Requested user (by ID or external identity) doesn't exist."
         },

--- a/apps/publications/src/app/services/publications-config.service.ts
+++ b/apps/publications/src/app/services/publications-config.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core';
-import { GuiAuthResolver, InitAuthService } from '@perun-web-apps/perun/services';
+import {
+  GuiAuthResolver,
+  InitAuthService,
+  MfaHandlerService,
+} from '@perun-web-apps/perun/services';
 import { AppConfigService, ColorConfig, EntityColorConfig } from '@perun-web-apps/config';
 import { Location } from '@angular/common';
 import { AuthzResolverService } from '@perun-web-apps/perun/openapi';
@@ -40,7 +44,8 @@ export class PublicationsConfigService {
     private appConfigService: AppConfigService,
     private location: Location,
     private authzSevice: AuthzResolverService,
-    private guiAuthResolver: GuiAuthResolver
+    private guiAuthResolver: GuiAuthResolver,
+    private mfaHandlerService: MfaHandlerService
   ) {}
 
   loadConfigs(): Promise<void> {
@@ -53,6 +58,8 @@ export class PublicationsConfigService {
       )
       .then(() => this.initAuthService.verifyAuth())
       .catch((err) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        this.mfaHandlerService.catchNoMfaTokenError(err?.params?.error);
         console.error(err);
         this.location.go('/');
         location.reload();
@@ -61,6 +68,9 @@ export class PublicationsConfigService {
       .then((isAuthenticated) => {
         // if the authentication is successful, continue
         if (isAuthenticated) {
+          // if this application is opened just for MFA, then close the window after MFA is successfully done
+          this.mfaHandlerService.closeMfaWindow();
+
           return this.initAuthService.loadPrincipal().then(() => this.loadPolicies());
         } else {
           return this.initAuthService.handleAuthStart();

--- a/apps/publications/src/assets/config/defaultConfig.json
+++ b/apps/publications/src/assets/config/defaultConfig.json
@@ -13,6 +13,9 @@
     "oauth_response_type": "code",
     "oauth_offline_access_consent_prompt": true
   },
+  "mfa": {
+    "url_en": "https://mfa.id.muni.cz/"
+  },
   "supported_languages": [
     "en"
   ],

--- a/apps/publications/src/assets/i18n/en.json
+++ b/apps/publications/src/assets/i18n/en.json
@@ -434,6 +434,22 @@
           "DESCRIPTION": "Your session has expired. Please sign in to continue.",
           "SIGN_IN": "Sign in"
         },
+        "MFA_REQUIRED_DIALOG": {
+          "TITLE": "Step-up authentication required",
+          "INFO": "To perform this action you need to execute step-up authentication.",
+          "CANCEL": "Cancel",
+          "STEP_UP": "Step-up authentication"
+        },
+        "NO_MFA_TOKEN": {
+          "TITLE": "No MFA token",
+          "INFO": "You need to have at least one active MFA token. Please manage your MFA tokens.",
+          "CANCEL": "Cancel",
+          "MANAGE_TOKENS": "Manage tokens"
+        },
+        "FOCUS_ON_MFA_DIALOG": {
+          "MODAL": "Modal window is opened.",
+          "MODAL_WARNING": "Please check your browser settings if no modal window is open."
+        },
         "RECENTLY_VIEWED_ICON": {
           "RECENT": "Recently viewed"
         },

--- a/apps/user-profile/src/app/components/dialogs/add-unix-group-dialog/add-unix-group-dialog.component.ts
+++ b/apps/user-profile/src/app/components/dialogs/add-unix-group-dialog/add-unix-group-dialog.component.ts
@@ -48,9 +48,12 @@ export class AddUnixGroupDialogComponent implements OnInit {
 
         this.attributesManagerService
           .setUserAttribute({ user: this.data.userId, attribute: attribute })
-          .subscribe(() => {
-            this.loading = false;
-            this.dialogRef.close(true);
+          .subscribe({
+            next: () => {
+              this.loading = false;
+              this.dialogRef.close(true);
+            },
+            error: () => (this.loading = false),
           });
       });
   }

--- a/apps/user-profile/src/app/components/dialogs/remove-alt-password-dialog/remove-alt-password-dialog.component.ts
+++ b/apps/user-profile/src/app/components/dialogs/remove-alt-password-dialog/remove-alt-password-dialog.component.ts
@@ -37,9 +37,12 @@ export class RemoveAltPasswordDialogComponent implements OnInit {
     this.loading = true;
     this.usersManagerService
       .deleteAlternativePassword(this.data.userId, 'einfra', this.data.passwordId)
-      .subscribe(() => {
-        this.loading = false;
-        this.dialogRef.close(true);
+      .subscribe({
+        next: () => {
+          this.loading = false;
+          this.dialogRef.close(true);
+        },
+        error: () => (this.loading = false),
       });
   }
 }

--- a/apps/user-profile/src/app/pages/settings-page/settings-preferred-shells/settings-preferred-shells.component.ts
+++ b/apps/user-profile/src/app/pages/settings-page/settings-preferred-shells/settings-preferred-shells.component.ts
@@ -90,8 +90,11 @@ export class SettingsPreferredShellsComponent implements OnInit {
         user: this.userId,
         attribute: this.prefShellsAttribute,
       })
-      .subscribe(() => {
-        this.getAttribute();
+      .subscribe({
+        next: () => {
+          this.getAttribute();
+        },
+        error: () => (this.loading = false),
       });
   }
 

--- a/apps/user-profile/src/app/services/user-profile-config.service.ts
+++ b/apps/user-profile/src/app/services/user-profile-config.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { InitAuthService } from '@perun-web-apps/perun/services';
+import { InitAuthService, MfaHandlerService } from '@perun-web-apps/perun/services';
 import { AppConfigService, ColorConfig, EntityColorConfig } from '@perun-web-apps/config';
 import { Location } from '@angular/common';
 
@@ -37,7 +37,8 @@ export class UserProfileConfigService {
   constructor(
     private initAuthService: InitAuthService,
     private appConfigService: AppConfigService,
-    private location: Location
+    private location: Location,
+    private mfaHandlerService: MfaHandlerService
   ) {}
 
   initialize(): Promise<void> {
@@ -51,6 +52,8 @@ export class UserProfileConfigService {
       .then(() => this.appConfigService.setInstanceFavicon())
       .then(() => this.initAuthService.verifyAuth())
       .catch((err) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+        this.mfaHandlerService.catchNoMfaTokenError(err?.params?.error);
         // if there is an error, it means user probably navigated to /api-callback without logging in
         console.error(err);
         this.location.go('/');
@@ -60,6 +63,9 @@ export class UserProfileConfigService {
       .then((isAuthenticated) => {
         // if the authentication is successful, continue
         if (isAuthenticated) {
+          // if this application is opened just for MFA, then close the window after MFA is successfully done
+          this.mfaHandlerService.closeMfaWindow();
+
           return this.initAuthService
             .loadPrincipal()
             .then(() => this.appConfigService.loadAppsConfig());

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -374,6 +374,22 @@
           "CLOSE": "Zrušit",
           "COPY": "Zkopírovat hodnotu"
         },
+        "MFA_REQUIRED_DIALOG": {
+          "TITLE": "Vyžadována step-up authentizace",
+          "INFO": "Pro vykonání této akce musíte provést step-up authentizaci.",
+          "CANCEL": "Zrušit",
+          "STEP_UP": "Step-up authentizace"
+        },
+        "NO_MFA_TOKEN": {
+          "TITLE": "Žádný MFA token",
+          "INFO": "Potřebujete mít alespoň jeden aktivní MFA token. Prosím upravte Vaše MFA tokeny.",
+          "CANCEL": "Zrušit",
+          "MANAGE_TOKENS": "Spravovat tokeny"
+        },
+        "FOCUS_ON_MFA_DIALOG": {
+          "MODAL": "Modalní okno otevřeno.",
+          "MODAL_WARNING": "Pokud se Vám žádné okno neotevřelo, zkontrolujte si prosím nastavení svého prohlížeče."
+        },
         "MAIL_CHANGE_FAILED_DIALOG": {
           "TITLE": "Zmněna preferovaného emailu se nezdařila",
           "INFO": "Žádost o změnu preferovaného emailu neexistuje nebo již není platná",

--- a/apps/user-profile/src/assets/i18n/en.json
+++ b/apps/user-profile/src/assets/i18n/en.json
@@ -450,6 +450,22 @@
           "DESCRIPTION": "Your session has expired. Please sign in to continue.",
           "SIGN_IN": "Sign in"
         },
+        "MFA_REQUIRED_DIALOG": {
+          "TITLE": "Step-up authentication required",
+          "INFO": "To perform this action you need to execute step-up authentication.",
+          "CANCEL": "Cancel",
+          "STEP_UP": "Step-up authentication"
+        },
+        "NO_MFA_TOKEN": {
+          "TITLE": "No MFA token",
+          "INFO": "You need to have at least one active MFA token. Please manage your MFA tokens.",
+          "CANCEL": "Cancel",
+          "MANAGE_TOKENS": "Manage tokens"
+        },
+        "FOCUS_ON_MFA_DIALOG": {
+          "MODAL": "Modal window is opened.",
+          "MODAL_WARNING": "Please check your browser settings if no modal window is open."
+        },
         "MAIL_CHANGE_FAILED_DIALOG": {
           "TITLE": "Preferred mail change failed",
           "INFO": "Preferred email change request does not exist or is not valid anymore",

--- a/libs/perun/multi-factor-authentication/.eslintrc.json
+++ b/libs/perun/multi-factor-authentication/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "parserOptions": {
+    "project": ["libs/perun/multi-factor-authentication/tsconfig.*?.json"]
+  }
+}

--- a/libs/perun/multi-factor-authentication/README.md
+++ b/libs/perun/multi-factor-authentication/README.md
@@ -1,0 +1,7 @@
+# perun-multi-factor-authentication
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test perun-multi-factor-authentication` to execute the unit tests.

--- a/libs/perun/multi-factor-authentication/jest.config.ts
+++ b/libs/perun/multi-factor-authentication/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'perun-multi-factor-authentication',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../coverage/libs/perun/multi-factor-authentication',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/perun/multi-factor-authentication/src/index.ts
+++ b/libs/perun/multi-factor-authentication/src/index.ts
@@ -1,0 +1,4 @@
+export * from './lib/perun-multi-factor-authentication.module';
+export * from './lib/mfa-required-dialog/mfa-required-dialog.component';
+export * from './lib/focus-on-mfa-window/focus-on-mfa-window.component';
+export * from './lib/no-mfa-tokens-dialog/no-mfa-tokens-dialog.component';

--- a/libs/perun/multi-factor-authentication/src/lib/focus-on-mfa-window/focus-on-mfa-window.component.html
+++ b/libs/perun/multi-factor-authentication/src/lib/focus-on-mfa-window/focus-on-mfa-window.component.html
@@ -1,0 +1,9 @@
+<div class="text-center custom-dialog">
+  <div>
+    <mat-icon class="align-text-bottom"> info </mat-icon>
+    {{'SHARED_LIB.PERUN.COMPONENTS.FOCUS_ON_MFA_DIALOG.MODAL' | translate}}
+  </div>
+  <div>
+    {{'SHARED_LIB.PERUN.COMPONENTS.FOCUS_ON_MFA_DIALOG.MODAL_WARNING' | translate}}
+  </div>
+</div>

--- a/libs/perun/multi-factor-authentication/src/lib/focus-on-mfa-window/focus-on-mfa-window.component.scss
+++ b/libs/perun/multi-factor-authentication/src/lib/focus-on-mfa-window/focus-on-mfa-window.component.scss
@@ -1,0 +1,5 @@
+.custom-dialog {
+  background-color: black;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 1.2rem;
+}

--- a/libs/perun/multi-factor-authentication/src/lib/focus-on-mfa-window/focus-on-mfa-window.component.ts
+++ b/libs/perun/multi-factor-authentication/src/lib/focus-on-mfa-window/focus-on-mfa-window.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'perun-web-apps-focus-on-mfa-window',
+  templateUrl: './focus-on-mfa-window.component.html',
+  styleUrls: ['./focus-on-mfa-window.component.scss'],
+})
+export class FocusOnMfaWindowComponent {}

--- a/libs/perun/multi-factor-authentication/src/lib/mfa-required-dialog/mfa-required-dialog.component.html
+++ b/libs/perun/multi-factor-authentication/src/lib/mfa-required-dialog/mfa-required-dialog.component.html
@@ -1,0 +1,14 @@
+<h1 mat-dialog-title>{{'SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.TITLE' | translate}}</h1>
+<div class="dialog-container" mat-dialog-content>
+  <perun-web-apps-alert alert_type="warn">
+    {{'SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.INFO' | translate}}
+  </perun-web-apps-alert>
+</div>
+<div mat-dialog-actions>
+  <button (click)="cancel()" class="ml-auto" mat-flat-button>
+    {{'SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.CANCEL' | translate}}
+  </button>
+  <button (click)="submit()" class="ml-2" color="accent" mat-flat-button>
+    {{'SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.STEP_UP' | translate}}
+  </button>
+</div>

--- a/libs/perun/multi-factor-authentication/src/lib/mfa-required-dialog/mfa-required-dialog.component.ts
+++ b/libs/perun/multi-factor-authentication/src/lib/mfa-required-dialog/mfa-required-dialog.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'perun-web-apps-mfa-required-dialog',
+  templateUrl: './mfa-required-dialog.component.html',
+  styleUrls: ['./mfa-required-dialog.component.scss'],
+})
+export class MfaRequiredDialogComponent {
+  constructor(private dialogRef: MatDialogRef<MfaRequiredDialogComponent>) {}
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  submit(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/libs/perun/multi-factor-authentication/src/lib/no-mfa-tokens-dialog/no-mfa-tokens-dialog.component.html
+++ b/libs/perun/multi-factor-authentication/src/lib/no-mfa-tokens-dialog/no-mfa-tokens-dialog.component.html
@@ -1,0 +1,14 @@
+<h1 mat-dialog-title>{{'SHARED_LIB.PERUN.COMPONENTS.NO_MFA_TOKEN.TITLE' | translate}}</h1>
+<div class="dialog-container" mat-dialog-content>
+  <perun-web-apps-alert alert_type="warn">
+    {{'SHARED_LIB.PERUN.COMPONENTS.NO_MFA_TOKEN.INFO' | translate}}
+  </perun-web-apps-alert>
+</div>
+<div mat-dialog-actions>
+  <button (click)="cancel()" class="ml-auto" mat-flat-button>
+    {{'SHARED_LIB.PERUN.COMPONENTS.NO_MFA_TOKEN.CANCEL' | translate}}
+  </button>
+  <button (click)="submit()" class="ml-2" color="accent" mat-flat-button>
+    {{'SHARED_LIB.PERUN.COMPONENTS.NO_MFA_TOKEN.MANAGE_TOKENS' | translate}}
+  </button>
+</div>

--- a/libs/perun/multi-factor-authentication/src/lib/no-mfa-tokens-dialog/no-mfa-tokens-dialog.component.ts
+++ b/libs/perun/multi-factor-authentication/src/lib/no-mfa-tokens-dialog/no-mfa-tokens-dialog.component.ts
@@ -1,0 +1,27 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+export interface NoMfaTokensData {
+  tokensUrl: string;
+}
+
+@Component({
+  selector: 'perun-web-apps-no-mfa-tokens-dialog',
+  templateUrl: './no-mfa-tokens-dialog.component.html',
+  styleUrls: ['./no-mfa-tokens-dialog.component.scss'],
+})
+export class NoMfaTokensDialogComponent {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: NoMfaTokensData,
+    private dialogRef: MatDialogRef<NoMfaTokensDialogComponent>
+  ) {}
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  submit(): void {
+    window.open(this.data.tokensUrl, '_blank');
+    this.dialogRef.close(true);
+  }
+}

--- a/libs/perun/multi-factor-authentication/src/lib/perun-multi-factor-authentication.module.ts
+++ b/libs/perun/multi-factor-authentication/src/lib/perun-multi-factor-authentication.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { MatIconModule } from '@angular/material/icon';
+import { MfaRequiredDialogComponent } from './mfa-required-dialog/mfa-required-dialog.component';
+import { FocusOnMfaWindowComponent } from './focus-on-mfa-window/focus-on-mfa-window.component';
+import { NoMfaTokensDialogComponent } from './no-mfa-tokens-dialog/no-mfa-tokens-dialog.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TranslateModule,
+    MatDialogModule,
+    MatButtonModule,
+    UiAlertsModule,
+    MatIconModule,
+  ],
+  declarations: [MfaRequiredDialogComponent, FocusOnMfaWindowComponent, NoMfaTokensDialogComponent],
+  exports: [MfaRequiredDialogComponent, FocusOnMfaWindowComponent, NoMfaTokensDialogComponent],
+})
+export class PerunMultiFactorAuthenticationModule {}

--- a/libs/perun/multi-factor-authentication/src/test-setup.ts
+++ b/libs/perun/multi-factor-authentication/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/perun/multi-factor-authentication/tsconfig.json
+++ b/libs/perun/multi-factor-authentication/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "target": "es2020"
+  }
+}

--- a/libs/perun/multi-factor-authentication/tsconfig.lib.json
+++ b/libs/perun/multi-factor-authentication/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/perun/multi-factor-authentication/tsconfig.spec.json
+++ b/libs/perun/multi-factor-authentication/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/perun/services/src/index.ts
+++ b/libs/perun/services/src/index.ts
@@ -22,3 +22,4 @@ export { EntityStorageService } from './lib/entity-storage.service';
 export { RoutePolicyService } from './lib/route-policy.service';
 export { AttributeRightsService } from './lib/attribute-rights.service';
 export { MfaApiService } from './lib/mfa-api.service';
+export { MfaHandlerService } from './lib/mfa-handler.service';

--- a/libs/perun/services/src/lib/ApiInterceptor.ts
+++ b/libs/perun/services/src/lib/ApiInterceptor.ts
@@ -8,7 +8,7 @@ import {
   HttpResponse,
 } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
-import { finalize, tap } from 'rxjs/operators';
+import { finalize, tap, switchMap, catchError } from 'rxjs/operators';
 import { RPCError } from '@perun-web-apps/perun/models';
 import { AuthService } from './auth.service';
 import { StoreService } from './store.service';
@@ -18,6 +18,7 @@ import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { SessionExpirationDialogComponent } from '@perun-web-apps/perun/session-expiration';
 import { InitAuthService } from './init-auth.service';
+import { MfaHandlerService } from './mfa-handler.service';
 
 @Injectable()
 export class ApiInterceptor implements HttpInterceptor {
@@ -28,7 +29,8 @@ export class ApiInterceptor implements HttpInterceptor {
     private notificator: NotificatorService,
     private store: StoreService,
     private dialog: MatDialog,
-    private initAuthService: InitAuthService
+    private initAuthService: InitAuthService,
+    private mfaHandlerService: MfaHandlerService
   ) {}
 
   intercept<T>(req: HttpRequest<T>, next: HttpHandler): Observable<HttpEvent<T>> {
@@ -81,6 +83,11 @@ export class ApiInterceptor implements HttpInterceptor {
         },
       });
     }
+
+    return this.handleRequest(req, next);
+  }
+
+  private handleRequest<T>(req: HttpRequest<T>, next: HttpHandler): Observable<HttpEvent<T>> {
     // Also handle errors globally, if not disabled
     const shouldHandleError = this.apiRequestConfiguration.shouldHandleError();
 
@@ -91,26 +98,47 @@ export class ApiInterceptor implements HttpInterceptor {
       this.isCallToPerunApi(req.url);
 
     return next.handle(req).pipe(
-      tap(
-        (x) => {
-          if (x instanceof HttpResponse && shouldReloadPrincipal) {
-            void this.initAuthService.loadPrincipal();
-          }
-        },
-        (err: HttpErrorResponse) => {
-          // Handle this err
+      tap((response) => {
+        if (response instanceof HttpResponse && shouldReloadPrincipal) {
+          void this.initAuthService.loadPrincipal();
+        }
+      }),
+      catchError((err: HttpErrorResponse) => {
+        const e = err.error as RPCError;
+        // catch MFA required error and start MFA logic
+        if (e.type === 'MfaPrivilegeException' || e.type === 'MfaRolePrivilegeException') {
+          return this.mfaHandlerService.openMfaWindow().pipe(
+            switchMap((verified) => {
+              if (verified) {
+                if (e.type === 'MfaRolePrivilegeException') {
+                  window.location.reload();
+                }
+                return this.handleRequest(this.replaceAuthenticationToken(req), next);
+              }
+              return throwError(() => e);
+            })
+          );
+        } else {
+          // Handle other errors
           const errRpc: RPCError = this.formatErrors(err, req);
           if (errRpc === undefined) {
-            return throwError(err);
+            return throwError(() => err);
           }
           if (shouldHandleError) {
             this.notificator.showRPCError(errRpc);
-          } else {
-            return throwError(errRpc);
           }
+          return throwError(() => errRpc);
         }
-      )
+      })
     );
+  }
+
+  private replaceAuthenticationToken<T>(req: HttpRequest<T>): HttpRequest<T> {
+    return req.clone({
+      setHeaders: {
+        Authorization: this.authService.getAuthorizationHeaderValue(),
+      },
+    });
   }
 
   private isCallToPerunApi(url: string): boolean {

--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -57,8 +57,10 @@ export class AuthService {
     ) {
       customQueryParams['prompt'] = 'consent';
     }
-    if (sessionStorage.getItem('mfa_route')) {
+    if (sessionStorage.getItem('mfa_route') || sessionStorage.getItem('mfaProcessed')) {
       customQueryParams['acr_values'] = 'https://refeds.org/profile/mfa';
+    }
+    if (sessionStorage.getItem('mfa_route')) {
       if (customQueryParams['prompt']) {
         customQueryParams['prompt'] += ' login';
       } else {

--- a/libs/perun/services/src/lib/mfa-handler.service.ts
+++ b/libs/perun/services/src/lib/mfa-handler.service.ts
@@ -1,0 +1,147 @@
+import { Injectable } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
+import { Observable } from 'rxjs';
+import {
+  MfaRequiredDialogComponent,
+  FocusOnMfaWindowComponent,
+  NoMfaTokensDialogComponent,
+} from '@perun-web-apps/perun/multi-factor-authentication';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { AuthService } from './auth.service';
+import { StoreService } from './store.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MfaHandlerService {
+  constructor(
+    private dialog: MatDialog,
+    private oauthService: OAuthService,
+    private authService: AuthService,
+    private store: StoreService
+  ) {}
+
+  /**
+   * 1) This function firstly opens a dialog that tells the user that MFA is required
+   * 2) If the user clicks on "Verify", then the new window will be opened and this
+   * window will handle MFA
+   * 3) In the original application is opened dialog which indicates, that there is
+   * opened another window and the user cannot continue in the original application
+   * without finishing authentication/closing the second window
+   */
+  openMfaWindow(): Observable<boolean> {
+    let newWindow: Window = null;
+    let dialogRef: MatDialogRef<FocusOnMfaWindowComponent, void> = null;
+
+    const configVerify = getDefaultDialogConfig();
+    configVerify.width = '450px';
+    const dialogVerifyRef = this.dialog.open(MfaRequiredDialogComponent, configVerify);
+    let verificationSkipped = false;
+
+    dialogVerifyRef.afterClosed().subscribe((result) => {
+      if (result) {
+        sessionStorage.setItem('mfaRequired', 'true');
+
+        // save tokens - if MFA will NOT be successful, we will need to give them back to oauth storage
+        sessionStorage.setItem('oldAccessToken', this.oauthService.getAccessToken());
+        sessionStorage.setItem('oldRefreshToken', this.oauthService.getRefreshToken());
+
+        newWindow = this.setupMfaWindow();
+
+        if (newWindow) {
+          const config = getDefaultDialogConfig();
+          config.width = '450px';
+          config.panelClass = 'noBorderDialog';
+
+          dialogRef = this.dialog.open(FocusOnMfaWindowComponent, config);
+        }
+      } else {
+        verificationSkipped = true;
+      }
+    });
+
+    // open no mfa token dialog
+    if (localStorage.getItem('noMfaTokenDialog')) {
+      localStorage.removeItem('noMfaTokenDialog');
+      const configNoToken = getDefaultDialogConfig();
+      configNoToken.width = '450px';
+      configNoToken.data = {
+        tokensUrl: this.store.getProperty('mfa').url_en,
+      };
+      this.dialog.open(NoMfaTokensDialogComponent, configNoToken);
+    }
+
+    return new Observable((observer) => {
+      const timer = setInterval(() => {
+        if (newWindow?.closed) {
+          clearInterval(timer);
+          dialogRef.close();
+          sessionStorage.removeItem('mfaRequired');
+          sessionStorage.removeItem('mfaProcessed');
+          // if the window is closed without successful MFA, then give back previous tokens to the oauth storage
+          if (this.oauthService.getAccessToken() === null) {
+            localStorage.setItem('access_token', sessionStorage.getItem('oldAccessToken'));
+            localStorage.setItem('refresh_token', sessionStorage.getItem('oldRefreshToken'));
+          }
+          return observer.next(true);
+        }
+        if (verificationSkipped) {
+          clearInterval(timer);
+          return observer.next(false);
+        }
+      }, 1000);
+    });
+  }
+
+  /**
+   * This method catch unmet_authentication_requirements error, which means that
+   * user doesn't have any active MFA token
+   * @param error err?.params?.error
+   */
+  catchNoMfaTokenError(error: string): void {
+    if (error === 'unmet_authentication_requirements') {
+      localStorage.setItem('noMfaTokenDialog', 'true');
+      window.close();
+    }
+  }
+
+  /**
+   * This function handles application which is opened just for executing MFA
+   * If the window for MFA is opened, log out from single factor and force
+   * multi factor authentication
+   */
+  mfaWindowForceLogout(): void {
+    if (sessionStorage.getItem('mfaRequired') && !sessionStorage.getItem('mfaProcessed')) {
+      sessionStorage.setItem('mfaProcessed', 'true');
+      this.oauthService.logOut(true);
+      this.authService.loadConfigData();
+      return void this.oauthService.loadDiscoveryDocumentAndLogin();
+    } else {
+      sessionStorage.removeItem('mfaRequired');
+    }
+  }
+
+  /**
+   * This function handles application which is opened just for executing MFA
+   * If MFA is successfully done, then close the window
+   */
+  closeMfaWindow(): void {
+    if (sessionStorage.getItem('mfaProcessed') && !sessionStorage.getItem('mfaRequired')) {
+      sessionStorage.removeItem('mfaProcessed');
+      window.close();
+    }
+  }
+
+  private setupMfaWindow(): Window {
+    const url = location.pathname + location.search;
+    const width = 600;
+    const height = 600;
+    const topmostWindow = window.top;
+
+    const top = topmostWindow.outerHeight / 2 + topmostWindow.screenY - height / 2;
+    const left = topmostWindow.outerWidth / 2 + topmostWindow.screenX - width / 2;
+
+    return window.open(url, '_blank', `width=${width},height=${height},top=${top}, left=${left}`);
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,9 @@
       ],
       "@perun-web-apps/perun/login": ["libs/perun/login/src/index.ts"],
       "@perun-web-apps/perun/models": ["libs/perun/models/src/index.ts"],
+      "@perun-web-apps/perun/multi-factor-authentication": [
+        "libs/perun/multi-factor-authentication/src/index.ts"
+      ],
       "@perun-web-apps/perun/namespace-password-form": [
         "libs/perun/namespace-password-form/src/index.ts"
       ],


### PR DESCRIPTION
* Now our applications catch new MFA required error.
* If this error occurs, then the first dialog is opened that tells the user, that MFA is required.
* If the user wants to proceed with additional verification, then is opened a new window, which handles MFA.
* Original window is locked until the second window is opened.