### PR TITLE
fix: fixed a bug that caused properties of object in instanceConfig t…

### DIFF
--- a/libs/perun/services/src/lib/store.service.ts
+++ b/libs/perun/services/src/lib/store.service.ts
@@ -89,21 +89,14 @@ export class StoreService {
     value: T[K],
     defaultValue: T[K]
   ): T[K] {
-    if (
-      typeof value === 'object' &&
-      !Array.isArray(value) &&
-      value !== null &&
-      value !== undefined
-    ) {
-      for (const key of Object.keys(defaultValue)) {
-        defaultValue[key] = this.addMissingValuesToProperty(
-          value[key] as T[K],
-          defaultValue[key] as T[K]
-        );
-      }
-    } else if (value !== null && value !== undefined) {
-      return value;
+    if (value === null || value === undefined) {
+      return defaultValue;
     }
-    return defaultValue;
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      for (const key of Object.keys(defaultValue)) {
+        value[key] = this.addMissingValuesToProperty(value[key] as T[K], defaultValue[key] as T[K]);
+      }
+    }
+    return value;
   }
 }


### PR DESCRIPTION
…hat weren't in the same object in defaultConfig to not load at all

* this bug caused that if instanceConfig contained password_help for a namespace that wasn't in the defaultConfig password_help, the password_help for that namespace wouldn't load (and would fall back to default).