### PR TITLE
feat(publications): improve Publications application for a production usage

### DIFF
--- a/apps/publications/src/app/app.component.ts
+++ b/apps/publications/src/app/app.component.ts
@@ -44,7 +44,17 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.isServiceAccess = this.initAuth.isServiceAccessLoginScreenShown();
     sessionStorage.removeItem('baLogout');
     const url = location.pathname;
-    if (!this.authResolver.isCabinetAdmin() && (url === '/' || url.includes('/all-publications'))) {
+    const disabledUrlsForSelfRole = [
+      '/all-publications',
+      '/authors',
+      '/categories',
+      '/publication-systems',
+    ];
+
+    if (
+      !this.authResolver.isCabinetAdmin() &&
+      (url === '/' || disabledUrlsForSelfRole.some((disabledUrl) => url.includes(disabledUrl)))
+    ) {
       void this.router.navigate(['my-publications']);
     }
   }

--- a/apps/publications/src/app/components/add-authors/add-authors.component.html
+++ b/apps/publications/src/app/components/add-authors/add-authors.component.html
@@ -8,7 +8,7 @@
     {{'PUBLICATION_DETAIL.ADD' | translate}}
   </button>
   <button
-    *ngIf="!publication.locked"
+    *ngIf="!publication.locked && !similarityCheck"
     mat-flat-button
     color="warn"
     class="mr-2"
@@ -26,6 +26,7 @@
     [selection]="selection"
     [filterValue]="filterValue"
     [tableId]="tableId"
+    [disableRouting]="disableRouting"
     [displayedColumns]="publication.locked ? ['id', 'name', 'organization', 'email'] : ['select', 'id', 'name', 'organization', 'email']">
   </perun-web-apps-authors-list>
 </div>

--- a/apps/publications/src/app/components/add-thanks/add-thanks.component.html
+++ b/apps/publications/src/app/components/add-thanks/add-thanks.component.html
@@ -1,6 +1,6 @@
 <div class="'user-theme'">
   <button
-    *ngIf="!publication.locked"
+    *ngIf="!publication.locked && !similarityCheck"
     mat-flat-button
     color="accent"
     class="mr-2 action-button"
@@ -8,7 +8,7 @@
     {{'PUBLICATION_DETAIL.ADD' | translate}}
   </button>
   <button
-    *ngIf="!publication.locked"
+    *ngIf="!publication.locked && !similarityCheck"
     mat-flat-button
     color="warn"
     class="mr-2"

--- a/apps/publications/src/app/components/add-thanks/add-thanks.component.ts
+++ b/apps/publications/src/app/components/add-thanks/add-thanks.component.ts
@@ -21,6 +21,7 @@ import { UniversalConfirmationItemsDialogComponent } from '@perun-web-apps/perun
 export class AddThanksComponent implements OnInit {
   @Input() publication: PublicationForGUI;
   @Input() selection: SelectionModel<ThanksForGUI> = new SelectionModel<ThanksForGUI>(true, []);
+  @Input() similarityCheck = false;
 
   tableId = TABLE_PUBLICATION_THANKS;
 

--- a/apps/publications/src/app/components/authors-list/authors-list.component.html
+++ b/apps/publications/src/app/components/authors-list/authors-list.component.html
@@ -13,8 +13,19 @@
       matSortActive="name"
       matSortDirection="asc"
       matSortDisableClear>
-      <ng-container matColumnDef="select">
-        <th *matHeaderCellDef mat-header-cell class="align-checkbox"></th>
+      <ng-container
+        matColumnDef="select"
+        *ngIf="{all: dataSource | isAllSelected: selection.selected.length} as selected">
+        <th *matHeaderCellDef mat-header-cell class="align-checkbox">
+          <mat-checkbox
+            (change)="$event ? masterToggle() : null"
+            *ngIf="selection.isMultipleSelection()"
+            [aria-label]="selected.all | masterCheckboxLabel | translate"
+            [checked]="selection.hasValue() && selected.all"
+            [indeterminate]="selection.hasValue() && !selected.all"
+            color="primary">
+          </mat-checkbox>
+        </th>
         <td *matCellDef="let author" class="static-column-size align-checkbox" mat-cell>
           <mat-checkbox
             (change)="$event ? selection.toggle(author) : null"
@@ -52,22 +63,6 @@
           {{'AUTHORS_LIST.NUMBER_OF_PUBLICATIONS' | translate}}
         </th>
         <td *matCellDef="let author" mat-cell>{{author.authorships.length.toString()}}</td>
-      </ng-container>
-      <ng-container matColumnDef="add">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let author" class="static-column-size" mat-cell>
-          <button (click)="onAddClick(author)" class="ml-2" color="accent" mat-flat-button>
-            {{'AUTHORS_LIST.ADD' | translate}}
-          </button>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="remove">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let author" class="static-column-size" mat-cell>
-          <button (click)="onRemoveClick(author)" class="ml-2" color="warn" mat-flat-button>
-            {{'AUTHORS_LIST.REMOVE' | translate}}
-          </button>
-        </td>
       </ng-container>
       <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
       <tr

--- a/apps/publications/src/app/components/authors-list/authors-list.component.ts
+++ b/apps/publications/src/app/components/authors-list/authors-list.component.ts
@@ -1,12 +1,4 @@
-import {
-  AfterViewInit,
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, Component, Input, OnChanges, ViewChild } from '@angular/core';
 import { Author } from '@perun-web-apps/perun/openapi';
 import {
   customDataSourceFilterPredicate,
@@ -22,6 +14,7 @@ import {
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { SelectionModel } from '@angular/cdk/collections';
+import { TableCheckbox } from '@perun-web-apps/perun/services';
 
 @Component({
   selector: 'perun-web-apps-authors-list',
@@ -39,18 +32,16 @@ export class AuthorsListComponent implements AfterViewInit, OnChanges {
     'organization',
     'email',
     'numberOfPublications',
-    'add',
-    'remove',
   ];
   @Input() disableRouting = false;
   @Input() reloadTable: boolean;
-  @Input() selection: SelectionModel<Author>;
+  @Input() selection = new SelectionModel<Author>(true, []);
   @Input() pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
-  @Output() addAuthor = new EventEmitter();
-  @Output() removeAuthor = new EventEmitter();
   @ViewChild(TableWrapperComponent, { static: true }) child: TableWrapperComponent;
   dataSource: MatTableDataSource<Author>;
   private sort: MatSort;
+
+  constructor(private tableCheckbox: TableCheckbox) {}
 
   @ViewChild(MatSort, { static: true }) set matSort(ms: MatSort) {
     this.sort = ms;
@@ -156,12 +147,23 @@ export class AuthorsListComponent implements AfterViewInit, OnChanges {
     return attribute;
   }
 
-  onAddClick(author: Author): void {
-    this.addAuthor.emit(author);
+  /** Whether the number of selected elements matches the total number of rows. */
+  isAllSelected(): boolean {
+    return this.tableCheckbox.isAllSelected(this.selection.selected.length, this.dataSource);
   }
 
-  onRemoveClick(author: Author): void {
-    this.removeAuthor.emit(author);
+  /** Selects all rows if they are not all selected; otherwise clear selection. */
+  masterToggle(): void {
+    this.tableCheckbox.masterToggle(
+      this.isAllSelected(),
+      this.selection,
+      this.filterValue,
+      this.dataSource,
+      this.sort,
+      this.child.paginator.pageSize,
+      this.child.paginator.pageIndex,
+      false
+    );
   }
 
   private setDataSource(): void {

--- a/apps/publications/src/app/components/publication-detail-list/publication-detail-list.component.html
+++ b/apps/publications/src/app/components/publication-detail-list/publication-detail-list.component.html
@@ -6,7 +6,7 @@
       <button
         class="ml-auto"
         (click)="editing = !editing"
-        *ngIf="!editing && !publication.locked"
+        *ngIf="!editing && !publication.locked && !similarityCheck"
         mat-icon-button
         matTooltipPosition="above"
         matTooltip="{{'PUBLICATION_DETAIL.LIST.EDIT' | translate}}">

--- a/apps/publications/src/app/components/publication-filter/publication-filter.component.ts
+++ b/apps/publications/src/app/components/publication-filter/publication-filter.component.ts
@@ -1,10 +1,11 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { CabinetManagerService, Category } from '@perun-web-apps/perun/openapi';
-import { UntypedFormControl } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 import * as _moment from 'moment';
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MomentDateAdapter } from '@angular/material-moment-adapter';
 import { formatDate } from '@angular/common';
+import { Moment } from 'moment';
 
 const moment = _moment;
 
@@ -46,12 +47,12 @@ export class PublicationFilterComponent implements OnInit {
   @Output() filteredPublication: EventEmitter<FilterPublication> =
     new EventEmitter<FilterPublication>();
   categories: Category[];
-  title = new UntypedFormControl();
-  code = new UntypedFormControl();
+  title = new FormControl('');
+  code = new FormControl('');
   selectedMode: string;
   selectedCategory: Category | 'no_value';
-  startYear = new UntypedFormControl(moment());
-  endYear = new UntypedFormControl(moment());
+  startYear: FormControl<Moment> = new FormControl(moment());
+  endYear: FormControl<Moment> = new FormControl(moment());
 
   constructor(private cabinetService: CabinetManagerService) {}
 
@@ -66,14 +67,18 @@ export class PublicationFilterComponent implements OnInit {
   }
 
   filter(): void {
-    const code = this.code.value as string;
+    const code = this.code.value;
     const filter = {
-      title: this.title.value as string,
+      title: this.title.value,
       isbnissn: this.selectedMode === 'isbn/issn' ? code : null,
       doi: this.selectedMode === 'doi' ? code : null,
       category: this.selectedCategory !== 'no_value' ? this.selectedCategory.id : null,
-      startYear: formatDate(this.startYear.value as Date, 'yyyy', 'en-GB'),
-      endYear: formatDate(this.endYear.value as Date, 'yyyy', 'en-GB'),
+      startYear: formatDate(
+        this.startYear.value ? this.startYear.value.toDate() : null,
+        'yyyy',
+        'en-GB'
+      ),
+      endYear: formatDate(this.endYear.value.toDate(), 'yyyy', 'en-GB'),
     };
     this.filteredPublication.emit(filter);
   }
@@ -83,8 +88,8 @@ export class PublicationFilterComponent implements OnInit {
     this.code.setValue('');
     this.selectedMode = 'isbn/issn';
     this.selectedCategory = 'no_value';
-    this.startYear = new UntypedFormControl(moment());
-    this.endYear = new UntypedFormControl(moment());
+    this.startYear.setValue(null);
+    this.endYear.setValue(moment());
     const filter = {
       title: null,
       isbnissn: null,

--- a/apps/publications/src/app/components/publications-list/publications-list.component.html
+++ b/apps/publications/src/app/components/publications-list/publications-list.component.html
@@ -50,6 +50,7 @@
         <td *matCellDef="let publication" class="static-column-size" mat-cell>
           <button
             (click)="lockOrUnlockPublication(publication)"
+            [disabled]="!lockAuth"
             (mouseenter)="buttonPressed = true"
             (mouseleave)="buttonPressed = false"
             *ngIf="publication.locked"
@@ -59,6 +60,7 @@
           </button>
           <button
             (click)="lockOrUnlockPublication(publication)"
+            [disabled]="!lockAuth"
             (mouseenter)="buttonPressed = true"
             (mouseleave)="buttonPressed = false"
             *ngIf="!publication.locked"
@@ -81,7 +83,7 @@
           {{'PUBLICATIONS_LIST.TABLE_REPORTED_BY' | translate}}
         </th>
         <td *matCellDef="let publication" class="static-column-size" mat-cell>
-          <span *ngFor="let author of publication.authors"> {{author | userFullName}}<br /> </span>
+          {{publication.authors | authorsSeparatedByComma}}
         </td>
       </ng-container>
       <ng-container matColumnDef="year">
@@ -127,7 +129,7 @@
         *matRowDef="let publication; columns: displayedColumns;"
         [perunWebAppsMiddleClickRouterLink]="disabledRouting || buttonPressed ? null : [routerPath, publication.id]"
         [routerLink]="disabledRouting || buttonPressed ? null : [routerPath, publication.id]"
-        [class.cursor-pointer]="!disabledRouting"
+        [class.cursor-pointer]="!disabledRouting || openInTab"
         class="dark-hover-list-item"
         mat-row></tr>
     </table>

--- a/apps/publications/src/app/components/publications-list/publications-list.component.scss
+++ b/apps/publications/src/app/components/publications-list/publications-list.component.scss
@@ -1,7 +1,3 @@
-.mat-column-title {
-  width: 40%;
-}
-
 .cursor-pointer {
   cursor: pointer;
 }

--- a/apps/publications/src/app/components/publications-list/publications-list.component.ts
+++ b/apps/publications/src/app/components/publications-list/publications-list.component.ts
@@ -21,11 +21,10 @@ import {
   downloadData,
   getDataForExport,
   getDefaultDialogConfig,
-  parseFullName,
   TABLE_ITEMS_COUNT_OPTIONS,
   TableWrapperComponent,
 } from '@perun-web-apps/perun/utils';
-import { NotificatorService, TableCheckbox } from '@perun-web-apps/perun/services';
+import { GuiAuthResolver, NotificatorService, TableCheckbox } from '@perun-web-apps/perun/services';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import { ShowCiteDialogComponent } from '../../dialogs/show-cite-dialog/show-cite-dialog.component';
@@ -62,6 +61,7 @@ export class PublicationsListComponent implements OnChanges, AfterViewInit {
   dataSource: MatTableDataSource<PublicationForGUI>;
   buttonPressed = false;
   changeLockMessage: string;
+  lockAuth = false;
   locked: string;
   unlocked: string;
 
@@ -72,7 +72,8 @@ export class PublicationsListComponent implements OnChanges, AfterViewInit {
     private cabinetService: CabinetManagerService,
     private dialog: MatDialog,
     private notificator: NotificatorService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private authResolver: GuiAuthResolver
   ) {
     translate
       .get('PUBLICATIONS_LIST.CHANGE_LOCK_SUCCESS')
@@ -81,6 +82,7 @@ export class PublicationsListComponent implements OnChanges, AfterViewInit {
     translate
       .get('PUBLICATIONS_LIST.UNLOCKED')
       .subscribe((value: string) => (this.unlocked = value));
+    this.lockAuth = this.authResolver.isCabinetAdmin();
   }
 
   @ViewChild(MatSort, { static: true }) set matSort(ms: MatSort) {
@@ -98,7 +100,7 @@ export class PublicationsListComponent implements OnChanges, AfterViewInit {
         return data.title;
       case 'reportedBy': {
         let result = '';
-        data.authors.forEach((a) => (result += parseFullName(a) + ';'));
+        data.authors.forEach((a) => (result += a.firstName + ' ' + a.lastName + ';'));
         return result.slice(0, -1);
       }
       case 'year':

--- a/apps/publications/src/app/components/year-range/year-range.component.html
+++ b/apps/publications/src/app/components/year-range/year-range.component.html
@@ -12,7 +12,7 @@
     #sdp
     startView="multi-year"
     (yearSelected)="chosenYearHandler(startYear, $event, sdp)"
-    panelClass="example-month-picker">
+    panelClass="year-picker">
   </mat-datepicker>
 </mat-form-field>
 
@@ -23,12 +23,13 @@
     [matDatepicker]="edp"
     [min]="endMinYear"
     [max]="endMaxYear"
-    [formControl]="endYear" />
+    [formControl]="endYear"
+    readonly />
   <mat-datepicker-toggle matSuffix [for]="edp"></mat-datepicker-toggle>
   <mat-datepicker
     #edp
     startView="multi-year"
     (yearSelected)="chosenYearHandler(endYear, $event, edp)"
-    panelClass="example-month-picker">
+    panelClass="year-picker">
   </mat-datepicker>
 </mat-form-field>

--- a/apps/publications/src/app/components/year-range/year-range.component.scss
+++ b/apps/publications/src/app/components/year-range/year-range.component.scss
@@ -1,5 +1,14 @@
 .year-field {
-  max-width: 80px !important;
+  max-width: 95px !important;
   width: 100% !important;
   min-width: initial !important;
+}
+
+.year-picker {
+  .mat-calendar-period-button {
+    pointer-events: none;
+  }
+  .mat-calendar-arrow {
+    display: none;
+  }
 }

--- a/apps/publications/src/app/components/year-range/year-range.component.ts
+++ b/apps/publications/src/app/components/year-range/year-range.component.ts
@@ -1,33 +1,35 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { MatDatepicker } from '@angular/material/datepicker';
+import { Moment } from 'moment';
 
 @Component({
   selector: 'perun-web-apps-year-range',
   templateUrl: './year-range.component.html',
   styleUrls: ['./year-range.component.scss'],
+  encapsulation: ViewEncapsulation.None,
 })
 export class YearRangeComponent implements OnInit {
-  @Input() startYear: UntypedFormControl;
-  @Input() endYear: UntypedFormControl;
+  @Input() startYear: FormControl<Moment>;
+  @Input() endYear: FormControl<Moment>;
   startMaxYear: Date;
   endMinYear: Date;
   endMaxYear: Date;
 
   ngOnInit(): void {
     this.endMaxYear = new Date();
-    this.startMaxYear = this.endYear.value as Date;
-    this.endMinYear = this.startYear.value as Date;
+    this.startMaxYear = this.endYear.value.toDate();
+    this.startYear.setValue(null);
   }
 
   chosenYearHandler(
-    dateFormControl: UntypedFormControl,
-    event: UntypedFormControl,
-    datepicker: MatDatepicker<Date>
+    dateFormControl: FormControl<Moment>,
+    event: Moment,
+    datepicker: MatDatepicker<Moment>
   ): void {
     dateFormControl.setValue(event);
-    this.startMaxYear = this.endYear.value as Date;
-    this.endMinYear = this.startYear.value as Date;
+    this.startMaxYear = this.endYear.value.toDate();
+    this.endMinYear = this.startYear.value ? this.startYear.value.toDate() : null;
     datepicker.close();
   }
 }

--- a/apps/publications/src/app/dialogs/add-authors-dialog/add-authors-dialog.component.html
+++ b/apps/publications/src/app/dialogs/add-authors-dialog/add-authors-dialog.component.html
@@ -27,33 +27,16 @@
         <perun-web-apps-authors-list
           *ngIf="firstSearchDone"
           [authors]="authors"
-          (addAuthor)="addAuthor($event)"
+          [selection]="selection"
           [disableRouting]="true"
           [tableId]="tableIdAuthors"
-          [displayedColumns]="['id', 'name', 'organization', 'email', 'add']">
+          [displayedColumns]="['select', 'id', 'name', 'organization', 'email']">
         </perun-web-apps-authors-list>
         <perun-web-apps-alert *ngIf="!firstSearchDone" alert_type="info">
           {{'DIALOGS.ADD_AUTHORS.SEARCH_INFO' | translate}}
         </perun-web-apps-alert>
       </div>
       <mat-spinner *ngIf="searchLoading" class="ml-auto mr-auto"></mat-spinner>
-      <h2 mat-dialog-title class="top-margin">
-        {{'DIALOGS.ADD_AUTHORS.AUTHORS_TO_ADD' | translate}}
-      </h2>
-      <div *ngIf="firstSearchDone && authorsToAdd.length !== 0">
-        <perun-web-apps-authors-list
-          *ngIf="firstSearchDone"
-          [reloadTable]="reloadTable"
-          [authors]="authorsToAdd"
-          (removeAuthor)="removeAuthor($event)"
-          [disableRouting]="true"
-          [tableId]="tableIdAuthors"
-          [displayedColumns]="['id', 'name', 'organization', 'email', 'remove']">
-        </perun-web-apps-authors-list>
-      </div>
-      <perun-web-apps-alert *ngIf="authorsToAdd.length === 0" alert_type="warn">
-        {{'DIALOGS.ADD_AUTHORS.NO_AUTHORS_TO_ADD' | translate}}
-      </perun-web-apps-alert>
     </div>
   </div>
   <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
@@ -64,7 +47,7 @@
     </button>
     <button
       (click)="onAdd()"
-      [disabled]="authorsToAdd.length === 0 || loading"
+      [disabled]="selection.selected.length === 0 || loading"
       class="ml-2"
       color="accent"
       mat-flat-button>

--- a/apps/publications/src/app/dialogs/add-category-dialog/add-category-dialog.component.ts
+++ b/apps/publications/src/app/dialogs/add-category-dialog/add-category-dialog.component.ts
@@ -3,7 +3,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { NotificatorService } from '@perun-web-apps/perun/services';
 import { CabinetManagerService } from '@perun-web-apps/perun/openapi';
 import { TranslateService } from '@ngx-translate/core';
-import { UntypedFormControl, Validators } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 
 @Component({
   selector: 'perun-web-apps-add-category-dialog',
@@ -14,8 +14,8 @@ export class AddCategoryDialogComponent implements OnInit {
   successMessage: string;
   loading: boolean;
 
-  nameCtrl: UntypedFormControl;
-  rankCtrl: UntypedFormControl;
+  nameCtrl: FormControl<string>;
+  rankCtrl: FormControl<number>;
 
   constructor(
     private dialogRef: MatDialogRef<AddCategoryDialogComponent>,
@@ -29,12 +29,12 @@ export class AddCategoryDialogComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.nameCtrl = new UntypedFormControl(null, [
+    this.nameCtrl = new FormControl('', [
       Validators.required,
       Validators.pattern('^[\\w.-]+( [\\w.-]+)*$'),
       Validators.maxLength(128),
     ]);
-    this.rankCtrl = new UntypedFormControl(null, [
+    this.rankCtrl = new FormControl<number>(null, [
       Validators.required,
       Validators.pattern('^[0-9]+(\\.[0-9])?$'),
     ]);
@@ -51,18 +51,18 @@ export class AddCategoryDialogComponent implements OnInit {
         category: {
           id: 0,
           beanName: 'Category',
-          name: this.nameCtrl.value as string,
-          rank: this.rankCtrl.value as number,
+          name: this.nameCtrl.value,
+          rank: this.rankCtrl.value,
         },
       })
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           // this.cabinetManagerService.createCategoryNR({name: this.nameCtrl.value, rank: this.rankCtrl.value}).subscribe(vo => {
           this.notificator.showSuccess(this.successMessage);
           this.loading = false;
           this.dialogRef.close(true);
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
   }
 }

--- a/apps/publications/src/app/dialogs/show-cite-dialog/show-cite-dialog.component.html
+++ b/apps/publications/src/app/dialogs/show-cite-dialog/show-cite-dialog.component.html
@@ -5,8 +5,12 @@
     {{publication.main}}
   </div>
   <div mat-dialog-actions>
-    <button mat-stroked-button class="ml-auto" (click)="close()">
-      {{'DIALOGS.SHOW_CITE.OK' | translate}}
+    <button mat-flat-button class="ml-auto" (click)="close()">
+      {{'DIALOGS.SHOW_CITE.CANCEL' | translate}}
+    </button>
+    <button (click)="clipboard.copy(publication.main)" mat-button>
+      {{'DIALOGS.SHOW_CITE.COPY' | translate}}
+      <mat-icon>content_copy</mat-icon>
     </button>
   </div>
 </div>

--- a/apps/publications/src/app/dialogs/show-cite-dialog/show-cite-dialog.component.ts
+++ b/apps/publications/src/app/dialogs/show-cite-dialog/show-cite-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { PublicationForGUI } from '@perun-web-apps/perun/openapi';
+import { Clipboard } from '@angular/cdk/clipboard';
 @Component({
   selector: 'perun-web-apps-show-cite-dialog',
   templateUrl: './show-cite-dialog.component.html',
@@ -11,7 +12,8 @@ export class ShowCiteDialogComponent implements OnInit {
 
   constructor(
     private dialogRef: MatDialogRef<ShowCiteDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: PublicationForGUI
+    @Inject(MAT_DIALOG_DATA) public data: PublicationForGUI,
+    public clipboard: Clipboard
   ) {}
 
   ngOnInit(): void {

--- a/apps/publications/src/app/dialogs/update-rank-dialog/update-rank-dialog.component.ts
+++ b/apps/publications/src/app/dialogs/update-rank-dialog/update-rank-dialog.component.ts
@@ -3,7 +3,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NotificatorService } from '@perun-web-apps/perun/services';
 import { CabinetManagerService, Category } from '@perun-web-apps/perun/openapi';
 import { TranslateService } from '@ngx-translate/core';
-import { UntypedFormControl, Validators } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 
 @Component({
   selector: 'perun-web-apps-update-rank-dialog',
@@ -14,7 +14,7 @@ export class UpdateRankDialogComponent implements OnInit {
   successMessage: string;
   loading: boolean;
   categoryName = '';
-  rankCtrl: UntypedFormControl;
+  rankCtrl: FormControl<number>;
 
   constructor(
     private dialogRef: MatDialogRef<UpdateRankDialogComponent>,
@@ -30,7 +30,7 @@ export class UpdateRankDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.categoryName = this.data.name;
-    this.rankCtrl = new UntypedFormControl(this.data.rank, [
+    this.rankCtrl = new FormControl(this.data.rank, [
       Validators.required,
       Validators.pattern('^[0-9]+(\\.[0-9])?$'),
     ]);
@@ -42,14 +42,14 @@ export class UpdateRankDialogComponent implements OnInit {
 
   onSubmit(): void {
     this.loading = true;
-    this.data.rank = this.rankCtrl.value as number;
-    this.cabinetManagerService.updateCategory({ category: this.data }).subscribe(
-      () => {
+    this.data.rank = this.rankCtrl.value;
+    this.cabinetManagerService.updateCategory({ category: this.data }).subscribe({
+      next: () => {
         this.notificator.showSuccess(this.successMessage);
         this.loading = false;
         this.dialogRef.close(true);
       },
-      () => (this.loading = false)
-    );
+      error: () => (this.loading = false),
+    });
   }
 }

--- a/apps/publications/src/app/pages/all-publications-page/all-publications-page.component.ts
+++ b/apps/publications/src/app/pages/all-publications-page/all-publications-page.component.ts
@@ -67,8 +67,8 @@ export class AllPublicationsPageComponent implements OnInit {
     this.cabinetService
       .findPublicationsByGUIFilter(
         this.filter.title,
-        null,
-        null,
+        this.filter.isbnissn,
+        this.filter.doi,
         null,
         null,
         this.filter.category,

--- a/apps/publications/src/app/pages/author-detail/author-detail.component.ts
+++ b/apps/publications/src/app/pages/author-detail/author-detail.component.ts
@@ -76,8 +76,8 @@ export class AuthorDetailComponent implements OnInit {
     this.cabinetService
       .findPublicationsByGUIFilter(
         event.title,
-        null,
-        null,
+        event.isbnissn,
+        event.doi,
         null,
         null,
         event.category,

--- a/apps/publications/src/app/pages/create-publication-page/create-publication-page.component.html
+++ b/apps/publications/src/app/pages/create-publication-page/create-publication-page.component.html
@@ -7,7 +7,7 @@
   </h1>
   <div class="card-container">
     <div class="align-cards">
-      <mat-card class="mat-elevation-z3">
+      <mat-card class="mat-elevation-z3 card-height">
         <mat-card-title>
           {{'CREATE_PUBLICATION.IMPORT_TITLE' | translate}}
         </mat-card-title>
@@ -26,7 +26,7 @@
       </mat-card>
     </div>
     <div class="align-cards">
-      <mat-card class="mat-elevation-z3">
+      <mat-card class="mat-elevation-z3 card-height">
         <mat-card-title>
           {{'CREATE_PUBLICATION.CREATE_TITLE' | translate}}
         </mat-card-title>
@@ -36,7 +36,7 @@
           </div>
           <button
             (click)="createPublication()"
-            class="align-self-end action-button"
+            class="align-self-end action-button create-button"
             mat-flat-button
             color="accent">
             {{'CREATE_PUBLICATION.CREATE' | translate}}

--- a/apps/publications/src/app/pages/create-publication-page/create-publication-page.component.scss
+++ b/apps/publications/src/app/pages/create-publication-page/create-publication-page.component.scss
@@ -14,3 +14,12 @@
   max-width: 250px;
   max-height: 200px;
 }
+
+.card-height {
+  height: 200px;
+}
+
+.create-button {
+  display: flex;
+  margin-top: 21px;
+}

--- a/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.html
+++ b/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.html
@@ -6,8 +6,8 @@
     </span>
   </h1>
   <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <mat-horizontal-stepper *ngIf="!loading" linear="True" (selectionChange)="stepChanged($event)">
-    <mat-step [editable]="!duplicateCheck" [stepControl]="publicationControl">
+  <mat-horizontal-stepper #stepper *ngIf="!loading" (selectionChange)="stepChanged($event)">
+    <mat-step [stepControl]="publicationControl">
       <ng-template
         matStepLabel
         >{{'CREATE_SINGLE_PUBLICATION.PUBLICATION' | translate}}</ng-template
@@ -45,6 +45,7 @@
             <mat-datepicker
               #sdp
               startView="multi-year"
+              panelClass="year-picker"
               (yearSelected)="chosenYearHandler($event, sdp)">
             </mat-datepicker>
             <mat-error *ngIf="publicationControl.hasError('required', 'year')">
@@ -92,18 +93,18 @@
           </mat-form-field>
         </div>
       </form>
-      <div class="mt-1">
+      <div class="actions">
         <button
           [disabled]="publicationControl.invalid"
-          class="ml-auto"
-          mat-stroked-button
-          type="button"
+          class="ml-auto mr-2"
+          mat-flat-button
+          color="accent"
           matStepperNext>
           {{'CREATE_SINGLE_PUBLICATION.NEXT' | translate}}
         </button>
       </div>
     </mat-step>
-    <mat-step [editable]="!duplicateCheck">
+    <mat-step [editable]="!duplicateCheck && !publicationControl.invalid">
       <ng-template matStepLabel>
         {{'CREATE_SINGLE_PUBLICATION.CHECK' | translate}}
       </ng-template>
@@ -158,10 +159,15 @@
           </mat-tab>
 
           <mat-tab *ngIf="selectedPubId !== null">
-            <ng-template matTabLabel>{{selectedPubTitle}}</ng-template>
+            <ng-template matTabLabel>
+              {{selectedPubTitle | publicationTabLabel}}
+            </ng-template>
             <ng-template matTabContent>
               <div class="mt-4">
-                <perun-web-apps-publication-detail [publicationId]="selectedPubId">
+                <perun-web-apps-publication-detail
+                  [publicationId]="selectedPubId"
+                  [disableRouting]="true"
+                  [similarityCheck]="true">
                 </perun-web-apps-publication-detail>
               </div>
             </ng-template>
@@ -176,25 +182,19 @@
         </div>
       </form>
 
-      <div *ngIf="!innerLoading" class="mt-3">
+      <div *ngIf="!innerLoading" class="actions">
         <button
-          *ngIf="!duplicateCheck"
-          class="ml-auto"
-          mat-stroked-button
-          type="button"
-          matStepperPrevious>
+          class="ml-2"
+          mat-flat-button
+          (click)="redirect(['create-publication'])"
+          type="button">
+          {{'CREATE_SINGLE_PUBLICATION.CANCEL' | translate}}
+        </button>
+        <button class="ml-auto" mat-flat-button type="button" matStepperPrevious>
           {{'CREATE_SINGLE_PUBLICATION.PREV' | translate}}
         </button>
         <button class="ml-2" mat-flat-button color="accent" type="button" matStepperNext>
           {{'CREATE_SINGLE_PUBLICATION.CREATE' | translate}}
-        </button>
-        <button
-          *ngIf="!duplicateCheck"
-          class="ml-2"
-          mat-stroked-button
-          (click)="redirect(['create-publication'])"
-          type="button">
-          {{'CREATE_SINGLE_PUBLICATION.RETURN' | translate}}
         </button>
       </div>
     </mat-step>
@@ -216,20 +216,14 @@
         <perun-web-apps-add-authors
           *ngIf="publication !== null"
           [publication]="publication"
-          [selection]="authorsSelection">
+          [selection]="authorsSelection"
+          [disableRouting]="true"
+          (yourselfAsAnAuthor)="yourselfAsAnAuthor = $event">
         </perun-web-apps-add-authors>
       </div>
 
-      <div *ngIf="!innerLoading" class="mt-1">
-        <button
-          *ngIf="!duplicateCheck"
-          class="ml-auto"
-          mat-stroked-button
-          type="button"
-          matStepperPrevious>
-          {{'CREATE_SINGLE_PUBLICATION.PREV' | translate}}
-        </button>
-        <button class="ml-2" mat-stroked-button type="button" matStepperNext>
+      <div *ngIf="!innerLoading" class="actions">
+        <button class="ml-auto" mat-flat-button color="accent" matStepperNext>
           {{'CREATE_SINGLE_PUBLICATION.NEXT' | translate}}
         </button>
       </div>
@@ -250,15 +244,14 @@
       </perun-web-apps-add-thanks>
       <mat-spinner *ngIf="innerLoading" class="ml-auto mr-auto"></mat-spinner>
 
-      <div class="mt-1">
-        <button class="ml-auto" mat-stroked-button type="button" matStepperPrevious>
+      <div class="actions">
+        <button class="ml-auto" mat-flat-button matStepperPrevious>
           {{'CREATE_SINGLE_PUBLICATION.PREV' | translate}}
         </button>
         <button
           class="ml-2"
-          (click)="redirect(['all-publications', this.publication.id])"
+          (click)="showDialogAndRedirect(['all-publications'], this.publication.id)"
           mat-flat-button
-          type="button"
           color="accent">
           {{'CREATE_SINGLE_PUBLICATION.FINISH' | translate}}
         </button>

--- a/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.scss
+++ b/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.scss
@@ -19,3 +19,22 @@
   display: flex;
   flex-direction: column;
 }
+
+.year-picker {
+  .mat-calendar-period-button {
+    pointer-events: none;
+  }
+  .mat-calendar-arrow {
+    display: none;
+  }
+}
+
+.actions {
+  background-color: #ffffff;
+  display: flex;
+  margin-top: 20px;
+}
+
+.mat-horizontal-stepper-header {
+  pointer-events: none !important;
+}

--- a/apps/publications/src/app/pages/create-publication-page/import-publications-page/import-publications-page.component.scss
+++ b/apps/publications/src/app/pages/create-publication-page/import-publications-page/import-publications-page.component.scss
@@ -1,3 +1,8 @@
+.add-icon {
+  font-size: 32px;
+  vertical-align: text-top;
+}
+
 .input-width-300 {
   width: 300px;
 }

--- a/apps/publications/src/app/pages/my-publications-page/my-publications-page.component.ts
+++ b/apps/publications/src/app/pages/my-publications-page/my-publications-page.component.ts
@@ -71,8 +71,8 @@ export class MyPublicationsPageComponent implements OnInit {
     this.cabinetService
       .findPublicationsByGUIFilter(
         this.filter.title,
-        null,
-        null,
+        this.filter.isbnissn,
+        this.filter.doi,
         null,
         null,
         this.filter.category,

--- a/apps/publications/src/app/pages/publication-detail/publication-detail.component.html
+++ b/apps/publications/src/app/pages/publication-detail/publication-detail.component.html
@@ -24,16 +24,21 @@
     <h5>{{'PUBLICATION_DETAIL.TITLE' | translate}}</h5>
     <h6>
       {{'PUBLICATION_DETAIL.LOCK_INFO' | translate}}
-      <button class="ml-2" (click)="changeLock()" mat-stroked-button>
-        <span *ngIf="publication.locked" class="font-weight-bold">
-          {{'PUBLICATION_DETAIL.LOCKED' | translate}}
-        </span>
-        <mat-icon *ngIf="publication.locked"> lock </mat-icon>
-        <span *ngIf="!publication.locked" class="font-weight-bold">
-          {{'PUBLICATION_DETAIL.UNLOCKED' | translate}}
-        </span>
-        <mat-icon *ngIf="!publication.locked"> lock_open </mat-icon>
-      </button>
+      <span
+        matTooltip="{{'PUBLICATION_DETAIL.LOCK_DISABLED_TOOLTIP' | translate}}"
+        matTooltipPosition="below"
+        [matTooltipDisabled]="lockAuth">
+        <button class="ml-2" [disabled]="!lockAuth" (click)="changeLock()" mat-stroked-button>
+          <span *ngIf="publication.locked" class="font-weight-bold">
+            {{'PUBLICATION_DETAIL.LOCKED' | translate}}
+          </span>
+          <mat-icon *ngIf="publication.locked"> lock </mat-icon>
+          <span *ngIf="!publication.locked" class="font-weight-bold">
+            {{'PUBLICATION_DETAIL.UNLOCKED' | translate}}
+          </span>
+          <mat-icon *ngIf="!publication.locked"> lock_open </mat-icon>
+        </button>
+      </span>
     </h6>
     <mat-card>
       <mat-card-content>
@@ -42,6 +47,7 @@
           *ngIf="!pubLoading && !loading"
           [publication]="publication"
           [categories]="categories"
+          [similarityCheck]="similarityCheck"
           (edited)="refreshPublication()">
         </perun-web-apps-publication-detail-list>
       </mat-card-content>
@@ -52,7 +58,11 @@
         {{'PUBLICATION_DETAIL.AUTHORS' | translate}}
       </mat-card-title>
       <mat-card-content>
-        <perun-web-apps-add-authors [publication]="publication" [selection]="selectionAuthors">
+        <perun-web-apps-add-authors
+          [publication]="publication"
+          [selection]="selectionAuthors"
+          [disableRouting]="disableRouting"
+          [similarityCheck]="similarityCheck">
         </perun-web-apps-add-authors>
       </mat-card-content>
     </mat-card>
@@ -61,7 +71,10 @@
         {{'PUBLICATION_DETAIL.ACKNOWLEDGEMENT' | translate}}
       </mat-card-title>
       <mat-card-content>
-        <perun-web-apps-add-thanks [publication]="publication" [selection]="selectionThanks">
+        <perun-web-apps-add-thanks
+          [publication]="publication"
+          [selection]="selectionThanks"
+          [similarityCheck]="similarityCheck">
         </perun-web-apps-add-thanks>
       </mat-card-content>
     </mat-card>

--- a/apps/publications/src/app/pages/publication-detail/publication-detail.component.ts
+++ b/apps/publications/src/app/pages/publication-detail/publication-detail.component.ts
@@ -12,7 +12,7 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatDialog } from '@angular/material/dialog';
-import { NotificatorService } from '@perun-web-apps/perun/services';
+import { GuiAuthResolver, NotificatorService } from '@perun-web-apps/perun/services';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -22,6 +22,8 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class PublicationDetailComponent implements OnInit {
   @Input() publicationId: number;
+  @Input() disableRouting = false;
+  @Input() similarityCheck = false;
   loading = false;
   pubLoading = false;
   initLoading = false;
@@ -30,9 +32,9 @@ export class PublicationDetailComponent implements OnInit {
   mode: string;
   mainAuthorId: number;
   mainAuthor: Author;
-  disabledColumns: string[];
   selectionAuthors: SelectionModel<Author> = new SelectionModel<Author>(true, []);
   selectionThanks: SelectionModel<ThanksForGUI> = new SelectionModel<ThanksForGUI>(true, []);
+  lockAuth = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -41,7 +43,8 @@ export class PublicationDetailComponent implements OnInit {
     private domSanitizer: DomSanitizer,
     private dialog: MatDialog,
     private notificator: NotificatorService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private authResolver: GuiAuthResolver
   ) {
     this.matIconRegistry.addSvgIcon(
       'publications',
@@ -51,6 +54,8 @@ export class PublicationDetailComponent implements OnInit {
 
   ngOnInit(): void {
     this.initLoading = true;
+    this.disableRouting = this.disableRouting || !this.authResolver.isCabinetAdmin();
+    this.lockAuth = this.authResolver.isCabinetAdmin();
     if (this.publicationId) {
       this.setMode();
       this.loadAllData();

--- a/apps/publications/src/app/services/side-menu-items.service.ts
+++ b/apps/publications/src/app/services/side-menu-items.service.ts
@@ -41,21 +41,21 @@ export class SideMenuItemsService {
         activatedRegex: '^/authors',
         tabName: 'authors',
       });
+      items.push({
+        label: 'MENU_ITEMS.CATEGORIES',
+        icon: 'all_inbox',
+        link: '/categories',
+        activatedRegex: '^/categories$',
+        tabName: 'categories',
+      });
+      items.push({
+        label: 'MENU_ITEMS.PUBLICATION_SYSTEMS',
+        icon: 'assignment',
+        link: '/publication-systems',
+        activatedRegex: '^/publication-systems$',
+        tabName: 'publication-systems',
+      });
     }
-    items.push({
-      label: 'MENU_ITEMS.CATEGORIES',
-      icon: 'all_inbox',
-      link: '/categories',
-      activatedRegex: '^/categories$',
-      tabName: 'categories',
-    });
-    items.push({
-      label: 'MENU_ITEMS.PUBLICATION_SYSTEMS',
-      icon: 'assignment',
-      link: '/publication-systems',
-      activatedRegex: '^/publication-systems$',
-      tabName: 'publication-systems',
-    });
     return items;
   }
 }

--- a/apps/publications/src/assets/i18n/en.json
+++ b/apps/publications/src/assets/i18n/en.json
@@ -2,7 +2,7 @@
   "MENU_ITEMS": {
     "ALL_PUBLICATIONS": "All publications",
     "MY_PUBLICATIONS": "My publications",
-    "CREATE_PUBLICATION": "Create publications",
+    "CREATE_PUBLICATION": "Create publication",
     "AUTHORS": "Authors",
     "CATEGORIES": "Categories",
     "PUBLICATION_SYSTEMS": "Publication systems"
@@ -33,9 +33,7 @@
     "ORGANIZATION": "Organization",
     "EMAIL": "Email",
     "NUMBER_OF_PUBLICATIONS": "Publications count",
-    "NO_AUTHORS": "No authors were found.",
-    "ADD": "Add",
-    "REMOVE": "Remove"
+    "NO_AUTHORS": "No authors were found."
   },
   "AUTHOR_DETAIL": {
     "TITLE": " publications",
@@ -52,14 +50,14 @@
   "CREATE_PUBLICATION": {
     "TITLE": "Create publication",
     "IMPORT_TITLE": "Import publication",
-    "IMPORT_HINT":  "Are you from MU, ZCU? You can import publications you have already reported in university publication systems.",
+    "IMPORT_HINT":  "Are you from MU, ZCU? You can import publication you have already reported in university publication systems.",
     "IMPORT": "Import",
     "CREATE_TITLE": "Create publication",
     "CREATE_HINT": "Use when you want to add custom publication or report publication created by other user.",
     "CREATE": "Create"
   },
   "IMPORT_PUBLICATIONS": {
-    "TITLE": "Import publications",
+    "TITLE": "Import publication",
     "EXT_PUB_SYSTEM": "External publication system",
     "START_DATE": "Start date",
     "END_DATE": "End date",
@@ -100,15 +98,17 @@
     "PREV": "Back",
     "FINISH": "Finish",
     "CREATE": "Create publication",
-    "RETURN": "Return",
+    "CANCEL": "Cancel",
     "SIMILAR_FOUND": "Similar publication already exists",
     "CHECK_BELOW": "Please check if your publication is listed below",
     "NOT_BELOW": "If NO, continue with Create button below.",
-    "IS_BELOW": "If YES, click on it to see details and add yourself as an author. Afterwards continue with the Return button. If desired publication is locked for changes, notify administrators about your request.",
+    "IS_BELOW": "If YES, click on it to see details and add yourself as an author. Afterwards continue with the Cancel button. If desired publication is locked for changes, notify administrators about your request.",
     "CHECK_PERFORM": "Checking for similar publications",
-    "NO_SIMILAR": "Publication similarity check passed",
+    "NO_SIMILAR": "Check passed - no similar publications were found.",
     "SUCCESS": "Publication was successfully created.",
-    "PUB_CREATED": "Publication was created, however it is not fully set up. You can finish setting up your publication by completing all steps. Additionally you can always edit publications on their detail."
+    "PUB_CREATED": "Publication was created, however it is not fully set up. You can finish setting up your publication by completing all steps. Additionally you can always edit publications on their detail.",
+    "NOT_AN_AUTHOR_DIALOG_TITLE": "Not an author",
+    "NOT_AN_AUTHOR_DIALOG_ALERT": "You are not set as an author of this publication. If you submit it like this, you won't be able to edit it afterwards."
   },
   "PUBLICATIONS_LIST": {
     "TABLE_ID": "Id",
@@ -120,14 +120,15 @@
     "TABLE_THANKEDTO": "Thanks",
     "TABLE_CITE": "Cite",
     "NO_PUBLICATIONS_FOUND": "No publications found",
-    "SHOW_CITE": "Show cite",
+    "SHOW_CITE": "Cite",
     "CHANGE_LOCK_SUCCESS": "Publication was successfully ",
-    "LOCKED": "locked",
-    "UNLOCKED": "unlocked"
+    "LOCKED": "Locked",
+    "UNLOCKED": "Unlocked"
   },
   "PUBLICATION_DETAIL": {
     "TITLE": "Publication detail",
     "LOCK_INFO": "This publication is",
+    "LOCK_DISABLED_TOOLTIP": "You are not authorized to perform this action",
     "ACKNOWLEDGEMENT": "Acknowledgement",
     "AUTHORS": "Authors / Reported by",
     "LOCKED": "Locked",
@@ -213,8 +214,9 @@
       "SUCCESS": "Category successfully updated"
     },
     "SHOW_CITE": {
-      "TITLE": "Publication cite",
-      "OK": "Ok"
+      "TITLE": "Cite publication",
+      "COPY": "Copy",
+      "CANCEL": "Cancel"
     },
     "REMOVE_PUBLICATION": {
       "TITLE": "Confirm removal",
@@ -235,8 +237,6 @@
       "SEARCH_PLACEHOLDER": "Search by name",
       "EMPTY_SEARCH_MESSAGE": "Search field cannot be empty",
       "SEARCH_INFO": "You can search authors by name",
-      "AUTHORS_TO_ADD": "Authors to add",
-      "NO_AUTHORS_TO_ADD": "No authors to add",
       "SUCCESS_MESSAGE": "Authors successfully added",
       "CANCEL": "Cancel",
       "ADD": "Add"
@@ -298,7 +298,7 @@
         "RESOURCES_LIST": {
           "TITLE": "Resources",
           "DELETE": "Remove selected",
-          "TABLE_RESOURCE_ID": "id",
+          "TABLE_RESOURCE_ID": "Id",
           "TABLE_RESOURCE_NAME": "Name",
           "TABLE_VO_NAME": "Organization",
           "TABLE_FACILITY_NAME": "Facility name",
@@ -354,7 +354,10 @@
           "TITLE": "Requested user (by ID or external identity) doesn't exist."
         },
         "TABLE_OPTIONS": {
-          "EXPORT_TO_FILE": "Export to file"
+          "EXPORT_TO_FILE": "Export to file",
+          "ALL_DATA": "All data",
+          "DISPLAYED_DATA": "Displayed data",
+          "EXPORT_LOADING": "Exporting data..."
         },
         "NOTIFICATOR": {
           "NOTIFICATION": {

--- a/apps/publications/src/styles.scss
+++ b/apps/publications/src/styles.scss
@@ -324,3 +324,21 @@ $i: 0;
 mat-icon {
   overflow: inherit !important;
 }
+
+.static-column-size {
+  width: 80px;
+}
+
+.align-checkbox {
+  text-align: center !important;
+  vertical-align: middle !important;
+}
+
+.align-checkbox mat-checkbox {
+  margin-top: 7px !important;
+}
+
+.mat-tooltip {
+  font-size: 14px !important;
+  word-wrap: break-word !important;
+}

--- a/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.html
@@ -10,7 +10,7 @@
       {{'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_REMOVE_ITEMS_DIALOG.ASK' | translate}}
     </div>
 
-    <table mat-table [dataSource]="dataSource" class="w-100">
+    <table *ngIf="data.items.length" mat-table [dataSource]="dataSource" class="w-100">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef></th>
         <td mat-cell *matCellDef="let item">{{item}}</td>

--- a/libs/perun/pipes/src/index.ts
+++ b/libs/perun/pipes/src/index.ts
@@ -33,3 +33,5 @@ export * from './lib/master-checkbox-label.pipe';
 export * from './lib/displayed-role.pipe';
 export * from './lib/manageable-entities.pipe';
 export * from './lib/unassigned-role.pipe';
+export * from './lib/publication-tab-label.pipe';
+export * from './lib/authors-separated-by-comma.pipe';

--- a/libs/perun/pipes/src/lib/authors-separated-by-comma.pipe.ts
+++ b/libs/perun/pipes/src/lib/authors-separated-by-comma.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Author } from '@perun-web-apps/perun/openapi';
+
+@Pipe({
+  name: 'authorsSeparatedByComma',
+})
+export class AuthorsSeparatedByCommaPipe implements PipeTransform {
+  transform(value: Author[]): string {
+    const authors: string[] = [];
+    value.forEach((author) => authors.push(author.firstName + ' ' + author.lastName));
+    return authors.join(', ');
+  }
+}

--- a/libs/perun/pipes/src/lib/perun-pipes.module.ts
+++ b/libs/perun/pipes/src/lib/perun-pipes.module.ts
@@ -50,6 +50,8 @@ import { CheckboxLabelPipe } from './checkbox-label.pipe';
 import { MasterCheckboxLabelPipe } from './master-checkbox-label.pipe';
 import { ManageableEntitiesPipe } from './manageable-entities.pipe';
 import { UnassignedRolePipe } from './unassigned-role.pipe';
+import { PublicationTabLabelPipe } from './publication-tab-label.pipe';
+import { AuthorsSeparatedByCommaPipe } from './authors-separated-by-comma.pipe';
 
 @NgModule({
   declarations: [
@@ -104,6 +106,8 @@ import { UnassignedRolePipe } from './unassigned-role.pipe';
     ConsentStatusIconPipe,
     ManageableEntitiesPipe,
     UnassignedRolePipe,
+    PublicationTabLabelPipe,
+    AuthorsSeparatedByCommaPipe,
   ],
   exports: [
     ResourceTagsToStringPipe,
@@ -157,6 +161,8 @@ import { UnassignedRolePipe } from './unassigned-role.pipe';
     ConsentStatusIconPipe,
     ManageableEntitiesPipe,
     UnassignedRolePipe,
+    PublicationTabLabelPipe,
+    AuthorsSeparatedByCommaPipe,
   ],
   imports: [CommonModule],
 })

--- a/libs/perun/pipes/src/lib/publication-tab-label.pipe.ts
+++ b/libs/perun/pipes/src/lib/publication-tab-label.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'publicationTabLabel',
+})
+export class PublicationTabLabelPipe implements PipeTransform {
+  transform(value: string): string {
+    return value.length > 50 ? value.substring(0, 50) + '...' : value;
+  }
+}


### PR DESCRIPTION
* Checked rules for different roles (PERUNADMIN, CABINETADMIN, SELF) and fixed some use cases for these roles (un/lock publication, side-menu, routing).
* Publications filter fixed - now it is possible to filter by code (isbn, issn, doi), in a date-picker are used only years, not months/days, start year is not selected by default, and also after Clear filter action is the start year also again unselected.
* Create publication guide improved - fixed some labels, button positioning, fixed the finding of similar publications, a label of a similar publication in a tab menu, and navigation between steps.
* According to an old GUI there is a new alert when a user tries to create a publication where he/she is not selected as an author.
* Fixed some other labels, translations, icons, and some other CSS magic has been involved.