### PR TITLE
feat(profile): support securityText attribute

### DIFF
--- a/apps/user-profile/src/app/app.module.ts
+++ b/apps/user-profile/src/app/app.module.ts
@@ -78,6 +78,7 @@ import { MfaSettingsComponent } from './pages/settings-page/settings-authorizati
 import { CategoryLabelPipe } from './pipes/category-label.pipe';
 import { SettingsMailingListsComponent } from './pages/settings-page/settings-mailing-lists/settings-mailing-lists.component';
 import { SettingsDataQuotasComponent } from './pages/settings-page/settings-data-quotas/settings-data-quotas.component';
+import { AddAuthTextDialogComponent } from './components/dialogs/add-auth-text-dialog/add-auth-text-dialog.component';
 
 export const API_INTERCEPTOR_PROVIDER: Provider = {
   provide: HTTP_INTERCEPTORS,
@@ -136,6 +137,7 @@ const loadConfigs: (appConfig: UserProfileConfigService) => () => Promise<void> 
     SettingsLocalAccountComponent,
     ActivateLocalAccountDialogComponent,
     MfaSettingsComponent,
+    AddAuthTextDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/apps/user-profile/src/app/components/dialogs/add-auth-text-dialog/add-auth-text-dialog.component.html
+++ b/apps/user-profile/src/app/components/dialogs/add-auth-text-dialog/add-auth-text-dialog.component.html
@@ -1,0 +1,23 @@
+<div class="{{theme}}">
+  <h1 mat-dialog-title>{{'DIALOGS.ADD_AUTH_TEXT.TITLE' | translate}}</h1>
+  <div mat-dialog-content>
+    <mat-form-field class="w-100">
+      <input [(ngModel)]="securityText" matInput autofocus />
+    </mat-form-field>
+    <perun-web-apps-alert alert_type="info">
+      {{'DIALOGS.ADD_AUTH_TEXT.DELAY_INFO' | customTranslate | translate}}
+    </perun-web-apps-alert>
+  </div>
+  <div matDialogActions>
+    <button (click)="onCancel()" class="ml-auto mr-2" mat-flat-button>
+      {{'DIALOGS.ADD_AUTH_TEXT.CANCEL' | translate}}
+    </button>
+    <button
+      [disabled]="securityText.trim() === ''"
+      (click)="onAdd()"
+      color="accent"
+      mat-flat-button>
+      {{'DIALOGS.ADD_AUTH_TEXT.ADD' | translate}}
+    </button>
+  </div>
+</div>

--- a/apps/user-profile/src/app/components/dialogs/add-auth-text-dialog/add-auth-text-dialog.component.ts
+++ b/apps/user-profile/src/app/components/dialogs/add-auth-text-dialog/add-auth-text-dialog.component.ts
@@ -1,0 +1,49 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { Attribute, AttributesManagerService } from '@perun-web-apps/perun/openapi';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { StoreService } from '@perun-web-apps/perun/services';
+
+export interface AddAuthTextDialogData {
+  theme: string;
+  attribute: Attribute;
+}
+
+@Component({
+  selector: 'perun-web-apps-add-auth-text-dialog',
+  templateUrl: './add-auth-text-dialog.component.html',
+  styleUrls: ['./add-auth-text-dialog.component.scss'],
+})
+export class AddAuthTextDialogComponent implements OnInit {
+  theme: string;
+  attribute: Attribute;
+  securityText = '';
+
+  constructor(
+    private dialogRef: MatDialogRef<AddAuthTextDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) private data: AddAuthTextDialogData,
+    private attributesManagerService: AttributesManagerService,
+    private store: StoreService
+  ) {}
+
+  ngOnInit(): void {
+    this.theme = this.data.theme;
+    this.attribute = this.data.attribute;
+    if (this.attribute.value) this.securityText = String(this.attribute.value);
+  }
+
+  onAdd(): void {
+    this.attribute.value = this.securityText;
+    this.attributesManagerService
+      .setUserAttribute({
+        attribute: this.attribute,
+        user: this.store.getPerunPrincipal().userId,
+      })
+      .subscribe(() => {
+        this.dialogRef.close(true);
+      });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
@@ -6,14 +6,14 @@
       <img [src]="imageSrc" alt="" />
     </div>
     <button
-      (click)="onAddAttribute('image')"
+      (click)="onAddAttribute(this.imgAtt, this.imgAttrName, 'AddAuthImgDialogComponent', 'IMG')"
       class="mr-2 mt-1 action-button"
       color="accent"
       mat-flat-button>
       {{'AUTHENTICATION.NEW_IMG' | customTranslate | translate}}
     </button>
     <button
-      (click)="onDeleteAttribute('image')"
+      (click)="onDeleteAttribute(this.imgAtt, this.imgAttrName, 'IMG')"
       color="warn"
       [disabled]="!imgAtt || !imgAtt.value"
       mat-flat-button>
@@ -26,14 +26,14 @@
     <p>{{'AUTHENTICATION.ANTI_PHISHING_INFO_TEXT' | customTranslate | translate}}</p>
     <h4 *ngIf="textAtt" class="security-text">{{textAtt.value}}</h4>
     <button
-      (click)="onAddAttribute('text')"
+      (click)="onAddAttribute(this.textAtt, this.textAttrName, 'AddAuthTextDialogComponent', 'TEXT')"
       class="mr-2 mt-1 action-button"
       color="accent"
       mat-flat-button>
       {{'AUTHENTICATION.NEW_TEXT' | customTranslate | translate}}
     </button>
     <button
-      (click)="onDeleteAttribute('text')"
+      (click)="onDeleteAttribute(this.textAtt, this.textAttrName, 'TEXT')"
       color="warn"
       [disabled]="!textAtt || !textAtt.value"
       mat-flat-button>

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.html
@@ -1,19 +1,43 @@
-<div [hidden]="loadingImg">
+<div [hidden]="loading">
   <div class="mb-5" *ngIf="displayImageBlock">
     <h1 class="page-subtitle">{{'AUTHENTICATION.TITLE' | customTranslate | translate}}</h1>
     <p>{{'AUTHENTICATION.ANTI_PHISHING_INFO' | customTranslate | translate}}</p>
     <div *ngIf="imageSrc && imageSrc.length">
       <img [src]="imageSrc" alt="" />
     </div>
-    <button (click)="onAddImg()" class="mr-2 mt-1 action-button" color="accent" mat-flat-button>
+    <button
+      (click)="onAddAttribute('image')"
+      class="mr-2 mt-1 action-button"
+      color="accent"
+      mat-flat-button>
       {{'AUTHENTICATION.NEW_IMG' | customTranslate | translate}}
     </button>
     <button
-      (click)="onDeleteImg()"
+      (click)="onDeleteAttribute('image')"
       color="warn"
       [disabled]="!imgAtt || !imgAtt.value"
       mat-flat-button>
       {{'AUTHENTICATION.DELETE_IMG' | customTranslate | translate}}
+    </button>
+  </div>
+
+  <div class="mb-5" *ngIf="displayTextBlock">
+    <h1 class="page-subtitle">{{'AUTHENTICATION.TITLE_TEXT' | customTranslate | translate}}</h1>
+    <p>{{'AUTHENTICATION.ANTI_PHISHING_INFO_TEXT' | customTranslate | translate}}</p>
+    <h4 *ngIf="textAtt" class="security-text">{{textAtt.value}}</h4>
+    <button
+      (click)="onAddAttribute('text')"
+      class="mr-2 mt-1 action-button"
+      color="accent"
+      mat-flat-button>
+      {{'AUTHENTICATION.NEW_TEXT' | customTranslate | translate}}
+    </button>
+    <button
+      (click)="onDeleteAttribute('text')"
+      color="warn"
+      [disabled]="!textAtt || !textAtt.value"
+      mat-flat-button>
+      {{'AUTHENTICATION.DELETE_TEXT' | customTranslate | translate}}
     </button>
   </div>
 
@@ -25,4 +49,4 @@
   <br />
   <perun-web-apps-mfa-settings></perun-web-apps-mfa-settings>
 </div>
-<mat-spinner class="ml-auto mr-auto" *ngIf="loadingImg"></mat-spinner>
+<mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.scss
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.scss
@@ -1,0 +1,4 @@
+.security-text {
+  font-family: FreeMono, monospace;
+  color: grey;
+}

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.ts
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/settings-authentication.component.ts
@@ -1,12 +1,16 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { AddAuthImgDialogComponent } from '../../../components/dialogs/add-auth-img-dialog/add-auth-img-dialog.component';
 import { Attribute, AttributesManagerService } from '@perun-web-apps/perun/openapi';
-import { NotificatorService, StoreService } from '@perun-web-apps/perun/services';
+import {
+  NotificatorService,
+  PerunTranslateService,
+  StoreService,
+} from '@perun-web-apps/perun/services';
 import { RemoveStringValueDialogComponent } from '@perun-web-apps/perun/dialogs';
-import { TranslateService } from '@ngx-translate/core';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
+import { AddAuthTextDialogComponent } from '../../../components/dialogs/add-auth-text-dialog/add-auth-text-dialog.component';
 
 @Component({
   selector: 'perun-web-apps-settings-authentication',
@@ -16,115 +20,126 @@ import { MatSlideToggle } from '@angular/material/slide-toggle';
 export class SettingsAuthenticationComponent implements OnInit {
   @ViewChild('toggle') toggle: MatSlideToggle;
 
-  removeDialogTitle: string;
   imgAtt: Attribute;
+  textAtt: Attribute;
   imageSrc = '';
-  removeDialogDescription: string;
   mfaUrl = '';
   displayImageBlock: boolean;
-  loadingImg = false;
-  saveImgSuccess = '';
-  removeImgSuccess = '';
+  displayTextBlock: boolean;
+  loading = false;
 
   constructor(
     private dialog: MatDialog,
     private attributesManagerService: AttributesManagerService,
     private store: StoreService,
-    private translate: TranslateService,
+    private translate: PerunTranslateService,
     private notificatorService: NotificatorService
-  ) {
-    translate
-      .get('AUTHENTICATION.DELETE_IMG_DIALOG_TITLE')
-      .subscribe((res: string) => (this.removeDialogTitle = res));
-    translate
-      .get('AUTHENTICATION.DELETE_IMG_DIALOG_DESC')
-      .subscribe((res: string) => (this.removeDialogDescription = res));
-    translate
-      .get('AUTHENTICATION.SAVE_IMG_SUCCESS')
-      .subscribe((res: string) => (this.saveImgSuccess = res));
-    translate
-      .get('AUTHENTICATION.REMOVE_IMG_SUCCESS')
-      .subscribe((res: string) => (this.removeImgSuccess = res));
-  }
+  ) {}
 
   ngOnInit(): void {
     const mfa = this.store.getProperty('mfa');
 
     this.translate.onLangChange.subscribe(() => {
-      this.translate
-        .get('AUTHENTICATION.DELETE_IMG_DIALOG_TITLE')
-        .subscribe((res: string) => (this.removeDialogTitle = res));
-      this.translate
-        .get('AUTHENTICATION.DELETE_IMG_DIALOG_DESC')
-        .subscribe((res: string) => (this.removeDialogDescription = res));
       this.mfaUrl = this.translate.currentLang === 'en' ? mfa.url_en : mfa.url_cs;
     });
 
     this.mfaUrl = this.translate.currentLang === 'en' ? mfa.url_en : mfa.url_cs;
     this.displayImageBlock = this.store.getProperty('mfa').enable_security_image;
     if (this.displayImageBlock) {
-      this.loadImage();
+      this.loadSecurityAttribute('image');
+    }
+    this.displayTextBlock = this.store.getProperty('mfa').enable_security_text;
+    if (this.displayTextBlock) {
+      this.loadSecurityAttribute('text');
     }
   }
 
-  loadImage(): void {
-    this.loadingImg = true;
-    const imgAttributeName = this.store.getProperty('mfa').security_image_attribute;
+  loadSecurityAttribute(mode: 'image' | 'text'): void {
+    this.loading = true;
+    const attributeName =
+      mode === 'image'
+        ? this.store.getProperty('mfa').security_image_attribute
+        : this.store.getProperty('mfa').security_text_attribute;
     this.attributesManagerService
-      .getUserAttributeByName(this.store.getPerunPrincipal().userId, imgAttributeName)
-      .subscribe(
-        (attr) => {
+      .getUserAttributeByName(this.store.getPerunPrincipal().userId, attributeName)
+      .subscribe({
+        next: (attr) => {
           if (!attr) {
             this.attributesManagerService
-              .getAttributeDefinitionByName(imgAttributeName)
+              .getAttributeDefinitionByName(attributeName)
               .subscribe((att) => {
-                this.imgAtt = att as Attribute;
+                if (mode === 'image') {
+                  this.imgAtt = att as Attribute;
+                } else {
+                  this.textAtt = att as Attribute;
+                }
               });
           } else {
-            this.imgAtt = attr;
-            this.imageSrc = this.imgAtt.value as string;
+            if (mode === 'image') {
+              this.imgAtt = attr;
+              this.imageSrc = this.imgAtt.value as string;
+            } else {
+              this.textAtt = attr;
+            }
           }
-          this.loadingImg = false;
+          this.loading = false;
         },
-        (e) => {
+        error: (e) => {
           console.error(e);
-          this.loadingImg = false;
-        }
-      );
+          this.loading = false;
+        },
+      });
   }
 
-  onAddImg(): void {
+  onAddAttribute(mode: 'image' | 'text'): void {
     const config = getDefaultDialogConfig();
     config.width = '500px';
-    config.data = { theme: 'user-theme', attribute: this.imgAtt };
+    config.data = { theme: 'user-theme', attribute: mode === 'image' ? this.imgAtt : this.textAtt };
 
-    const dialogRef = this.dialog.open(AddAuthImgDialogComponent, config);
+    const dialogRef: MatDialogRef<AddAuthImgDialogComponent | AddAuthTextDialogComponent> =
+      mode === 'image'
+        ? this.dialog.open(AddAuthImgDialogComponent, config)
+        : this.dialog.open(AddAuthTextDialogComponent, config);
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        this.notificatorService.showSuccess(this.saveImgSuccess);
-        this.loadImage();
+        this.notificatorService.showSuccess(
+          this.translate.instant(`AUTHENTICATION.SAVE_${mode === 'image' ? 'IMG' : 'TEXT'}_SUCCESS`)
+        );
+        this.loadSecurityAttribute(mode);
       }
     });
   }
 
-  onDeleteImg(): void {
+  onDeleteAttribute(mode: 'image' | 'text'): void {
     const config = getDefaultDialogConfig();
     config.width = '600px';
+
+    const attr: Attribute = mode === 'image' ? this.imgAtt : this.textAtt;
+    const removeDialogTitle = this.translate.instant(
+      `AUTHENTICATION.DELETE_${mode === 'image' ? 'IMG' : 'TEXT'}_DIALOG_TITLE`
+    );
+    const removeDialogDescription = this.translate.instant(
+      `AUTHENTICATION.DELETE_${mode === 'image' ? 'IMG' : 'TEXT'}_DIALOG_DESC`
+    );
     config.data = {
       doNotShowValues: true,
-      attribute: this.imgAtt,
+      attribute: attr,
       userId: this.store.getPerunPrincipal().userId,
-      title: this.removeDialogTitle,
-      description: this.removeDialogDescription,
+      title: removeDialogTitle,
+      description: removeDialogDescription,
     };
 
     const dialogRef = this.dialog.open(RemoveStringValueDialogComponent, config);
 
-    dialogRef.afterClosed().subscribe((imgRemoved) => {
-      if (imgRemoved) {
-        this.notificatorService.showSuccess(this.removeImgSuccess);
-        this.loadImage();
+    dialogRef.afterClosed().subscribe((attrRemoved) => {
+      if (attrRemoved) {
+        this.notificatorService.showSuccess(
+          this.translate.instant(
+            `AUTHENTICATION.REMOVE_${mode === 'image' ? 'IMG' : 'TEXT'}_SUCCESS`
+          )
+        );
+        this.loadSecurityAttribute('image');
       }
     });
   }

--- a/apps/user-profile/src/assets/config/defaultConfig.json
+++ b/apps/user-profile/src/assets/config/defaultConfig.json
@@ -73,8 +73,10 @@
   "mfa": {
     "api_url": "https://id.muni.cz/mfaapi/",
     "enable_security_image": true,
+    "enable_security_text": true,
     "enable_detail_settings": false,
     "security_image_attribute": "urn:perun:user:attribute-def:def:securityImage:mu",
+    "security_text_attribute": "urn:perun:user:attribute-def:def:securityText:mu",
     "enforce_mfa_attribute": "urn:perun:user:attribute-def:def:mfaEnforced:mu",
     "url_en": "https://mfa.aai.muni.cz/",
     "url_cs": "https://mfa.aai.muni.cz/"

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -135,6 +135,7 @@
   },
   "AUTHENTICATION": {
     "TITLE": "Bezpečnostní obrázek",
+    "TITLE_TEXT": "Bezpečnostní text",
     "MFA": "Vícefázové ověření",
     "MFA_TOGGLE": "Zapnout vícefázové ověření pro všechny služby",
     "MFA_DISABLED": "Potřebujete mít alespoň jeden aktivní MFA token.",
@@ -144,9 +145,16 @@
     "ANTI_PHISHING_INFO": "Tento bezpečnostní obrázek se vám ukáže před tím, než zadáte heslo, ujistíte se tak, že se nepřihlašujete na podvrženou stránku",
     "DELETE_IMG_DIALOG_TITLE": "Vymazat bezpečnostní obrázek",
     "DELETE_IMG_DIALOG_DESC": "Váš bezpečnostní obrázek bude odstraněn a nebude použit během autentizace.",
+    "NEW_TEXT": "Nový text",
+    "DELETE_TEXT": "Vymazat text",
+    "ANTI_PHISHING_INFO_TEXT": "Tento bezpečnostní text se vám ukáže před tím, než zadáte heslo, ujistíte se tak, že se nepřihlašujete na podvrženou stránku",
+    "DELETE_TEXT_DIALOG_TITLE": "Vymazat bezpečnostní text",
+    "DELETE_TEXT_DIALOG_DESC": "Váš bezpečnostní text bude odstraněn a nebude použit během autentizace.",
     "MFA_INFO": "Spravovat moje prostředky vícefázového ověření (MFA)",
     "SAVE_IMG_SUCCESS": "Bezpečnostní obrázek byl změněn.",
-    "REMOVE_IMG_SUCCESS": "Bezpečnostní obrázek byl odebrán."
+    "REMOVE_IMG_SUCCESS": "Bezpečnostní obrázek byl odebrán.",
+    "SAVE_TEXT_SUCCESS": "Bezpečnostní text byl změněn.",
+    "REMOVE_TEXT_SUCCESS": "Bezpečnostní text byl odebrán."
   },
   "LOCAL_ACCOUNT": {
     "TITLE": "Lokální účet",
@@ -207,6 +215,12 @@
       "ADD": "Uložit obrázek",
       "IMG_TOO_LONG": "Zvolený obrázek se nepodařilo zmenšit na cílovou velikost. Prosím zvolte jiný obrázek.",
       "DELAY_INFO": "Změna bezpečnostního obrázku se projeví většinou do 5 minut, v ojedinělých případech může propagace změny trvat několik hodin."
+    },
+    "ADD_AUTH_TEXT": {
+      "TITLE": "Změna bezpečnostního textu",
+      "CANCEL": "Zrušit",
+      "ADD": "Uložit text",
+      "DELAY_INFO": "Změna bezpečnostního textu se projeví většinou do 5 minut, v ojedinělých případech může propagace změny trvat několik hodin."
     },
     "ACTIVATE_LOCAL_ACCOUNT": {
       "TITLE": "Aktivovat účet",

--- a/apps/user-profile/src/assets/i18n/en.json
+++ b/apps/user-profile/src/assets/i18n/en.json
@@ -135,6 +135,7 @@
   },
   "AUTHENTICATION": {
     "TITLE": "Security image",
+    "TITLE_TEXT": "Security text",
     "MFA": "Multi-factor authentication",
     "MFA_TOGGLE": "Turn on multi-factor authentication for all services",
     "MFA_DISABLED": "You need to have at least one active MFA token.",
@@ -144,9 +145,16 @@
     "ANTI_PHISHING_INFO": "You will be shown this security image before you enter your password so you will know that you are visiting the right site",
     "DELETE_IMG_DIALOG_TITLE": "Delete security image",
     "DELETE_IMG_DIALOG_DESC": "Your security image will be deleted and will not be used during authentication process.",
+    "NEW_TEXT": "New text",
+    "DELETE_TEXT": "Delete text",
+    "ANTI_PHISHING_INFO_TEXT": "You will be shown this security text before you enter your password so you will know that you are visiting the right site",
+    "DELETE_TEXT_DIALOG_TITLE": "Delete security text",
+    "DELETE_TEXT_DIALOG_DESC": "Your security text will be deleted and will not be used during authentication process.",
     "MFA_INFO": "Manage my MFA tokens",
     "SAVE_IMG_SUCCESS": "Security image has been saved.",
-    "REMOVE_IMG_SUCCESS": "Security image has been removed."
+    "REMOVE_IMG_SUCCESS": "Security image has been removed.",
+    "SAVE_TEXT_SUCCESS": "Security text has been saved.",
+    "REMOVE_TEXT_SUCCESS": "Security text has been removed."
   },
   "LOCAL_ACCOUNT": {
     "TITLE": "Local account",
@@ -207,6 +215,12 @@
       "ADD": "Save image",
       "IMG_TOO_LONG": "Your image could not be resized to fit. Please try a different one.",
       "DELAY_INFO": "New security image usually becomes effective in 5 minutes, in rare cases it might take a couple of hours."
+    },
+    "ADD_AUTH_TEXT": {
+      "TITLE": "Change security text",
+      "CANCEL": "Cancel",
+      "ADD": "Save text",
+      "DELAY_INFO": "New security text usually becomes effective in 5 minutes, in rare cases it might take a couple of hours."
     },
     "ACTIVATE_LOCAL_ACCOUNT": {
       "TITLE": "Activate account",

--- a/libs/perun/models/src/lib/ConfigProperties.ts
+++ b/libs/perun/models/src/lib/ConfigProperties.ts
@@ -113,8 +113,10 @@ interface ProfileCustomLabel {
 interface ProfileMFA {
   api_url: string;
   enable_security_image: boolean;
+  enable_security_text: boolean;
   enable_detail_settings: boolean;
   security_image_attribute: string;
+  security_text_attribute: string;
   enforce_mfa_attribute: string;
   url_en: string;
   url_cs: string;


### PR DESCRIPTION
* In Settings->Authentication section we already have support for security images. We wanted to add support also for security texts.