### PR TITLE
fix(admin): fixed two-entity attributes selection, setting and removal

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/create-attribute-dialog/create-attribute-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-attribute-dialog/create-attribute-dialog.component.ts
@@ -163,14 +163,29 @@ export class CreateAttributeDialogComponent implements OnInit {
 
     switch (this.data.entity) {
       case 'facility':
-        this.attributesManager
-          .setFacilityAttributes({
-            facility: this.data.entityId,
-            attributes: this.selected.selected,
-          })
-          .subscribe(() => {
-            this.handleSuccess();
-          });
+        switch (this.data.secondEntity) {
+          case 'user':
+            this.attributesManager
+              .setUserFacilityAttributes({
+                facility: this.data.entityId,
+                user: this.data.secondEntityId,
+                attributes: this.selected.selected,
+              })
+              .subscribe(() => {
+                this.handleSuccess();
+              });
+            break;
+          default:
+            this.attributesManager
+              .setFacilityAttributes({
+                facility: this.data.entityId,
+                attributes: this.selected.selected,
+              })
+              .subscribe(() => {
+                this.handleSuccess();
+              });
+            break;
+        }
         break;
       case 'group':
         switch (this.data.secondEntity) {
@@ -232,14 +247,39 @@ export class CreateAttributeDialogComponent implements OnInit {
         }
         break;
       case 'resource':
-        this.attributesManager
-          .setResourceAttributes({
-            resource: this.data.entityId,
-            attributes: this.selected.selected,
-          })
-          .subscribe(() => {
-            this.handleSuccess();
-          });
+        switch (this.data.secondEntity) {
+          case 'member':
+            this.attributesManager
+              .setMemberResourceAttributes({
+                resource: this.data.entityId,
+                member: this.data.secondEntityId,
+                attributes: this.selected.selected,
+              })
+              .subscribe(() => {
+                this.handleSuccess();
+              });
+            break;
+          case 'group':
+            this.attributesManager
+              .setGroupResourceAttributes({
+                resource: this.data.entityId,
+                group: this.data.secondEntityId,
+                attributes: this.selected.selected,
+              })
+              .subscribe(() => {
+                this.handleSuccess();
+              });
+            break;
+          default:
+            this.attributesManager
+              .setResourceAttributes({
+                resource: this.data.entityId,
+                attributes: this.selected.selected,
+              })
+              .subscribe(() => {
+                this.handleSuccess();
+              });
+        }
         break;
       case 'user':
         switch (this.data.secondEntity) {
@@ -312,6 +352,9 @@ export class CreateAttributeDialogComponent implements OnInit {
     if (!this.data.secondEntity) {
       return true;
     }
-    return attribute.entity === `${this.data.entity}_${this.data.secondEntity}`;
+    return (
+      attribute.entity === `${this.data.entity}_${this.data.secondEntity}` ||
+      attribute.entity === `${this.data.secondEntity}_${this.data.entity}`
+    );
   }
 }

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-dialog/delete-attribute-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-dialog/delete-attribute-dialog.component.ts
@@ -61,32 +61,32 @@ export class DeleteAttributeDialogComponent implements OnInit {
     this.loading = true;
     switch (this.data.entity) {
       case 'vo':
-        this.attributesManager.removeVoAttributes(this.data.entityId, ids).subscribe(
-          () => {
+        this.attributesManager.removeVoAttributes(this.data.entityId, ids).subscribe({
+          next: () => {
             this.onSuccess();
           },
-          () => (this.loading = false)
-        );
+          error: () => (this.loading = false),
+        });
         break;
       case 'group':
         switch (this.data.secondEntity) {
           case 'resource':
             this.attributesManager
               .removeGroupResourceAttributes(this.data.entityId, this.data.secondEntityId, ids)
-              .subscribe(
-                () => {
+              .subscribe({
+                next: () => {
                   this.onSuccess();
                 },
-                () => (this.loading = false)
-              );
+                error: () => (this.loading = false),
+              });
             break;
           default:
-            this.attributesManager.removeGroupAttributes(this.data.entityId, ids).subscribe(
-              () => {
+            this.attributesManager.removeGroupAttributes(this.data.entityId, ids).subscribe({
+              next: () => {
                 this.onSuccess();
               },
-              () => (this.loading = false)
-            );
+              error: () => (this.loading = false),
+            });
         }
         break;
       case 'user':
@@ -94,20 +94,20 @@ export class DeleteAttributeDialogComponent implements OnInit {
           case 'facility':
             this.attributesManager
               .removeUserFacilityAttributes(this.data.entityId, this.data.secondEntityId, ids)
-              .subscribe(
-                () => {
+              .subscribe({
+                next: () => {
                   this.onSuccess();
                 },
-                () => (this.loading = false)
-              );
+                error: () => (this.loading = false),
+              });
             break;
           default:
-            this.attributesManager.removeUserAttributes(this.data.entityId, ids).subscribe(
-              () => {
+            this.attributesManager.removeUserAttributes(this.data.entityId, ids).subscribe({
+              next: () => {
                 this.onSuccess();
               },
-              () => (this.loading = false)
-            );
+              error: () => (this.loading = false),
+            });
         }
         break;
       case 'member':
@@ -115,47 +115,60 @@ export class DeleteAttributeDialogComponent implements OnInit {
           case 'resource':
             this.attributesManager
               .removeMemberResourceAttributes(this.data.entityId, this.data.secondEntityId, ids)
-              .subscribe(
-                () => {
+              .subscribe({
+                next: () => {
                   this.onSuccess();
                 },
-                () => (this.loading = false)
-              );
+                error: () => (this.loading = false),
+              });
             break;
           case 'group':
             this.attributesManager
               .removeMemberGroupAttributes(this.data.entityId, this.data.secondEntityId, ids)
-              .subscribe(
-                () => {
+              .subscribe({
+                next: () => {
                   this.onSuccess();
                 },
-                () => (this.loading = false)
-              );
+                error: () => (this.loading = false),
+              });
             break;
           default:
-            this.attributesManager.removeMemberAttributes(this.data.entityId, ids).subscribe(
-              () => {
+            this.attributesManager.removeMemberAttributes(this.data.entityId, ids).subscribe({
+              next: () => {
                 this.onSuccess();
               },
-              () => (this.loading = false)
-            );
+              error: () => (this.loading = false),
+            });
         }
         break;
       case 'facility':
-        this.attributesManager.removeFacilityAttributes(this.data.entityId, ids).subscribe(
-          () => {
-            this.onSuccess();
-          },
-          () => (this.loading = false)
-        );
+        switch (this.data.secondEntity) {
+          case 'user':
+            this.attributesManager
+              .removeUserFacilityAttributes(this.data.secondEntityId, this.data.entityId, ids)
+              .subscribe({
+                next: () => {
+                  this.onSuccess();
+                },
+                error: () => (this.loading = false),
+              });
+            break;
+          default:
+            this.attributesManager.removeFacilityAttributes(this.data.entityId, ids).subscribe({
+              next: () => {
+                this.onSuccess();
+              },
+              error: () => (this.loading = false),
+            });
+        }
         break;
       case 'host':
-        this.attributesManager.removeHostAttributes(this.data.entityId, ids).subscribe(
-          () => {
+        this.attributesManager.removeHostAttributes(this.data.entityId, ids).subscribe({
+          next: () => {
             this.onSuccess();
           },
-          () => (this.loading = false)
-        );
+          error: () => (this.loading = false),
+        });
         break;
       case 'ues':
         this.attributesManager.removeUesAttributes(this.data.entityId, ids).subscribe({
@@ -166,9 +179,35 @@ export class DeleteAttributeDialogComponent implements OnInit {
         });
         break;
       case 'resource':
-        this.attributesManager
-          .removeResourceAttributes(this.data.entityId, ids)
-          .subscribe({ next: () => this.onSuccess(), error: () => (this.loading = false) });
+        switch (this.data.secondEntity) {
+          case 'member':
+            this.attributesManager
+              .removeMemberResourceAttributes(this.data.secondEntityId, this.data.entityId, ids)
+              .subscribe({
+                next: () => {
+                  this.onSuccess();
+                },
+                error: () => (this.loading = false),
+              });
+            break;
+          case 'group':
+            this.attributesManager
+              .removeGroupResourceAttributes(this.data.secondEntityId, this.data.entityId, ids)
+              .subscribe({
+                next: () => {
+                  this.onSuccess();
+                },
+                error: () => (this.loading = false),
+              });
+            break;
+          default:
+            this.attributesManager.removeResourceAttributes(this.data.entityId, ids).subscribe({
+              next: () => {
+                this.onSuccess();
+              },
+              error: () => (this.loading = false),
+            });
+        }
         break;
     }
   }

--- a/libs/perun/dialogs/src/lib/edit-attribute-dialog/edit-attribute-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/edit-attribute-dialog/edit-attribute-dialog.component.ts
@@ -127,14 +127,27 @@ export class EditAttributeDialogComponent implements OnInit {
         }
         break;
       case 'facility':
-        this.attributesManager
-          .setFacilityAttributes({
-            facility: this.data.entityId,
-            attributes: this.data.attributes,
-          })
-          .subscribe(() => {
-            this.onSuccess();
-          });
+        switch (this.data.secondEntity) {
+          case 'user':
+            this.attributesManager
+              .setFacilityUserAttributes({
+                facility: this.data.entityId,
+                user: this.data.secondEntityId,
+                attributes: this.data.attributes,
+              })
+              .subscribe(() => this.onSuccess());
+            break;
+          default:
+            this.attributesManager
+              .setFacilityAttributes({
+                facility: this.data.entityId,
+                attributes: this.data.attributes,
+              })
+              .subscribe(() => {
+                this.onSuccess();
+              });
+            break;
+        }
         break;
       case 'host':
         this.attributesManager
@@ -157,12 +170,34 @@ export class EditAttributeDialogComponent implements OnInit {
           });
         break;
       case 'resource':
-        this.attributesManager
-          .setResourceAttributes({
-            resource: this.data.entityId,
-            attributes: this.data.attributes,
-          })
-          .subscribe(() => this.onSuccess());
+        switch (this.data.secondEntity) {
+          case 'member':
+            this.attributesManager
+              .setMemberResourceAttributes({
+                resource: this.data.entityId,
+                member: this.data.secondEntityId,
+                attributes: this.data.attributes,
+              })
+              .subscribe(() => this.onSuccess());
+            break;
+          case 'group':
+            this.attributesManager
+              .setResourceGroupAttributes({
+                resource: this.data.entityId,
+                group: this.data.secondEntityId,
+                attributes: this.data.attributes,
+              })
+              .subscribe(() => this.onSuccess());
+            break;
+          default:
+            this.attributesManager
+              .setResourceAttributes({
+                resource: this.data.entityId,
+                attributes: this.data.attributes,
+              })
+              .subscribe(() => this.onSuccess());
+            break;
+        }
         break;
     }
   }


### PR DESCRIPTION
* on resource and facility details, it was not possible to correctly work with two-entity attributes
* now they are correctly shown, filtered, updatable and removable