### PR TITLE
fix(admin): entityless attributes key-value pairs correctly displayed

### DIFF
--- a/apps/admin-gui/src/app/shared/components/entityless-attribute-keys-list/entityless-attribute-keys-list.component.html
+++ b/apps/admin-gui/src/app/shared/components/entityless-attribute-keys-list/entityless-attribute-keys-list.component.html
@@ -62,7 +62,7 @@
         </ng-container>
 
         <ng-container matColumnDef="key">
-          <th *matHeaderCellDef mat-header-cell mat-sort-header>
+          <th *matHeaderCellDef mat-header-cell>
             {{'SHARED.COMPONENTS.ENTITYLESS_ATTRIBUTES_LIST.KEY' | translate}}
           </th>
           <td *matCellDef="let record" mat-cell>
@@ -77,7 +77,7 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="value">
-          <th *matHeaderCellDef mat-header-cell mat-sort-header>
+          <th *matHeaderCellDef mat-header-cell>
             {{'SHARED.COMPONENTS.ENTITYLESS_ATTRIBUTES_LIST.VALUE' | translate}}
           </th>
           <td *matCellDef="let record" mat-cell>

--- a/apps/admin-gui/src/app/shared/components/entityless-attribute-keys-list/entityless-attribute-keys-list.component.ts
+++ b/apps/admin-gui/src/app/shared/components/entityless-attribute-keys-list/entityless-attribute-keys-list.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectorRef,
   Component,
   EventEmitter,
   Inject,
@@ -62,7 +63,8 @@ export class EntitylessAttributeKeysListComponent implements OnChanges, OnInit, 
     @Inject(MAT_DIALOG_DATA) public data: EntitylessAttributeKeysListData,
     private notificator: NotificatorService,
     private translate: TranslateService,
-    private attributesManager: AttributesManagerService
+    private attributesManager: AttributesManagerService,
+    private cd: ChangeDetectorRef
   ) {}
 
   @ViewChild(MatSort, { static: true }) set matSort(ms: MatSort) {
@@ -119,6 +121,7 @@ export class EntitylessAttributeKeysListComponent implements OnChanges, OnInit, 
     }
     this.selection.clear();
     this.isAddButtonDisabled = false;
+    this.cd.detectChanges();
   }
 
   onRemove(): void {
@@ -135,6 +138,7 @@ export class EntitylessAttributeKeysListComponent implements OnChanges, OnInit, 
     this.ngOnInit();
     this.selection.clear();
     this.isAddButtonDisabled = false;
+    this.cd.detectChanges();
   }
 
   onAdd(): void {
@@ -146,6 +150,7 @@ export class EntitylessAttributeKeysListComponent implements OnChanges, OnInit, 
     this.selection.clear();
     this.selection.select(rec);
     this.isAddButtonDisabled = true;
+    this.cd.detectChanges();
   }
 
   onCancel(): void {
@@ -185,5 +190,6 @@ export class EntitylessAttributeKeysListComponent implements OnChanges, OnInit, 
       this.child = children.first;
       this.dataSource.paginator = this.child.paginator;
     });
+    this.setDataSource();
   }
 }

--- a/libs/perun/services/src/lib/table-checkbox.service.ts
+++ b/libs/perun/services/src/lib/table-checkbox.service.ts
@@ -41,7 +41,10 @@ export class TableCheckbox {
     }
     this.pageIterator = 0;
 
-    dataSource.sortData(dataSource.filteredData, sort).forEach((row: T) => {
+    const data = sort
+      ? dataSource.sortData(dataSource.filteredData, sort)
+      : dataSource.filteredData;
+    data.forEach((row: T) => {
       if (
         this.pageStart <= this.pageIterator &&
         this.pageIterator < this.pageEnd &&


### PR DESCRIPTION
* fixed problem when adding new key-value pair for attribute definition, table was not rendered (loaded) properly - missing newly prepared row
* checkboxes fixed
* mat-sort-header keyword removed from table headers (for now)