### PR TITLE
feat: better workflow for MFA dialog with MfaRolePrivilegeException

### DIFF
--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2931,6 +2931,7 @@
         "MFA_REQUIRED_DIALOG": {
           "TITLE": "Step-up authentication required",
           "INFO": "To perform this action you need to execute step-up authentication.",
+          "INFO_ROLE": "To log in you need to execute step-up authentication.",
           "CANCEL": "Cancel",
           "STEP_UP": "Step-up authentication"
         },

--- a/apps/consolidator/src/assets/i18n/en.json
+++ b/apps/consolidator/src/assets/i18n/en.json
@@ -41,6 +41,7 @@
         "MFA_REQUIRED_DIALOG": {
           "TITLE": "Step-up authentication required",
           "INFO": "To perform this action you need to execute step-up authentication.",
+          "INFO_ROLE": "To log in you need to execute step-up authentication.",
           "CANCEL": "Cancel",
           "STEP_UP": "Step-up authentication"
         },

--- a/apps/linker/src/assets/i18n/en.json
+++ b/apps/linker/src/assets/i18n/en.json
@@ -22,6 +22,7 @@
         "MFA_REQUIRED_DIALOG": {
           "TITLE": "Step-up authentication required",
           "INFO": "To perform this action you need to execute step-up authentication.",
+          "INFO_ROLE": "To log in you need to execute step-up authentication.",
           "CANCEL": "Cancel",
           "STEP_UP": "Step-up authentication"
         },

--- a/apps/password-reset/src/assets/i18n/cs.json
+++ b/apps/password-reset/src/assets/i18n/cs.json
@@ -21,6 +21,7 @@
         "MFA_REQUIRED_DIALOG": {
           "TITLE": "Vyžadována step-up authentizace",
           "INFO": "Pro vykonání této akce musíte provést step-up authentizaci.",
+          "INFO_ROLE": "Pro přihlášení musíte provést step-up authentizaci.",
           "CANCEL": "Zrušit",
           "STEP_UP": "Step-up authentizace"
         },

--- a/apps/password-reset/src/assets/i18n/en.json
+++ b/apps/password-reset/src/assets/i18n/en.json
@@ -21,6 +21,7 @@
         "MFA_REQUIRED_DIALOG": {
           "TITLE": "Step-up authentication required",
           "INFO": "To perform this action you need to execute step-up authentication.",
+          "INFO_ROLE": "To log in you need to execute step-up authentication.",
           "CANCEL": "Cancel",
           "STEP_UP": "Step-up authentication"
         },

--- a/apps/publications/src/assets/i18n/en.json
+++ b/apps/publications/src/assets/i18n/en.json
@@ -437,6 +437,7 @@
         "MFA_REQUIRED_DIALOG": {
           "TITLE": "Step-up authentication required",
           "INFO": "To perform this action you need to execute step-up authentication.",
+          "INFO_ROLE": "To log in you need to execute step-up authentication.",
           "CANCEL": "Cancel",
           "STEP_UP": "Step-up authentication"
         },

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -351,6 +351,7 @@
         "MFA_REQUIRED_DIALOG": {
           "TITLE": "Vyžadována step-up authentizace",
           "INFO": "Pro vykonání této akce musíte provést step-up authentizaci.",
+          "INFO_ROLE": "Pro přihlášení musíte provést step-up authentizaci.",
           "CANCEL": "Zrušit",
           "STEP_UP": "Step-up authentizace"
         },

--- a/apps/user-profile/src/assets/i18n/en.json
+++ b/apps/user-profile/src/assets/i18n/en.json
@@ -427,6 +427,7 @@
         "MFA_REQUIRED_DIALOG": {
           "TITLE": "Step-up authentication required",
           "INFO": "To perform this action you need to execute step-up authentication.",
+          "INFO_ROLE": "To log in you need to execute step-up authentication.",
           "CANCEL": "Cancel",
           "STEP_UP": "Step-up authentication"
         },

--- a/libs/perun/multi-factor-authentication/src/lib/mfa-required-dialog/mfa-required-dialog.component.html
+++ b/libs/perun/multi-factor-authentication/src/lib/mfa-required-dialog/mfa-required-dialog.component.html
@@ -1,14 +1,20 @@
 <h1 mat-dialog-title>{{'SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.TITLE' | translate}}</h1>
 <div class="dialog-container" mat-dialog-content>
   <perun-web-apps-alert alert_type="warn">
-    {{'SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.INFO' | translate}}
+    {{data.mfaRoleException ?
+    ('SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.INFO_ROLE' | translate) :
+    ('SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.INFO' | translate)}}
   </perun-web-apps-alert>
 </div>
 <div mat-dialog-actions>
-  <button (click)="cancel()" class="ml-auto" mat-flat-button>
+  <button [hidden]="data.mfaRoleException" (click)="cancel()" class="ml-auto" mat-flat-button>
     {{'SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.CANCEL' | translate}}
   </button>
-  <button (click)="submit()" class="ml-2" color="accent" mat-flat-button>
+  <button
+    (click)="submit()"
+    [class]="data.mfaRoleException ? 'ml-auto' : 'ml-2'"
+    color="accent"
+    mat-flat-button>
     {{'SHARED_LIB.PERUN.COMPONENTS.MFA_REQUIRED_DIALOG.STEP_UP' | translate}}
   </button>
 </div>

--- a/libs/perun/multi-factor-authentication/src/lib/mfa-required-dialog/mfa-required-dialog.component.ts
+++ b/libs/perun/multi-factor-authentication/src/lib/mfa-required-dialog/mfa-required-dialog.component.ts
@@ -1,5 +1,9 @@
-import { Component } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+export interface MfaRequiredDialogData {
+  mfaRoleException: boolean;
+}
 
 @Component({
   selector: 'perun-web-apps-mfa-required-dialog',
@@ -7,7 +11,10 @@ import { MatDialogRef } from '@angular/material/dialog';
   styleUrls: ['./mfa-required-dialog.component.scss'],
 })
 export class MfaRequiredDialogComponent {
-  constructor(private dialogRef: MatDialogRef<MfaRequiredDialogComponent>) {}
+  constructor(
+    private dialogRef: MatDialogRef<MfaRequiredDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: MfaRequiredDialogData
+  ) {}
 
   cancel(): void {
     this.dialogRef.close(false);

--- a/libs/perun/services/src/lib/ApiInterceptor.ts
+++ b/libs/perun/services/src/lib/ApiInterceptor.ts
@@ -104,7 +104,7 @@ export class ApiInterceptor implements HttpInterceptor {
         const e = err.error as RPCError;
         // catch MFA required error and start MFA logic
         if (e.type === 'MfaPrivilegeException' || e.type === 'MfaRolePrivilegeException') {
-          return this.mfaHandlerService.openMfaWindow().pipe(
+          return this.mfaHandlerService.openMfaWindow(e.type === 'MfaRolePrivilegeException').pipe(
             switchMap((verified) => {
               if (verified) {
                 if (e.type === 'MfaRolePrivilegeException') {

--- a/libs/perun/services/src/lib/mfa-handler.service.ts
+++ b/libs/perun/services/src/lib/mfa-handler.service.ts
@@ -30,12 +30,15 @@ export class MfaHandlerService {
    * opened another window and the user cannot continue in the original application
    * without finishing authentication/closing the second window
    */
-  openMfaWindow(): Observable<boolean> {
+  openMfaWindow(mfaRoleException: boolean): Observable<boolean> {
     let newWindow: Window = null;
     let dialogRef: MatDialogRef<FocusOnMfaWindowComponent, void> = null;
 
     const configVerify = getDefaultDialogConfig();
     configVerify.width = '450px';
+    configVerify.data = {
+      mfaRoleException: mfaRoleException,
+    };
     const dialogVerifyRef = this.dialog.open(MfaRequiredDialogComponent, configVerify);
     let verificationSkipped = false;
 


### PR DESCRIPTION
* If there is the MfaRolePrivilegeException, we want to hide the cancel button.
* Previously after clicking on the cancel button there appeared another dialog with a refresh button, which only redirects the user back to the first dialog, so the cancel button is useless for this use case with role exception.