### PR TITLE
fix: Login page redirect to correct "home" page

### DIFF
--- a/libs/perun/login/src/lib/login-screen/login-screen.component.ts
+++ b/libs/perun/login/src/lib/login-screen/login-screen.component.ts
@@ -12,7 +12,7 @@ export class LoginScreenComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.auth.isLoggedIn()) {
-      void this.router.navigate(['/home'], { queryParamsHandling: 'merge' });
+      void this.router.navigate([''], { queryParamsHandling: 'merge' });
     }
   }
   startAuth(): void {


### PR DESCRIPTION
Previously if user was logged in and tried to access login page he would be redirected to "/home" which does not exist on all applications. Now he is redirected to "" (just base url). Each application than correctly navigates to it's "home" page.