### PR TITLE
fix: preserve query parameters during the routing

### DIFF
--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-detail-page.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-detail-page.component.html
@@ -17,8 +17,7 @@
               [perunWebAppsMiddleClickRouterLink]="['/admin/services', service.id.toString()]"
               (auxclick)="$event.preventDefault()"
               [routerLink]="['/admin/services', service.id]"
-              class="service-link"
-              queryParamsHandling="merge">
+              class="service-link">
               {{service.name}}
             </a>
             <span class="text-muted"> &nbsp; #{{service.id}} </span>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-detail-page.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-detail-page.component.ts
@@ -82,7 +82,7 @@ export class ServiceDetailPageComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        void this.router.navigate(['/admin/services']);
+        void this.router.navigate(['/admin/services'], { queryParamsHandling: 'preserve' });
       }
     });
   }

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-visualizer/user-destination-relationship/user-destination-relationship.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-visualizer/user-destination-relationship/user-destination-relationship.component.ts
@@ -141,6 +141,7 @@ export class UserDestinationRelationshipComponent implements OnInit {
           destination: this.destination,
           service: 'noService',
         },
+        queryParamsHandling: 'merge',
       });
     } else {
       void this.router.navigate(['admin/visualizer/userDestinationRelationship/graph'], {
@@ -149,6 +150,7 @@ export class UserDestinationRelationshipComponent implements OnInit {
           destination: this.destination,
           service: this.chosenService,
         },
+        queryParamsHandling: 'merge',
       });
     }
   }

--- a/apps/admin-gui/src/app/admin/pages/admin-user-detail-page/admin-user-detail-page.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-user-detail-page/admin-user-detail-page.component.html
@@ -10,11 +10,7 @@
     </mat-icon>
     <div class="page-title-block">
       <div class="page-title-headline d-flex align-items-center">
-        <a
-          [routerLink]="['/admin/users', user.id]"
-          class="user-link"
-          queryParamsHandling="merge"
-          data-cy="user-name-link">
+        <a [routerLink]="['/admin/users', user.id]" class="user-link" data-cy="user-name-link">
           {{user | userFullName}}
         </a>
         <span class="text-muted"> &nbsp;#{{user.id}} </span>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-detail-page.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-detail-page.component.html
@@ -16,7 +16,6 @@
             [perunWebAppsMiddleClickRouterLink]="['/facilities', facility.id.toString()]"
             (auxclick)="$event.preventDefault()"
             [routerLink]="['/facilities', facility.id]"
-            queryParamsHandling="merge"
             >{{facility.name}}</a
           >
           <span class="text-muted"> &nbsp;#{{facility.id}} </span>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-detail-page.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-detail-page.component.ts
@@ -118,7 +118,7 @@ export class FacilityDetailPageComponent extends destroyDetailMixin() implements
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        void this.router.navigate(['']);
+        void this.router.navigate([''], { queryParamsHandling: 'preserve' });
       }
     });
   }

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-detail-page.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-detail-page.component.html
@@ -15,8 +15,7 @@
             [perunWebAppsMiddleClickRouterLink]="[baseUrl]"
             (auxclick)="$event.preventDefault()"
             [routerLink]="[baseUrl]"
-            class="resource-link"
-            queryParamsHandling="merge">
+            class="resource-link">
             {{resource.name}}
           </a>
           <span class="text-muted"> &nbsp;#{{resource.id}} </span>
@@ -40,7 +39,6 @@
             [perunWebAppsMiddleClickRouterLink]="['/organizations', resource.vo.id.toString()]"
             (auxclick)="$event.preventDefault()"
             [routerLink]="['/organizations', resource.vo.id]"
-            queryParamsHandling="merge"
             class="resource-link"
             >{{resource.vo.name}}</a
           >
@@ -52,7 +50,6 @@
             class="resource-link"
             *ngIf="facilityLinkAuth"
             attr.data-cy="{{resource.facility.name}}"
-            queryParamsHandling="merge"
             [perunWebAppsMiddleClickRouterLink]="['/facilities', resource.facilityId.toString()]"
             (auxclick)="$event.preventDefault()"
             [routerLink]="['/facilities', resource.facilityId]"

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-detail-page.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-detail-page.component.ts
@@ -155,7 +155,10 @@ export class ResourceDetailPageComponent extends destroyDetailMixin() implements
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        void this.router.navigate(['../'], { relativeTo: this.route });
+        void this.router.navigate(['../'], {
+          relativeTo: this.route,
+          queryParamsHandling: 'preserve',
+        });
       }
     });
   }

--- a/apps/admin-gui/src/app/main-menu-page/main-menu-page.component.html
+++ b/apps/admin-gui/src/app/main-menu-page/main-menu-page.component.html
@@ -1,9 +1,5 @@
 <div class="buttons-container pl-2 pr-2 pl-xl-5 pr-xl-5">
-  <a
-    class="main-menu-button user-btn"
-    [routerLink]="['profile']"
-    mat-ripple
-    queryParamsHandling="merge">
+  <a class="main-menu-button user-btn" [routerLink]="['profile']" mat-ripple>
     <mat-icon [svgIcon]="'perun-user'" class="item-pic perun-icon"></mat-icon>
     <!--    <img src="assets/img/PerunWebImages/user-white.svg">-->
     <h1>{{'MAIN_MENU.PROFILE' | translate}}</h1>
@@ -13,8 +9,7 @@
     *ngIf="authResolver.isVoAdmin() || authResolver.isVoObserver()"
     class="main-menu-button vo-btn"
     [routerLink]="['organizations']"
-    mat-ripple
-    queryParamsHandling="merge">
+    mat-ripple>
     <mat-icon [svgIcon]="'perun-vo'" class="item-pic perun-icon"></mat-icon>
     <!--    <img src="assets/img/PerunWebImages/vo-white.svg">-->
     <h1>{{'MAIN_MENU.ACCESS' | translate}}</h1>
@@ -24,8 +19,7 @@
     *ngIf="authResolver.canManageFacilities()"
     [routerLink]="['facilities']"
     class="main-menu-button facility-btn"
-    mat-ripple
-    queryParamsHandling="merge">
+    mat-ripple>
     <mat-icon [svgIcon]="'perun-manage-facility'" class="item-pic perun-icon"></mat-icon>
     <!--    <img src="assets/img/PerunWebImages/manage_facility_white.svg">-->
     <h1>{{'MAIN_MENU.FACILITIES' | translate}}</h1>
@@ -35,8 +29,7 @@
     *ngIf="authResolver.isPerunAdminOrObserver()"
     class="main-menu-button admin-btn"
     [routerLink]="['admin']"
-    mat-ripple
-    queryParamsHandling="merge">
+    mat-ripple>
     <mat-icon [svgIcon]="'perun-perun-admin'" class="item-pic perun-icon"></mat-icon>
     <!--    <img src="assets/img/PerunWebImages/perun_admin-white.svg">-->
     <h1>{{'MAIN_MENU.ADMIN' | translate}}</h1>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-facility-dialog/create-facility-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-facility-dialog/create-facility-dialog.component.ts
@@ -94,7 +94,9 @@ export class CreateFacilityDialogComponent implements OnInit {
       this.translate.instant('DIALOGS.CREATE_FACILITY.SUCCESS') as string
     );
     if (this.configure) {
-      void this.router.navigate(['facilities', facilityId.toString(), 'configuration']);
+      void this.router.navigate(['facilities', facilityId.toString(), 'configuration'], {
+        queryParamsHandling: 'preserve',
+      });
     }
     this.dialogRef.close(true);
   }

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-vo-dialog/create-vo-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-vo-dialog/create-vo-dialog.component.ts
@@ -57,14 +57,14 @@ export class CreateVoDialogComponent implements OnInit {
     this.loading = true;
     this.voService
       .createVoWithName(this.fullNameCtrl.value as string, this.shortNameCtrl.value as string)
-      .subscribe(
-        (vo) => {
+      .subscribe({
+        next: (vo) => {
           this.notificator.showSuccess(this.successMessage);
           this.loading = false;
-          void this.router.navigate(['/organizations', vo.id]);
+          void this.router.navigate(['/organizations', vo.id], { queryParamsHandling: 'preserve' });
           this.dialogRef.close(true);
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
   }
 }

--- a/apps/admin-gui/src/app/shared/query-params-router.service.ts
+++ b/apps/admin-gui/src/app/shared/query-params-router.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { take } from 'rxjs/operators';
+import { ActivatedRoute, QueryParamsHandling, Router } from '@angular/router';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class QueryParamsRouterService {
+  constructor(private router: Router, private route: ActivatedRoute) {}
+
+  navigate(url: string[], relativeTo: ActivatedRoute = null): void {
+    this.route.queryParams.pipe(take(1)).subscribe((params) => {
+      let paramsHandlingMethod: QueryParamsHandling = 'merge';
+      const queryParams = Object.assign({}, params);
+
+      if (location.pathname.endsWith('applicationForm/preview')) {
+        paramsHandlingMethod = '';
+        delete queryParams.applicationFormItems;
+      }
+
+      void this.router.navigate(url, {
+        relativeTo: relativeTo,
+        queryParams: queryParams,
+        queryParamsHandling: paramsHandlingMethod,
+      });
+    });
+  }
+}

--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-item/side-menu-item.component.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-item/side-menu-item.component.ts
@@ -4,6 +4,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { openClose, rollInOut } from '@perun-web-apps/perun/animations';
 import { MatSidenav } from '@angular/material/sidenav';
 import { StoreService } from '@perun-web-apps/perun/services';
+import { QueryParamsRouterService } from '../../query-params-router.service';
 
 @Component({
   selector: 'app-side-menu-item',
@@ -27,7 +28,11 @@ export class SideMenuItemComponent {
   linkTextColor = this.store.getProperty('theme').sidemenu_submenu_text_color;
   dividerStyle = '1px solid ' + this.store.getProperty('theme').sidemenu_divider_color;
 
-  constructor(private router: Router, private store: StoreService) {
+  constructor(
+    private router: Router,
+    private store: StoreService,
+    private queryParamsRouter: QueryParamsRouterService
+  ) {
     this.currentUrl = router.url;
 
     router.events.subscribe((_: NavigationEnd) => {
@@ -50,14 +55,14 @@ export class SideMenuItemComponent {
   isActive(currentUrl: string, regexValue: string): boolean {
     const regexp = new RegExp(regexValue);
 
-    return regexp.test(currentUrl);
+    return regexp.test(currentUrl.split('?')[0]);
   }
 
   navigate(url: string[]): void {
     if (this.sideNav.mode === 'over') {
-      void this.sideNav.close().then(() => this.router.navigate(url));
+      void this.sideNav.close().then(() => this.queryParamsRouter.navigate(url));
     } else {
-      void this.router.navigate(url);
+      this.queryParamsRouter.navigate(url);
     }
   }
 }

--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-root-item/side-menu-root-item.component.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-root-item/side-menu-root-item.component.ts
@@ -4,6 +4,7 @@ import { SideMenuItem } from '../side-menu.component';
 import { openClose, rollInOut } from '@perun-web-apps/perun/animations';
 import { MatSidenav } from '@angular/material/sidenav';
 import { StoreService } from '@perun-web-apps/perun/services';
+import { QueryParamsRouterService } from '../../query-params-router.service';
 
 @Component({
   selector: 'app-side-menu-root-item',
@@ -29,7 +30,11 @@ export class SideMenuRootItemComponent implements OnInit, OnChanges {
   linkTextColor = this.store.getProperty('theme').sidemenu_submenu_text_color;
   currentUrl: string;
 
-  constructor(private router: Router, private store: StoreService) {
+  constructor(
+    private router: Router,
+    private store: StoreService,
+    private queryParamsRouter: QueryParamsRouterService
+  ) {
     this.currentUrl = router.url;
 
     router.events.subscribe((_: NavigationEnd) => {
@@ -73,9 +78,9 @@ export class SideMenuRootItemComponent implements OnInit, OnChanges {
 
   navigate(url: string[]): void {
     if (this.sideNav.mode === 'over') {
-      void this.sideNav.close().then(() => this.router.navigate(url));
+      void this.sideNav.close().then(() => this.queryParamsRouter.navigate(url));
     } else {
-      void this.router.navigate(url);
+      this.queryParamsRouter.navigate(url);
     }
   }
 }

--- a/apps/admin-gui/src/app/users/components/user-profile/user-profile.component.html
+++ b/apps/admin-gui/src/app/users/components/user-profile/user-profile.component.html
@@ -13,8 +13,7 @@
           [perunWebAppsMiddleClickRouterLink]="['/myProfile']"
           (auxclick)="$event.preventDefault()"
           [routerLink]="['/myProfile']"
-          class="user-link"
-          queryParamsHandling="merge">
+          class="user-link">
           {{user | userFullName}}
         </a>
         <span class="text-muted"> &nbsp;#{{user.id}} </span>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-accounts/user-accounts.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-accounts/user-accounts.component.html
@@ -23,7 +23,6 @@
             [perunWebAppsMiddleClickRouterLink]="['/organizations', selectedVo.id.toString(), 'members', member.id.toString()]"
             (auxclick)="$event.preventDefault()"
             [routerLink]="['/organizations', selectedVo.id, 'members', member.id]"
-            queryParamsHandling="merge"
             >{{member.id}}
           </a>
         </div>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-recently-viewed-button-field/dashboard-recently-viewed-button-field.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-recently-viewed-button-field/dashboard-recently-viewed-button-field.component.html
@@ -11,7 +11,6 @@
       [perunWebAppsMiddleClickRouterLink]="[item.url]"
       (auxclick)="$event.preventDefault()"
       [routerLink]="item.url"
-      queryParamsHandling="merge"
       matTooltip="{{item.tooltip}}">
       <span class="item-type">{{item.type}}</span>
       <mat-icon [svgIcon]="item.cssIcon" class="item-pic perun-icon"></mat-icon>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/user-dashboard.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/user-dashboard.component.html
@@ -52,7 +52,11 @@
             >
           </div>
           <div class="mx-auto pt-3">
-            <button [routerLink]="['/myProfile']" class="text-bigger" mat-stroked-button>
+            <button
+              [routerLink]="['/myProfile']"
+              queryParamsHandling="merge"
+              class="text-bigger"
+              mat-stroked-button>
               <mat-icon class="mr-1 user-icon perun-icon" svgIcon="perun-user-dark"></mat-icon>
               {{'USER_DETAIL.DASHBOARD.GO_TO_MY_PROFILE' | translate}}
             </button>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/user-dashboard.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/user-dashboard.component.ts
@@ -113,12 +113,12 @@ export class UserDashboardComponent implements OnInit {
       this.apiRequestConfiguration.dontHandleErrorForNext();
       this.userManager
         .validatePreferredEmailChangeWithToken(token, Number.parseInt(u, 10))
-        .subscribe(
-          () => {
+        .subscribe({
+          next: () => {
             this.notificator.showSuccess(this.mailSuccessMessage);
-            void this.router.navigate([], { replaceUrl: true });
+            void this.router.navigate([], { replaceUrl: true, queryParamsHandling: 'preserve' });
           },
-          () => {
+          error: () => {
             const config = getDefaultDialogConfig();
             config.width = '600px';
 
@@ -126,8 +126,8 @@ export class UserDashboardComponent implements OnInit {
             dialogRef.afterClosed().subscribe(() => {
               this.getDashboardSettings();
             });
-          }
-        );
+          },
+        });
     }
   }
 

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-associated-users/user-settings-associated-users.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-associated-users/user-settings-associated-users.component.ts
@@ -105,7 +105,7 @@ export class UserSettingsAssociatedUsersComponent implements OnInit {
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
         if (!this.authResolver.isAuthorized('getUsersBySpecificUser_User_policy', [this.user])) {
-          void this.router.navigate(['/myProfile']);
+          void this.router.navigate(['/myProfile'], { queryParamsHandling: 'preserve' });
         } else {
           this.refreshTable();
         }

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-service-identities/service-identity-detail-page/service-identity-detail-page.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-service-identities/service-identity-detail-page/service-identity-detail-page.component.html
@@ -14,8 +14,7 @@
           [perunWebAppsMiddleClickRouterLink]="['/myProfile/service-identities', user.id.toString()]"
           (auxclick)="$event.preventDefault()"
           [routerLink]="['/myProfile/service-identities', user.id]"
-          class="user-link"
-          queryParamsHandling="merge">
+          class="user-link">
           {{user | userFullName}}
         </a>
         <span class="text-muted"> &nbsp;#{{user.id}} </span>

--- a/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.ts
@@ -244,12 +244,9 @@ export class ApplicationFormListComponent implements OnInit, OnChanges {
   }
 
   openManagingGroups(): void {
-    void this.router.navigate([
-      '/organizations',
-      this.applicationForm.vo.id,
-      'settings',
-      'applicationForm',
-      'manageGroups',
-    ]);
+    void this.router.navigate(
+      ['/organizations', this.applicationForm.vo.id, 'settings', 'applicationForm', 'manageGroups'],
+      { queryParamsHandling: 'preserve' }
+    );
   }
 }

--- a/apps/admin-gui/src/app/vos/components/related-vos/related-vos.component.html
+++ b/apps/admin-gui/src/app/vos/components/related-vos/related-vos.component.html
@@ -4,8 +4,7 @@
     class="vo-link pointer"
     [perunWebAppsMiddleClickRouterLink]="['/organizations', vo.id.toString()]"
     (auxclick)="$event.preventDefault()"
-    [perunWebAppsForceRouterLink]="['/organizations/', vo.id.toString()]"
-    queryParamsHandling="merge">
+    [perunWebAppsForceRouterLink]="['/organizations/', vo.id.toString()]">
     {{vo.name}}
   </a>
   <span *ngIf="vos.length > i+1">, </span>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-detail-page.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-detail-page.component.html
@@ -17,7 +17,7 @@
             [perunWebAppsMiddleClickRouterLink]="['/organizations', vo.id.toString(), 'groups', group.id.toString()]"
             (auxclick)="$event.preventDefault()"
             [routerLink]="['/organizations', vo.id, 'groups', group.id]"
-            queryParamsHandling="merge">
+            [queryParams]="route.snapshot.queryParams">
             {{group.shortName}}
           </a>
           <span class="text-muted"> &nbsp;#{{group.id}} </span>
@@ -44,7 +44,7 @@
             [perunWebAppsMiddleClickRouterLink]="['/organizations', vo.id.toString()]"
             (auxclick)="$event.preventDefault()"
             [routerLink]="['/organizations', vo.id]"
-            queryParamsHandling="merge"
+            [queryParams]="route.snapshot.queryParams"
             >{{vo.name}}</a
           >, {{'GROUP_DETAIL.DESCRIPTION' | translate}}: {{group.description}}
           <span *ngIf="syncEnabled">

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-detail-page.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-detail-page.component.ts
@@ -27,6 +27,7 @@ import { DeleteGroupDialogComponent } from '../../../shared/components/dialogs/d
 import { ReloadEntityDetailService } from '../../../core/services/common/reload-entity-detail.service';
 import { destroyDetailMixin } from '../../../shared/destroy-entity-detail';
 import { takeUntil } from 'rxjs/operators';
+import { QueryParamsRouterService } from '../../../shared/query-params-router.service';
 
 @Component({
   selector: 'app-group-detail-page',
@@ -54,14 +55,15 @@ export class GroupDetailPageComponent extends destroyDetailMixin() implements On
   constructor(
     private sideMenuService: SideMenuService,
     private voService: VosManagerService,
-    private route: ActivatedRoute,
+    public route: ActivatedRoute,
     private sideMenuItemService: SideMenuItemService,
     private groupService: GroupsManagerService,
     private dialog: MatDialog,
     private guiAuthResolver: GuiAuthResolver,
     private router: Router,
     private entityStorageService: EntityStorageService,
-    private reloadEntityDetail: ReloadEntityDetailService
+    private reloadEntityDetail: ReloadEntityDetailService,
+    private queryParamsRouter: QueryParamsRouterService
   ) {
     super();
   }
@@ -178,7 +180,7 @@ export class GroupDetailPageComponent extends destroyDetailMixin() implements On
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        void this.router.navigate(['../'], { relativeTo: this.route });
+        this.queryParamsRouter.navigate(['../'], this.route);
       }
     });
   }

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-overview/group-overview.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-overview/group-overview.component.html
@@ -6,8 +6,7 @@
       class="group-link"
       [perunWebAppsMiddleClickRouterLink]="['/organizations', parentGroup.voId.toString(), 'groups', parentGroup.id.toString()]"
       (auxclick)="$event.preventDefault()"
-      [routerLink]="['/organizations', parentGroup.voId, 'groups', parentGroup.id]"
-      queryParamsHandling="merge">
+      [routerLink]="['/organizations', parentGroup.voId, 'groups', parentGroup.id]">
       {{parentGroup.name}}
     </a>
   </p>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.ts
@@ -194,7 +194,10 @@ export class GroupSettingsApplicationFormComponent implements OnInit {
         'applicationForm',
         'preview',
       ],
-      { queryParams: { applicationFormItems: JSON.stringify(this.applicationFormItems) } }
+      {
+        queryParams: { applicationFormItems: JSON.stringify(this.applicationFormItems) },
+        queryParamsHandling: 'merge',
+      }
     );
   }
 

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-detail-page.component.html
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-detail-page.component.html
@@ -16,8 +16,7 @@
             class="member-link"
             [perunWebAppsMiddleClickRouterLink]="['/organizations', vo.id.toString(), 'members', member.id.toString()]"
             (auxclick)="$event.preventDefault()"
-            [routerLink]="['/organizations', vo.id, 'members', member.id]"
-            queryParamsHandling="merge">
+            [routerLink]="['/organizations', vo.id, 'members', member.id]">
             {{fullName}}
           </a>
           <span class="text-muted"> &nbsp;#{{member.id}} </span>
@@ -29,8 +28,7 @@
             *ngIf="isAuthorized"
             [perunWebAppsMiddleClickRouterLink]="['/admin', 'users', member.userId.toString()]"
             (auxclick)="$event.preventDefault()"
-            [routerLink]="['/admin', 'users', member.userId]"
-            queryParamsHandling="merge">
+            [routerLink]="['/admin', 'users', member.userId]">
             {{member.userId}}
           </a>
           <span *ngIf="!isAuthorized">{{member.userId}}</span>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-detail-page.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-detail-page.component.html
@@ -16,7 +16,7 @@
             [perunWebAppsMiddleClickRouterLink]="['/organizations', vo.id.toString()]"
             (auxclick)="$event.preventDefault()"
             [routerLink]="['/organizations/', vo.id]"
-            queryParamsHandling="merge"
+            [queryParams]="route.snapshot.queryParams"
             data-cy="vo-name-link">
             {{vo.name}}
           </a>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-detail-page.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-detail-page.component.ts
@@ -19,6 +19,7 @@ import { RemoveVoDialogComponent } from '../../../shared/components/dialogs/remo
 import { ReloadEntityDetailService } from '../../../core/services/common/reload-entity-detail.service';
 import { destroyDetailMixin } from '../../../shared/destroy-entity-detail';
 import { takeUntil } from 'rxjs/operators';
+import { QueryParamsRouterService } from '../../../shared/query-params-router.service';
 
 @Component({
   selector: 'app-vo-detail-page',
@@ -36,13 +37,14 @@ export class VoDetailPageComponent extends destroyDetailMixin() implements OnIni
   constructor(
     private sideMenuService: SideMenuService,
     private voService: VosManagerService,
-    private route: ActivatedRoute,
+    public route: ActivatedRoute,
     private router: Router,
     private sideMenuItemService: SideMenuItemService,
     private dialog: MatDialog,
     private authResolver: GuiAuthResolver,
     private entityStorageService: EntityStorageService,
-    private reloadEntityDetail: ReloadEntityDetailService
+    private reloadEntityDetail: ReloadEntityDetailService,
+    private queryParamsRouter: QueryParamsRouterService
   ) {
     super();
   }
@@ -117,7 +119,7 @@ export class VoDetailPageComponent extends destroyDetailMixin() implements OnIni
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        void this.router.navigate(['']);
+        this.queryParamsRouter.navigate(['']);
       }
     });
   }

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.ts
@@ -136,6 +136,7 @@ export class VoSettingsApplicationFormComponent implements OnInit {
       ['/organizations', this.vo.id, 'settings', 'applicationForm', 'preview'],
       {
         queryParams: { applicationFormItems: JSON.stringify(this.applicationFormItems) },
+        queryParamsHandling: 'merge',
       }
     );
   }

--- a/apps/consolidator/src/app/components/main-window/main-window.component.ts
+++ b/apps/consolidator/src/app/components/main-window/main-window.component.ts
@@ -64,7 +64,7 @@ export class MainWindowComponent implements OnInit {
         this.reloadData++;
         this.initData();
       } else if (result === 'MESSAGE_SENT_TO_SUPPORT') {
-        void this.router.navigate(['/result', result]);
+        void this.router.navigate(['/result', result], { queryParamsHandling: 'preserve' });
       }
     }, idpFilter);
   }

--- a/apps/linker/src/app/service/link-identities.service.ts
+++ b/apps/linker/src/app/service/link-identities.service.ts
@@ -17,7 +17,7 @@ export class LinkIdentitiesService {
       this.registrarService.consolidate({ accessToken: accessToken }).subscribe(
         () => {
           void this.consolidatePreviousLogins(1, queryParams).then(() => {
-            void this.router.navigate(['/result', 'OK']);
+            void this.router.navigate(['/result', 'OK'], { queryParamsHandling: 'preserve' });
             resolve();
           });
         },

--- a/apps/publications/src/app/app.component.ts
+++ b/apps/publications/src/app/app.component.ts
@@ -55,7 +55,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       !this.authResolver.isCabinetAdmin() &&
       (url === '/' || disabledUrlsForSelfRole.some((disabledUrl) => url.includes(disabledUrl)))
     ) {
-      void this.router.navigate(['my-publications']);
+      void this.router.navigate(['my-publications'], { queryParamsHandling: 'preserve' });
     }
   }
 

--- a/apps/publications/src/app/pages/create-publication-page/create-publication-page.component.ts
+++ b/apps/publications/src/app/pages/create-publication-page/create-publication-page.component.ts
@@ -10,10 +10,14 @@ export class CreatePublicationPageComponent {
   constructor(private router: Router) {}
 
   importPublications(): void {
-    void this.router.navigate(['create-publication', 'import']);
+    void this.router.navigate(['create-publication', 'import'], {
+      queryParamsHandling: 'preserve',
+    });
   }
 
   createPublication(): void {
-    void this.router.navigate(['create-publication', 'create']);
+    void this.router.navigate(['create-publication', 'create'], {
+      queryParamsHandling: 'preserve',
+    });
   }
 }

--- a/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.ts
+++ b/apps/publications/src/app/pages/create-publication-page/create-single-publication-page/create-single-publication-page.component.ts
@@ -207,7 +207,7 @@ export class CreateSinglePublicationPageComponent implements OnInit {
   }
 
   redirect(commands: string[]): void {
-    void this.router.navigate(commands);
+    void this.router.navigate(commands, { queryParamsHandling: 'preserve' });
   }
 
   showDialogAndRedirect(commands: string[], publicationId: number): void {

--- a/apps/publications/src/app/pages/create-publication-page/import-publications-page/import-publications-page.component.ts
+++ b/apps/publications/src/app/pages/create-publication-page/import-publications-page/import-publications-page.component.ts
@@ -215,6 +215,6 @@ export class ImportPublicationsPageComponent implements OnInit {
     this.notificator.showSuccess(
       this.translate.instant('IMPORT_PUBLICATIONS.SHOW_FINISH') as string
     );
-    void this.router.navigate(['/my-publications']);
+    void this.router.navigate(['/my-publications'], { queryParamsHandling: 'preserve' });
   }
 }

--- a/apps/user-profile/src/app/components/breadcrumbs/breadcrumbs.component.html
+++ b/apps/user-profile/src/app/components/breadcrumbs/breadcrumbs.component.html
@@ -1,8 +1,3 @@
 <span *ngFor="let item of menuItems" class="custom-breadcrumb">
-  <a
-    [routerLink]="item.routerLink"
-    class="breadcrumb-text"
-    queryParamsHandling="merge"
-    >{{item.label}}</a
-  >
+  <a [routerLink]="item.routerLink" class="breadcrumb-text">{{item.label}}</a>
 </span>

--- a/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.ts
+++ b/apps/user-profile/src/app/pages/consents-page/consent-request/consent-request.component.ts
@@ -64,15 +64,15 @@ export class ConsentRequestComponent implements OnInit {
 
   rejectConsent(): void {
     this.loading = true;
-    this.consentService.changeConsentStatus(this.consent.id, 'REVOKED').subscribe(
-      () => {
+    this.consentService.changeConsentStatus(this.consent.id, 'REVOKED').subscribe({
+      next: () => {
         this.notificator.showSuccess(
           (this.translate.instant('CONSENTS.CONSENT_REJECTED') as string) +
             this.consent.consentHub.name
         );
         void this.router.navigate(['/profile', 'consents'], { queryParamsHandling: 'merge' });
       },
-      () => (this.loading = false)
-    );
+      error: () => (this.loading = false),
+    });
   }
 }

--- a/apps/user-profile/src/app/pages/profile-page/profile-page.component.ts
+++ b/apps/user-profile/src/app/pages/profile-page/profile-page.component.ts
@@ -89,13 +89,13 @@ export class ProfilePageComponent implements OnInit {
       this.apiRequestConfiguration.dontHandleErrorForNext();
       this.usersManagerService
         .validatePreferredEmailChangeWithToken(token, Number.parseInt(u, 10))
-        .subscribe(
-          () => {
+        .subscribe({
+          next: () => {
             this.notificator.showSuccess(this.successMessage);
-            void this.router.navigate([], { replaceUrl: true });
+            void this.router.navigate([], { replaceUrl: true, queryParamsHandling: 'preserve' });
             this.getData();
           },
-          () => {
+          error: () => {
             const config = getDefaultDialogConfig();
             config.width = '600px';
 
@@ -103,8 +103,8 @@ export class ProfilePageComponent implements OnInit {
             dialogRef.afterClosed().subscribe(() => {
               this.getData();
             });
-          }
-        );
+          },
+        });
     } else {
       this.getData();
     }

--- a/libs/perun/components/src/lib/groups-tree/groups-tree.component.html
+++ b/libs/perun/components/src/lib/groups-tree/groups-tree.component.html
@@ -23,8 +23,7 @@
           class="group-item-content text-format"
           [perunWebAppsMiddleClickRouterLink]="disableRouting ? null :['/organizations', group.voId.toString(), 'groups', group.id.toString()]"
           (auxclick)="$event.preventDefault()"
-          [routerLink]="disableRouting ? null :['/organizations', group.voId, 'groups', group.id]"
-          queryParamsHandling="merge">
+          [routerLink]="disableRouting ? null :['/organizations', group.voId, 'groups', group.id]">
           <button
             mat-icon-button
             (mouseenter)="disableRouting = true"

--- a/libs/perun/components/src/lib/menu-buttons-field/menu-buttons-field.component.html
+++ b/libs/perun/components/src/lib/menu-buttons-field/menu-buttons-field.component.html
@@ -5,7 +5,6 @@
       [perunWebAppsMiddleClickRouterLink]="[item.url]"
       (auxclick)="$event.preventDefault()"
       [routerLink]="item.url"
-      queryParamsHandling="merge"
       attr.data-cy="{{item.label | translate | multiWordDataCy}}">
       <mat-icon [svgIcon]="item.cssIcon" class="item-pic perun-icon"></mat-icon>
       <!--    <img src="assets/img/PerunWebImages/{{item.icon}}" alt="{{item.label}}">-->

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -110,6 +110,7 @@ import { RoleSearchSelectComponent } from './role-search-select/role-search-sele
 import { PerunHeaderComponent } from './perun-header/perun-header.component';
 import { MatBadgeModule } from '@angular/material/badge';
 import { ShowNotificationHistoryDialogComponent } from '@perun-web-apps/perun/dialogs';
+import { QueryParamsHandlingDirective } from '@perun-web-apps/perun/directives';
 
 @Injectable()
 export class AppDateAdapter extends NativeDateAdapter {
@@ -252,6 +253,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     RoleSearchSelectComponent,
     PerunHeaderComponent,
     ShowNotificationHistoryDialogComponent,
+    QueryParamsHandlingDirective,
   ],
   exports: [
     VosListComponent,
@@ -321,6 +323,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     RoleSearchSelectComponent,
     PerunHeaderComponent,
     ShowNotificationHistoryDialogComponent,
+    QueryParamsHandlingDirective,
   ],
   providers: [
     { provide: DateAdapter, useClass: AppDateAdapter },

--- a/libs/perun/components/src/lib/perun-header/perun-header.component.html
+++ b/libs/perun/components/src/lib/perun-header/perun-header.component.html
@@ -14,6 +14,7 @@
     <a
       [innerHTML]="logo"
       [routerLink]="disableLogo ? [] : ['/']"
+      [queryParams]="route.snapshot.queryParams"
       class="logo-container mt-auto mb-auto"
       queryParamsHandling="merge"></a>
 

--- a/libs/perun/components/src/lib/perun-header/perun-header.component.ts
+++ b/libs/perun/components/src/lib/perun-header/perun-header.component.ts
@@ -10,6 +10,7 @@ import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { MatDialog } from '@angular/material/dialog';
 import { ShowNotificationHistoryDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { AppType } from '@perun-web-apps/perun/models';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'perun-web-apps-header',
@@ -47,7 +48,8 @@ export class PerunHeaderComponent implements OnInit {
     private translateService: TranslateService,
     private otherApplicationService: OtherApplicationsService,
     private notificationStorageService: NotificationStorageService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    public route: ActivatedRoute
   ) {}
 
   ngOnInit(): void {

--- a/libs/perun/components/src/lib/redirect-page/redirect-page.component.ts
+++ b/libs/perun/components/src/lib/redirect-page/redirect-page.component.ts
@@ -23,7 +23,15 @@ export class RedirectPageComponent implements OnInit {
     }
 
     this.route.queryParams.subscribe((params) => {
-      void this.router.navigate([params.redirectTo]);
+      const newParams = Object.assign({}, params);
+      // preserve all previous params excluding temporary params redirectTo and applicationFormItems (application preview)
+      delete newParams.redirectTo;
+      delete newParams.applicationFormItems;
+      void this.router.navigate([params.redirectTo], {
+        queryParams: newParams,
+        // we don't want to merge or preserve old queryParams here!
+        queryParamsHandling: '',
+      });
     });
   }
 }

--- a/libs/perun/components/src/lib/settings-mailing-lists/mailing-lists.component.ts
+++ b/libs/perun/components/src/lib/settings-mailing-lists/mailing-lists.component.ts
@@ -52,6 +52,7 @@ export class MailingListsComponent implements OnInit, OnDestroy {
         relativeTo: this.route,
         queryParams: { vo: null, resource: null },
         replaceUrl: true,
+        queryParamsHandling: 'merge',
       });
     }
   }

--- a/libs/perun/components/src/lib/user-ext-sources-list/user-ext-sources-list.component.html
+++ b/libs/perun/components/src/lib/user-ext-sources-list/user-ext-sources-list.component.html
@@ -79,7 +79,7 @@
         *matRowDef="let richUserExtSource; columns: displayedColumns;"
         [class.cursor-pointer]="!disableRouting"
         [class.disable-outline]="disableRouting"
-        [perunWebAppsMiddleClickRouterLink]="disableRouting ? null : ['/admin', 'users', userId, 'identities', richUserExtSource.userExtSource.id]"
+        [perunWebAppsMiddleClickRouterLink]="disableRouting ? null : ['/admin', 'users', userId.toString(), 'identities', richUserExtSource.userExtSource.id.toString()]"
         [routerLink]="disableRouting ? null : ['/admin', 'users', userId, 'identities', richUserExtSource.userExtSource.id]"
         class="dark-hover-list-item"
         mat-row></tr>

--- a/libs/perun/dialogs/src/lib/mail-change-failed-dialog/mail-change-failed-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/mail-change-failed-dialog/mail-change-failed-dialog.component.ts
@@ -14,7 +14,7 @@ export class MailChangeFailedDialogComponent {
   ) {}
 
   onClose(): void {
-    void this.router.navigate([]);
+    void this.router.navigate([], { queryParamsHandling: 'preserve' });
     this.dialogRef.close();
   }
 }

--- a/libs/perun/directives/src/index.ts
+++ b/libs/perun/directives/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/auto-focus.directive';
 export * from './lib/force-router-link.directive';
 export * from './lib/middle-click-router-link';
 export * from './lib/loader.directive';
+export * from './lib/query-params-handling.directive';

--- a/libs/perun/directives/src/lib/query-params-handling.directive.ts
+++ b/libs/perun/directives/src/lib/query-params-handling.directive.ts
@@ -1,0 +1,20 @@
+import { Directive, OnChanges } from '@angular/core';
+import { QueryParamsHandling, RouterLink } from '@angular/router';
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: 'tr[routerLink], a[routerLink]',
+})
+export class QueryParamsHandlingDirective extends RouterLink implements OnChanges {
+  queryParamsHandling: QueryParamsHandling = 'merge';
+
+  ngOnChanges(): void {
+    // avoid to preserving application preview query params
+    if (this.queryParams && 'applicationFormItems' in this.queryParams) {
+      this.queryParamsHandling = '';
+      const newParams = Object.assign({}, this.queryParams);
+      delete newParams.applicationFormItems;
+      this.queryParams = newParams;
+    }
+  }
+}

--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -44,7 +44,7 @@ export class AuthService {
       sessionStorage.removeItem('basicUsername');
       sessionStorage.removeItem('basicPassword');
       sessionStorage.setItem('baLogout', 'true');
-      void this.router.navigate(['/service-access']);
+      void this.router.navigate(['/service-access'], { queryParamsHandling: 'preserve' });
     } else {
       this.oauthService.logOut();
     }

--- a/libs/perun/services/src/lib/force-router.service.ts
+++ b/libs/perun/services/src/lib/force-router.service.ts
@@ -51,6 +51,7 @@ export class ForceRouterService {
       extras = {};
     }
     extras.queryParams = { redirectTo: fullUrl };
+    extras.queryParamsHandling = 'merge';
 
     void this.router.navigate(['redirect'], extras);
   }

--- a/libs/perun/services/src/lib/route-policy.service.ts
+++ b/libs/perun/services/src/lib/route-policy.service.ts
@@ -247,15 +247,15 @@ export class RoutePolicyService {
         this.apiRequest.dontHandleErrorForNext();
         this.attributesManager
           .getGroupAttributeByName(group.id, Urns.GROUP_DEF_EXPIRATION_RULES)
-          .subscribe(
-            () => {
+          .subscribe({
+            next: () => {
               // do nothing - routing will be successfull
             },
-            () => {
+            error: () => {
               this.notificator.showRouteError();
-              void this.router.navigate(['/notAuthorized']);
-            }
-          );
+              void this.router.navigate(['/notAuthorized'], { queryParamsHandling: 'preserve' });
+            },
+          });
         return true;
       },
     ],


### PR DESCRIPTION
* Programmatic navigation in all ts files was fixed by merging or preserving query parameters.
* Correct navigation with all query params by <a> tag and <tr> tag via [routerLink] is managed by the new directive.
* Special use cases were handled like navigation between the same entities (e.g. hierarchical organizations) and do NOT preserve query params by redirecting from the preview page, where the query parameters are used for the definition of application items.