### PR TITLE
fix: added jdocs for useNon parameter

### DIFF
--- a/.openapi-generator/templates/api.service.mustache
+++ b/.openapi-generator/templates/api.service.mustache
@@ -158,6 +158,7 @@ export class {{classname}} {
      * @param requestParameters
      {{/allParams.0}}
      {{/useSingleRequestParameter}}
+     * @param useNon if set to true sends the request to the backend server as 'non' instead of the usual (oauth, krb...).
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      {{#isDeprecated}}


### PR DESCRIPTION
* added description for the useNon parameter in services
* changes will be visible after next openapi generation