### PR TITLE
feat: allow inputting multi-line string values to string attributes

### DIFF
--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2934,12 +2934,18 @@
             "SUBMIT_BUTTON": "Submit",
             "CANCEL_BUTTON": "Cancel"
           },
+
           "DELETE_DIALOG": {
             "TITLE": "Delete attribute value",
             "DESCRIPTION": "Do you really want to delete this attribute list value from list?",
             "SUBMIT_BUTTON": "Delete",
             "CANCEL_BUTTON": "Cancel"
           }
+        },
+        "ATTRIBUTE_VALUE_STRING": {
+          "TOOLTIP": "Please use the edit button to edit multi-line string attributes",
+          "EXTRA_LINES_SINGLE": "more line",
+          "EXTRA_LINES_PLURAL": "more lines"
         },
         "ATTRIBUTES_LIST": {
           "FILTER": "Filter attributes by Id, name, value or description",

--- a/libs/perun/components/src/lib/attributes-list/attribute-value/attribute-value-string/attribute-value-string.component.html
+++ b/libs/perun/components/src/lib/attributes-list/attribute-value/attribute-value-string/attribute-value-string.component.html
@@ -1,12 +1,17 @@
 <mat-form-field appearance="{{readonly ? 'none' : 'standard'}}" class="w-100">
-  <input
-    matInput
-    (click)="readonly && value !== undefined && showValue(value, attribute.displayName)"
-    [class.cursor-pointer]="readonly && value !== undefined"
-    [readonly]="readonly"
-    class="overflow-ellipsis"
-    [(ngModel)]="attribute.value"
-    type="text"
-    attr.data-cy="{{attribute.displayName | multiWordDataCy}}-value"
-    (keydown)="_sendEventToParent()" />
+  <div class="inline">
+    <input
+      matInput
+      matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTE_VALUE_STRING.TOOLTIP' | translate}}"
+      [matTooltipDisabled]="readonly || !multiline"
+      (click)="(readonly || multiline) && value !== undefined && showValue(attribute.value, attribute.displayName)"
+      [class.cursor-pointer]="(readonly || multiline) && value !== undefined"
+      [readonly]="readonly || multiline"
+      class="overflow-ellipsis"
+      [(ngModel)]="value"
+      type="text"
+      attr.data-cy="{{attribute.displayName | multiWordDataCy}}-value"
+      (keyup)="_sendEventToParent()" />
+    <mat-icon *ngIf="!readonly" (click)="edit()" class="edit-delete-icon">edit</mat-icon>
+  </div>
 </mat-form-field>

--- a/libs/perun/components/src/lib/attributes-list/attribute-value/attribute-value-string/attribute-value-string.component.scss
+++ b/libs/perun/components/src/lib/attributes-list/attribute-value/attribute-value-string/attribute-value-string.component.scss
@@ -5,3 +5,16 @@
 .overflow-ellipsis {
   text-overflow: ellipsis;
 }
+
+.edit-delete-icon {
+  font-size: 18px;
+  justify-content: center;
+  align-items: normal;
+  display: flex;
+  cursor: pointer;
+}
+
+.inline {
+  display: flex;
+  flex-direction: row;
+}

--- a/libs/perun/components/src/lib/attributes-list/attribute-value/attribute-value-string/attribute-value-string.component.ts
+++ b/libs/perun/components/src/lib/attributes-list/attribute-value/attribute-value-string/attribute-value-string.component.ts
@@ -1,8 +1,12 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Attribute } from '@perun-web-apps/perun/openapi';
 import { getDefaultDialogConfig, isVirtualAttribute } from '@perun-web-apps/perun/utils';
-import { ShowValueDialogComponent } from '@perun-web-apps/perun/dialogs';
+import {
+  AttributeValueListEditDialogComponent,
+  ShowValueDialogComponent,
+} from '@perun-web-apps/perun/dialogs';
 import { MatDialog } from '@angular/material/dialog';
+import { PerunTranslateService } from '@perun-web-apps/perun/services';
 
 @Component({
   selector: 'perun-web-apps-attribute-value-string',
@@ -15,17 +19,39 @@ export class AttributeValueStringComponent implements OnInit {
   @Output() sendEventToParent = new EventEmitter();
 
   value: string;
-  constructor(private dialog: MatDialog) {}
+  multiline = false;
+
+  constructor(private dialog: MatDialog, private translate: PerunTranslateService) {}
 
   ngOnInit(): void {
     this.value = this.attribute.value as string;
     if (!this.readonly) {
       this.readonly = isVirtualAttribute(this.attribute);
     }
+    this.checkMultilineValue();
   }
 
   _sendEventToParent(): void {
+    this.attribute.value = this.value;
     this.sendEventToParent.emit();
+  }
+
+  checkMultilineValue(): void {
+    this.multiline = false;
+    if (this.attribute.value && (this.attribute.value as string).includes('\n')) {
+      this.multiline = true;
+      const values = (this.attribute.value as string).split('\n');
+      this.value =
+        `${values[0]} ... (${values.length - 1} ` +
+        (values.length > 2
+          ? this.translate.instant(
+              'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTE_VALUE_STRING.EXTRA_LINES_PLURAL'
+            )
+          : this.translate.instant(
+              'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTE_VALUE_STRING.EXTRA_LINES_SINGLE'
+            )) +
+        ')';
+    }
   }
 
   showValue(value: string, title: string): void {
@@ -36,5 +62,20 @@ export class AttributeValueStringComponent implements OnInit {
       title: title,
     };
     this.dialog.open(ShowValueDialogComponent, config);
+  }
+
+  edit(): void {
+    const config = getDefaultDialogConfig();
+    config.width = '600px';
+    config.data = { attribute: this.attribute };
+
+    const dialogRef = this.dialog.open(AttributeValueListEditDialogComponent, config);
+    dialogRef.afterClosed().subscribe((success) => {
+      if (success) {
+        this.value = this.attribute.value as string;
+        this.checkMultilineValue();
+        this.sendEventToParent.emit();
+      }
+    });
   }
 }

--- a/libs/perun/dialogs/src/lib/attribute-value-list-edit-dialog/attribute-value-list-edit-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/attribute-value-list-edit-dialog/attribute-value-list-edit-dialog.component.html
@@ -3,7 +3,7 @@
 </h5>
 <div class="dialog-container" mat-dialog-content>
   <mat-form-field>
-    <textarea [(ngModel)]="attributeValue" cdkTextareaAutosize="true" matInput></textarea>
+    <textarea [(ngModel)]="attributeValue" matInput class="white-space-pre" rows="5"></textarea>
   </mat-form-field>
 </div>
 

--- a/libs/perun/dialogs/src/lib/attribute-value-list-edit-dialog/attribute-value-list-edit-dialog.component.scss
+++ b/libs/perun/dialogs/src/lib/attribute-value-list-edit-dialog/attribute-value-list-edit-dialog.component.scss
@@ -1,0 +1,3 @@
+.white-space-pre {
+  white-space: pre;
+}

--- a/libs/perun/dialogs/src/lib/attribute-value-list-edit-dialog/attribute-value-list-edit-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/attribute-value-list-edit-dialog/attribute-value-list-edit-dialog.component.ts
@@ -21,7 +21,11 @@ export class AttributeValueListEditDialogComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.attributeValue = (this.data.attribute.value as string[])[this.data.index];
+    if (this.data.index === undefined) {
+      this.attributeValue = this.data.attribute.value as string;
+    } else {
+      this.attributeValue = (this.data.attribute.value as string[])[this.data.index];
+    }
   }
 
   cancel(): void {
@@ -29,7 +33,11 @@ export class AttributeValueListEditDialogComponent implements OnInit {
   }
 
   submit(): void {
-    (this.data.attribute.value as string[])[this.data.index] = this.attributeValue;
+    if (this.data.index === undefined) {
+      this.data.attribute.value = this.attributeValue;
+    } else {
+      (this.data.attribute.value as string[])[this.data.index] = this.attributeValue;
+    }
     this.dialogRef.close(true);
   }
 }


### PR DESCRIPTION
* when changing/adding string attribute value, an edit icon is now present that opens a dialog with a text area that supports multi-line input
* when displaying a multi-line attribute value, show an indicator that it contains multiple lines (whole value is displayed upon clicking or opening the edit dialog)