### PR TITLE
fix: resize window on sidenav reopening

### DIFF
--- a/apps/admin-gui/src/app/app.component.html
+++ b/apps/admin-gui/src/app/app.component.html
@@ -12,6 +12,7 @@
     id="nav-menu">
   </app-perun-nav-menu>
   <mat-sidenav-container
+    autosize="true"
     [ngStyle]="{'margin-top': getSideNavMarginTop(),'min-height': getSideNavMinHeight()}">
     <mat-sidenav
       #sidenav

--- a/apps/publications/src/app/app.component.html
+++ b/apps/publications/src/app/app.component.html
@@ -1,7 +1,7 @@
 <perun-web-apps-notificator></perun-web-apps-notificator>
 <div *ngIf="!isLoginScreenShow && !isServiceAccess && !isServiceLogin()">
   <perun-web-apps-header [sideNav]="sidenav" id="nav-menu"></perun-web-apps-header>
-  <mat-sidenav-container>
+  <mat-sidenav-container autosize="true">
     <mat-sidenav
       #sidenav
       [mode]="sidebarMode"

--- a/apps/user-profile/src/app/app.component.html
+++ b/apps/user-profile/src/app/app.component.html
@@ -2,7 +2,7 @@
   <perun-web-apps-notificator></perun-web-apps-notificator>
   <div class="app-min-width">
     <perun-web-apps-header (sidenavToggle)="sidenav.toggle()"></perun-web-apps-header>
-    <mat-sidenav-container>
+    <mat-sidenav-container autosize="true">
       <mat-sidenav
         #sidenav
         [mode]="sidebarMode"


### PR DESCRIPTION
* when sidenav is hidden and reopened, the below window's width is not recalculated
* currently this is only a case in admin-gui, the fix is applied also to publications and profile as a precaution