### PR TITLE
fix(admin): move default filter option in applications up

### DIFF
--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-applications/group-applications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-applications/group-applications.component.html
@@ -20,14 +20,14 @@
     <mat-label>{{'APPLICATIONS_LIST.STATE' | translate}}</mat-label>
     <mat-select (selectionChange)="select()" [(value)]="state" disableOptionCentering>
       <mat-option value="all">{{'VO_DETAIL.APPLICATION.SELECTION_ALL' | translate}}</mat-option>
+      <mat-option
+        value="pending"
+        >{{'VO_DETAIL.APPLICATION.SELECTION_PENDING' | translate}}</mat-option
+      >
       <mat-option value="wfmv">{{'VO_DETAIL.APPLICATION.SELECTION_WFMV' | translate}}</mat-option>
       <mat-option
         value="submited"
         >{{'VO_DETAIL.APPLICATION.SELECTION_SUBMITTED' | translate}}</mat-option
-      >
-      <mat-option
-        value="pending"
-        >{{'VO_DETAIL.APPLICATION.SELECTION_PENDING' | translate}}</mat-option
       >
       <mat-option
         value="approved"

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-applications/vo-applications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-applications/vo-applications.component.html
@@ -12,14 +12,14 @@
     <mat-label>{{'APPLICATIONS_LIST.STATE' | translate}}</mat-label>
     <mat-select (selectionChange)="select()" [(value)]="state" disableOptionCentering>
       <mat-option value="all">{{'VO_DETAIL.APPLICATION.SELECTION_ALL' | translate}}</mat-option>
+      <mat-option
+        value="pending"
+        >{{'VO_DETAIL.APPLICATION.SELECTION_PENDING' | translate}}</mat-option
+      >
       <mat-option value="wfmv">{{'VO_DETAIL.APPLICATION.SELECTION_WFMV' | translate}}</mat-option>
       <mat-option
         value="submited"
         >{{'VO_DETAIL.APPLICATION.SELECTION_SUBMITTED' | translate}}</mat-option
-      >
-      <mat-option
-        value="pending"
-        >{{'VO_DETAIL.APPLICATION.SELECTION_PENDING' | translate}}</mat-option
       >
       <mat-option
         value="approved"


### PR DESCRIPTION
* 'pending' applications are preselected in the filer
* the order of the selection makes the dropdown sidebar slide downwards, which is confusing for the users as they don't see the top options
* prioritized the pending applications field to keep sidebar at top when filter menu is opened