### PR TITLE
fix: correctly handle RPC error in all components

### DIFF
--- a/apps/admin-gui/src/app/shared/components/member-overview-membership/member-overview-membership.component.ts
+++ b/apps/admin-gui/src/app/shared/components/member-overview-membership/member-overview-membership.component.ts
@@ -14,7 +14,6 @@ import {
 } from '@perun-web-apps/perun/services';
 import { Urns } from '@perun-web-apps/perun/urns';
 import { TranslateService } from '@ngx-translate/core';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 
 @Component({
@@ -103,10 +102,9 @@ export class MemberOverviewMembershipComponent implements OnChanges {
             : (attr.value as string);
           this.loading = false;
         },
-        (error: HttpErrorResponse) => {
-          const e = error.error as RPCError;
-          if (e.name !== 'PrivilegeException') {
-            this.notificator.showError(e.name);
+        (error: RPCError) => {
+          if (error.name !== 'PrivilegeException') {
+            this.notificator.showError(error.name);
           } else {
             this.voMembershipDataSource = new MatTableDataSource<string>(['Status']);
           }

--- a/apps/admin-gui/src/app/shared/route-auth-guard.service.ts
+++ b/apps/admin-gui/src/app/shared/route-auth-guard.service.ts
@@ -20,7 +20,6 @@ import {
 } from '@perun-web-apps/perun/openapi';
 import { catchError, map } from 'rxjs/operators';
 import { of } from 'rxjs';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 
 interface PerunBeanExtension {
@@ -114,8 +113,8 @@ export class RouteAuthGuardService implements CanActivateChild {
           authPair.entity.voId = member.voId;
           return this.finalizeCanActivateChild(authPair);
         }),
-        catchError((error: HttpErrorResponse) => {
-          return this.errorRedirectUrl(error.error as RPCError);
+        catchError((error: RPCError) => {
+          return this.errorRedirectUrl(error);
         })
       );
     } else if (authPair.key.startsWith('groups')) {
@@ -125,8 +124,8 @@ export class RouteAuthGuardService implements CanActivateChild {
           authPair.entity.voId = group.voId;
           return this.finalizeCanActivateChild(authPair);
         }),
-        catchError((error: HttpErrorResponse) => {
-          return this.errorRedirectUrl(error.error as RPCError);
+        catchError((error: RPCError) => {
+          return this.errorRedirectUrl(error);
         })
       );
     } else if (authPair.key.startsWith('resources')) {
@@ -137,8 +136,8 @@ export class RouteAuthGuardService implements CanActivateChild {
           authPair.entity.voId = resource.voId;
           return this.finalizeCanActivateChild(authPair);
         }),
-        catchError((error: HttpErrorResponse) => {
-          return this.errorRedirectUrl(error.error as RPCError);
+        catchError((error: RPCError) => {
+          return this.errorRedirectUrl(error);
         })
       );
     } else {

--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
@@ -948,7 +948,7 @@ export class SideMenuItemService {
           });
         },
         (error: RPCError) => {
-          if (error.name !== 'HttpErrorResponse') {
+          if (error.name !== 'PrivilegeException') {
             this.notificator.showRPCError(error);
           }
         }

--- a/apps/admin-gui/src/app/vos/components/add-member.service.ts
+++ b/apps/admin-gui/src/app/vos/components/add-member.service.ts
@@ -5,7 +5,6 @@ import { GroupAddMemberDialogComponent } from './group-add-member-dialog/group-a
 import { VoAddMemberDialogComponent } from './vo-add-member-dialog/vo-add-member-dialog.component';
 import { NotificatorService } from '@perun-web-apps/perun/services';
 import { TranslateService } from '@ngx-translate/core';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 
 export interface FailedCandidate {
@@ -65,13 +64,12 @@ export class AddMemberService {
     this.dialogRef.close(true);
   }
 
-  getCandidateWithError(candidate: MemberCandidate, error: HttpErrorResponse): FailedCandidate {
+  getCandidateWithError(candidate: MemberCandidate, error: RPCError): FailedCandidate {
     if (String(error.type) === 'MfaPrivilegeException') {
       return null;
     } else {
-      const e: RPCError = error.error as RPCError;
-      const msg: string = e.message.split(':').splice(1).join();
-      return { candidate: candidate, errorName: e.name, errorMsg: msg };
+      const msg: string = error.message.split(':').splice(1).join();
+      return { candidate: candidate, errorName: error.name, errorMsg: msg };
     }
   }
 }

--- a/apps/admin-gui/src/app/vos/components/group-add-member-dialog/group-add-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/vos/components/group-add-member-dialog/group-add-member-dialog.component.ts
@@ -16,10 +16,10 @@ import {
   StoreService,
 } from '@perun-web-apps/perun/services';
 import { getCandidateEmail } from '@perun-web-apps/perun/utils';
-import { HttpErrorResponse } from '@angular/common/http';
 import { AddMemberService, FailedCandidate } from '../add-member.service';
 import { merge, Observable, of, Subject } from 'rxjs';
 import { startWith, switchMap } from 'rxjs/operators';
+import { RPCError } from '@perun-web-apps/perun/models';
 
 export interface GroupAddMemberData {
   group: Group;
@@ -150,28 +150,28 @@ export class GroupAddMemberDialogComponent implements OnInit {
         candidate: this.addMemberService.createCandidate(candidate.candidate),
         groups: [this.addMemberService.getFormattedGroup(this.data.group)],
       })
-      .subscribe(
-        (member) => {
+      .subscribe({
+        next: (member) => {
           this.membersManagerService.validateMemberAsync(member.id).subscribe();
           this.add();
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
           this.add();
-        }
-      );
+        },
+      });
   }
 
   private addMember(candidate: MemberCandidate): void {
-    this.groupService.addMembers(this.data.group.id, [candidate.member.id]).subscribe(
-      () => {
+    this.groupService.addMembers(this.data.group.id, [candidate.member.id]).subscribe({
+      next: () => {
         this.add();
       },
-      (error: HttpErrorResponse) => {
+      error: (error: RPCError) => {
         this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
         this.add();
-      }
-    );
+      },
+    });
   }
 
   private addUser(candidate: MemberCandidate): void {
@@ -181,16 +181,16 @@ export class GroupAddMemberDialogComponent implements OnInit {
         user: candidate.richUser.id,
         groups: [this.addMemberService.getFormattedGroup(this.data.group)],
       })
-      .subscribe(
-        (member) => {
+      .subscribe({
+        next: (member) => {
           this.membersManagerService.validateMemberAsync(member.id).subscribe();
           this.add();
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
           this.add();
-        }
-      );
+        },
+      });
   }
 
   private inviteCandidate(candidate: MemberCandidate, lang: string): void {
@@ -201,15 +201,15 @@ export class GroupAddMemberDialogComponent implements OnInit {
         this.data.group.voId,
         this.data.group.id
       )
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.invite(lang);
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
           this.invite(lang);
-        }
-      );
+        },
+      });
   }
 
   private inviteUser(candidate: MemberCandidate, lang: string): void {
@@ -219,14 +219,14 @@ export class GroupAddMemberDialogComponent implements OnInit {
         this.data.group.voId,
         this.data.group.id
       )
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.invite(lang);
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
           this.invite(lang);
-        }
-      );
+        },
+      });
   }
 }

--- a/apps/admin-gui/src/app/vos/components/vo-add-member-dialog/vo-add-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/vos/components/vo-add-member-dialog/vo-add-member-dialog.component.ts
@@ -10,10 +10,10 @@ import { ApiRequestConfigurationService, StoreService } from '@perun-web-apps/pe
 import { SelectionModel } from '@angular/cdk/collections';
 import { getCandidateEmail } from '@perun-web-apps/perun/utils';
 import { Urns } from '@perun-web-apps/perun/urns';
-import { HttpErrorResponse } from '@angular/common/http';
 import { AddMemberService, FailedCandidate } from '../add-member.service';
 import { merge, Observable, of, Subject } from 'rxjs';
 import { startWith, switchMap } from 'rxjs/operators';
+import { RPCError } from '@perun-web-apps/perun/models';
 
 export interface VoAddMemberData {
   voId: number;
@@ -115,58 +115,58 @@ export class VoAddMemberDialogComponent {
         vo: this.data.voId,
         candidate: this.addMemberService.createCandidate(candidate.candidate),
       })
-      .subscribe(
-        (member) => {
+      .subscribe({
+        next: (member) => {
           this.membersManagerService.validateMemberAsync(member.id).subscribe();
           this.add();
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
           this.add();
-        }
-      );
+        },
+      });
   }
 
   private addUser(candidate: MemberCandidate): void {
     this.membersManagerService
       .createMemberForUser({ vo: this.data.voId, user: candidate.richUser.id })
-      .subscribe(
-        (member) => {
+      .subscribe({
+        next: (member) => {
           this.membersManagerService.validateMemberAsync(member.id).subscribe();
           this.add();
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
           this.add();
-        }
-      );
+        },
+      });
   }
 
   private inviteCandidate(candidate: MemberCandidate, lang: string): void {
     this.registrarManager
       .sendInvitation(getCandidateEmail(candidate.candidate), lang, this.data.voId)
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.invite(lang);
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
           this.invite(lang);
-        }
-      );
+        },
+      });
   }
 
   private inviteUser(candidate: MemberCandidate, lang: string): void {
     this.registrarManager
       .sendInvitationToExistingUser(candidate.richUser.id, this.data.voId)
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.invite(lang);
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.failed.push(this.addMemberService.getCandidateWithError(candidate, error));
           this.invite(lang);
-        }
-      );
+        },
+      });
   }
 }

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.ts
@@ -22,7 +22,6 @@ import { TABLE_GROUP_MEMBERS } from '@perun-web-apps/config/table-config';
 import { getDefaultDialogConfig, isGroupSynchronized } from '@perun-web-apps/perun/utils';
 import { InviteMemberDialogComponent } from '../../../../shared/components/dialogs/invite-member-dialog/invite-member-dialog.component';
 import { UntypedFormControl } from '@angular/forms';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 import { GroupAddMemberDialogComponent } from '../../../components/group-add-member-dialog/group-add-member-dialog.component';
 
@@ -216,19 +215,18 @@ export class GroupMembersComponent implements OnInit {
       this.apiRequest.dontHandleErrorForNext();
       this.attributesManager
         .getVoAttributeByName(voId, 'urn:perun:vo:attribute-def:def:blockManualMemberAdding')
-        .subscribe(
-          (attrValue) => {
+        .subscribe({
+          next: (attrValue) => {
             this.blockManualMemberAdding = attrValue.value !== null;
             resolve();
           },
-          (error: HttpErrorResponse) => {
-            const e = error.error as RPCError;
-            if (e.name !== 'PrivilegeException') {
-              this.notificator.showError(e.name);
+          error: (error: RPCError) => {
+            if (error.name !== 'PrivilegeException') {
+              this.notificator.showError(error.name);
             }
             resolve();
-          }
-        );
+          },
+        });
     });
   }
 

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-overview/group-overview.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-overview/group-overview.component.ts
@@ -175,7 +175,7 @@ export class GroupOverviewComponent implements OnInit {
           expirationAuth = true;
         },
         (error: RPCError) => {
-          if (error.name !== 'HttpErrorResponse') {
+          if (error.name !== 'PrivilegeException') {
             this.notificator.showRPCError(error);
           }
         }

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-expiration/group-settings-expiration.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-expiration/group-settings-expiration.component.ts
@@ -7,7 +7,6 @@ import {
 } from '@perun-web-apps/perun/services';
 import { Urns } from '@perun-web-apps/perun/urns';
 import { Attribute, AttributesManagerService, Group } from '@perun-web-apps/perun/openapi';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 
 @Component({
@@ -48,14 +47,13 @@ export class GroupSettingsExpirationComponent implements OnInit {
 
     this.attributesManager
       .setGroupAttribute({ group: this.group.id, attribute: attribute })
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.loadSettings();
           this.notificator.showSuccess(this.successMessage);
         },
-        (error: HttpErrorResponse) =>
-          this.notificator.showRPCError(error.error as RPCError, this.errorMessage)
-      );
+        error: (error: RPCError) => this.notificator.showRPCError(error, this.errorMessage),
+      });
   }
 
   private loadSettings(): void {

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-notifications/group-settings-notifications.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-notifications/group-settings-notifications.component.ts
@@ -82,7 +82,7 @@ export class GroupSettingsNotificationsComponent implements OnInit {
                 this.loading = false;
               },
               (error: RPCError) => {
-                if (error.name !== 'HttpErrorResponse') {
+                if (error.name !== 'PrivilegeException') {
                   this.notificator.showRPCError(error);
                 }
                 this.setAuthRights();

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-overview/group-settings-overview.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-overview/group-settings-overview.component.ts
@@ -64,7 +64,7 @@ export class GroupSettingsOverviewComponent implements OnInit {
           });
         },
         (error: RPCError) => {
-          if (error.name !== 'HttpErrorResponse') {
+          if (error.name !== 'PrivilegeException') {
             this.notificator.showRPCError(error);
           }
         }

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.ts
@@ -20,7 +20,6 @@ import { UntypedFormControl } from '@angular/forms';
 import { TABLE_VO_MEMBERS } from '@perun-web-apps/config/table-config';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { InviteMemberDialogComponent } from '../../../../shared/components/dialogs/invite-member-dialog/invite-member-dialog.component';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 import { VoAddMemberDialogComponent } from '../../../components/vo-add-member-dialog/vo-add-member-dialog.component';
 
@@ -176,19 +175,18 @@ export class VoMembersComponent implements OnInit {
       this.apiRequest.dontHandleErrorForNext();
       this.attributesManager
         .getVoAttributeByName(voId, 'urn:perun:vo:attribute-def:def:blockManualMemberAdding')
-        .subscribe(
-          (attrValue) => {
+        .subscribe({
+          next: (attrValue) => {
             this.blockManualMemberAdding = attrValue.value !== null;
             resolve();
           },
-          (error: HttpErrorResponse) => {
-            const e = error.error as RPCError;
-            if (e.name !== 'PrivilegeException') {
-              this.notificator.showError(e.name);
+          error: (error: RPCError) => {
+            if (error.name !== 'PrivilegeException') {
+              this.notificator.showError(error.name);
             }
             resolve();
-          }
-        );
+          },
+        });
     });
   }
 

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-expiration/vo-settings-expiration.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-expiration/vo-settings-expiration.component.ts
@@ -8,7 +8,6 @@ import {
 import { TranslateService } from '@ngx-translate/core';
 import { Urns } from '@perun-web-apps/perun/urns';
 import { Attribute, AttributesManagerService, Vo } from '@perun-web-apps/perun/openapi';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 
 @Component({
@@ -51,15 +50,15 @@ export class VoSettingsExpirationComponent implements OnInit {
     // FIXME this might not work in case of some race condition (other request finishes sooner)
     this.apiRequest.dontHandleErrorForNext();
 
-    this.attributesManager.setVoAttribute({ vo: this.vo.id, attribute: attribute }).subscribe(
-      () => {
+    this.attributesManager.setVoAttribute({ vo: this.vo.id, attribute: attribute }).subscribe({
+      next: () => {
         this.loadSettings();
         this.notificator.showSuccess(this.successMessage);
       },
-      (error: HttpErrorResponse) => {
-        this.notificator.showRPCError(error.error as RPCError, this.errorMessage);
-      }
-    );
+      error: (error: RPCError) => {
+        this.notificator.showRPCError(error, this.errorMessage);
+      },
+    });
   }
 
   private loadSettings(): void {

--- a/apps/admin-gui/src/app/vos/pages/vo-select-page/vo-select-page.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-select-page/vo-select-page.component.ts
@@ -12,7 +12,6 @@ import { RemoveVoDialogComponent } from '../../../shared/components/dialogs/remo
 import { SelectionModel } from '@angular/cdk/collections';
 import { CreateVoDialogComponent } from '../../../shared/components/dialogs/create-vo-dialog/create-vo-dialog.component';
 import { TABLE_VO_SELECT } from '@perun-web-apps/config/table-config';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 
 @Component({
@@ -64,22 +63,21 @@ export class VoSelectPageComponent implements OnInit, AfterViewChecked {
     this.loading = true;
     this.selection.clear();
     this.apiRequest.dontHandleErrorForNext();
-    this.voService.getMyEnrichedVos().subscribe(
-      (vos) => {
+    this.voService.getMyEnrichedVos().subscribe({
+      next: (vos) => {
         this.vos = vos;
         this.recentIds = getRecentlyVisitedIds('vos');
         this.loading = false;
       },
-      (error: HttpErrorResponse) => {
-        const e = error.error as RPCError;
-        if (e.name === 'PrivilegeException') {
+      error: (error: RPCError) => {
+        if (error.name === 'PrivilegeException') {
           this.vos = [];
           this.loading = false;
         } else {
-          this.notificator.showRPCError(e);
+          this.notificator.showRPCError(error);
         }
-      }
-    );
+      },
+    });
   }
 
   applyFilter(filterValue: string): void {

--- a/apps/linker/src/app/service/link-identities.service.ts
+++ b/apps/linker/src/app/service/link-identities.service.ts
@@ -3,7 +3,6 @@ import { RegistrarManagerService } from '@perun-web-apps/perun/openapi';
 import { Router } from '@angular/router';
 import { parseQueryParams } from '@perun-web-apps/perun/utils';
 import { RPCError } from '@perun-web-apps/perun/models';
-import { HttpErrorResponse } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root',
@@ -22,8 +21,8 @@ export class LinkIdentitiesService {
             resolve();
           });
         },
-        (error: HttpErrorResponse) => {
-          const exceptionName = (error.error as RPCError).name;
+        (error: RPCError) => {
+          const exceptionName = error.name;
           let linkerResult = 'UNKNOWN_ERROR';
           switch (exceptionName) {
             case 'InvalidTokenException':

--- a/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.ts
+++ b/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.ts
@@ -4,7 +4,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Consent, ConsentsManagerService } from '@perun-web-apps/perun/openapi';
 import { RPCError } from '@perun-web-apps/perun/models';
-import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'perun-web-apps-consent-request',
@@ -30,23 +29,22 @@ export class ConsentRequestComponent implements OnInit {
     this.route.params.subscribe((params) => {
       const consentId = Number(params['consentId']);
       this.apiRequest.dontHandleErrorForNext();
-      this.consentService.getConsentById(consentId).subscribe(
-        (consent) => {
+      this.consentService.getConsentById(consentId).subscribe({
+        next: (consent) => {
           this.consent = consent;
           if (this.consent.status !== 'UNSIGNED') {
             void this.router.navigate(['/profile', 'consents'], { queryParamsHandling: 'merge' });
           }
           this.loading = false;
         },
-        (error: HttpErrorResponse) => {
+        error: (error: RPCError) => {
           this.loading = false;
-          const e: RPCError = error.error as RPCError;
-          if (e.name !== 'ConsentNotExistsException') {
-            this.notificator.showRPCError(e);
+          if (error.name !== 'ConsentNotExistsException') {
+            this.notificator.showRPCError(error);
           }
           void this.router.navigate(['/profile', 'consents'], { queryParamsHandling: 'merge' });
-        }
-      );
+        },
+      });
     });
   }
 

--- a/libs/perun/namespace-password-form/src/lib/perun-namespace-password-form.ts
+++ b/libs/perun/namespace-password-form/src/lib/perun-namespace-password-form.ts
@@ -4,7 +4,6 @@ import { UsersManagerService } from '@perun-web-apps/perun/openapi';
 import { ApiRequestConfigurationService } from '@perun-web-apps/perun/services';
 import { Observable, of, timer } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
-import { HttpErrorResponse } from '@angular/common/http';
 import { RPCError } from '@perun-web-apps/perun/models';
 
 interface PasswordError {
@@ -42,10 +41,9 @@ export const loginAsyncValidator =
       }),
       map(() => null),
       // catch error and send it as a valid value
-      catchError((err: HttpErrorResponse) => {
-        const innerErr: RPCError = err.error as RPCError;
+      catchError((err: RPCError) => {
         const pwdError: PasswordError = {
-          backendError: innerErr.message.substring(innerErr.message.indexOf(':') + 1),
+          backendError: err.message.substring(err.message.indexOf(':') + 1),
         };
         return of(pwdError);
       })

--- a/libs/perun/services/src/lib/api.service.ts
+++ b/libs/perun/services/src/lib/api.service.ts
@@ -33,6 +33,9 @@ export class ApiService implements PerunApiService {
     return headers;
   }
 
+  /**
+   * @deprecated The method should not be used
+   */
   get(path: string, showError = true): Observable<object> {
     const url = `${this.getApiUrl()}${path}`;
     return this.http
@@ -40,6 +43,9 @@ export class ApiService implements PerunApiService {
       .pipe(catchError((err: HttpErrorResponse) => this.formatErrors(err, url, null, showError)));
   }
 
+  /**
+   * @deprecated The method should not be used
+   */
   put(path: string, body = {}, showError = true): Observable<object> {
     const url = `${this.getApiUrl()}${path}`;
     const payload = JSON.stringify(body);
@@ -50,6 +56,9 @@ export class ApiService implements PerunApiService {
       );
   }
 
+  /**
+   * @deprecated The method should not be used
+   */
   post(path: string, body = {}, showError = true): Observable<object> {
     const url = `${this.getApiUrl()}${path}`;
     const payload = JSON.stringify(body);
@@ -62,6 +71,9 @@ export class ApiService implements PerunApiService {
       );
   }
 
+  /**
+   * @deprecated The method should not be used
+   */
   delete(path: string, showError = true): Observable<object> {
     const url = `${this.getApiUrl()}${path}`;
     return this.http


### PR DESCRIPTION
* Due to changes in ApiInterceptor there are some bugs in how we handle RPC errors. We used to "catch" HttpErrorResponse in components and then we unwrapped the inner RPC error. Now we have to catch the RPC inner error directly in all components.