### PR TITLE
fix(admin): show styles correctly on preview for HTML form items

### DIFF
--- a/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.html
+++ b/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.html
@@ -96,10 +96,11 @@
                   value="{{'VO_DETAIL.SETTINGS.APPLICATION_FORM.CLEAR_SELECTION' | translate}}" />
               </form>
             </div>
-            <div
-              *ngIf="applicationFormItem.type ==='HEADING' ||
-                      applicationFormItem.type === 'HTML_COMMENT'">
+            <div *ngIf="applicationFormItem.type ==='HEADING'">
               <span [innerHTML]="getLocalizedLabel(applicationFormItem)"></span>
+            </div>
+            <div *ngIf="applicationFormItem.type === 'HTML_COMMENT'">
+              <span [innerHTML]="getLocalizedLabel(applicationFormItem) | sanitizeHtml"></span>
             </div>
             <div *ngIf="applicationFormItem.type === 'SELECTIONBOX'">
               <select>

--- a/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.html
+++ b/apps/admin-gui/src/app/vos/components/application-form-preview/application-form-preview.component.html
@@ -129,10 +129,13 @@
         </div>
 
         <div
-          *ngIf="(applicationFormItem.type ==='HEADING' ||
-                    applicationFormItem.type === 'HTML_COMMENT') &&
-                    applicationFormItem.hidden !== 'ALWAYS'">
+          *ngIf="applicationFormItem.type ==='HEADING' && applicationFormItem.hidden !== 'ALWAYS'">
           <span [innerHTML]="getLocalizedLabel(applicationFormItem)"></span>
+        </div>
+
+        <div
+          *ngIf="applicationFormItem.type === 'HTML_COMMENT' && applicationFormItem.hidden !== 'ALWAYS'">
+          <span [innerHTML]="getLocalizedLabel(applicationFormItem) | sanitizeHtml"></span>
         </div>
 
         <div


### PR DESCRIPTION
* In the preview column in the application form list and also on the preview page there are now the HTML items displayed correctly with CSS styles.