### PR TITLE
fix(admin): add member dialog behavior on MFA error

### DIFF
--- a/apps/admin-gui/src/app/vos/components/add-member.service.ts
+++ b/apps/admin-gui/src/app/vos/components/add-member.service.ts
@@ -66,8 +66,12 @@ export class AddMemberService {
   }
 
   getCandidateWithError(candidate: MemberCandidate, error: HttpErrorResponse): FailedCandidate {
-    const e: RPCError = error.error as RPCError;
-    const msg: string = e.message.split(':').splice(1).join();
-    return { candidate: candidate, errorName: e.name, errorMsg: msg };
+    if (String(error.type) === 'MfaPrivilegeException') {
+      return null;
+    } else {
+      const e: RPCError = error.error as RPCError;
+      const msg: string = e.message.split(':').splice(1).join();
+      return { candidate: candidate, errorName: e.name, errorMsg: msg };
+    }
   }
 }

--- a/apps/admin-gui/src/app/vos/components/group-add-member-dialog/group-add-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/vos/components/group-add-member-dialog/group-add-member-dialog.component.ts
@@ -95,6 +95,8 @@ export class GroupAddMemberDialogComponent implements OnInit {
     this.loading = true;
     if (this.selection.selected.length === 0) {
       if (this.failed.length !== 0) {
+        this.failed = this.failed.filter((failed) => failed !== null);
+        this.selection.clear();
         this.loading = false;
       } else {
         this.addMemberService.success('DIALOGS.ADD_MEMBERS.SUCCESS_ADD');
@@ -118,6 +120,8 @@ export class GroupAddMemberDialogComponent implements OnInit {
     this.loading = true;
     if (this.selection.selected.length === 0) {
       if (this.failed.length !== 0) {
+        this.failed = this.failed.filter((failed) => failed !== null);
+        this.selection.clear();
         this.loading = false;
       } else {
         this.addMemberService.success('DIALOGS.ADD_MEMBERS.SUCCESS_INVITE');

--- a/apps/admin-gui/src/app/vos/components/vo-add-member-dialog/vo-add-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/vos/components/vo-add-member-dialog/vo-add-member-dialog.component.ts
@@ -63,6 +63,8 @@ export class VoAddMemberDialogComponent {
     this.loading = true;
     if (this.selection.selected.length === 0) {
       if (this.failed.length !== 0) {
+        this.failed = this.failed.filter((failed) => failed !== null);
+        this.selection.clear();
         this.loading = false;
       } else {
         this.addMemberService.success('DIALOGS.ADD_MEMBERS.SUCCESS_ADD');
@@ -84,6 +86,8 @@ export class VoAddMemberDialogComponent {
     this.loading = true;
     if (this.selection.selected.length === 0) {
       if (this.failed.length !== 0) {
+        this.failed = this.failed.filter((failed) => failed !== null);
+        this.selection.clear();
         this.loading = false;
       } else {
         this.addMemberService.success('DIALOGS.ADD_MEMBERS.SUCCESS_INVITE');


### PR DESCRIPTION
* When MFA error occurs in this dialog and user clicks on cancel in MFA dialog, the previous dialog for member adding stayed in loading state.