### PR TITLE
fix(admin): do not change tab when removed manager

### DIFF
--- a/apps/admin-gui/src/app/shared/components/managers-page/managers-page.component.ts
+++ b/apps/admin-gui/src/app/shared/components/managers-page/managers-page.component.ts
@@ -243,7 +243,6 @@ export class ManagersPageComponent implements OnInit {
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
         if (this.guiAuthResolver.isManagerPagePrivileged(this.complementaryObject)) {
-          this.reloadEntityDetail.reloadEntityDetail();
           this.refreshGroups();
         } else {
           this.redirectToAuthRoute();


### PR DESCRIPTION
* after manager was removed the whole page was reloaded resulting in tab and role selection reseting to default