### PR TITLE
fix: do not call checkPasswordStrength without authorization unless expli…

### DIFF
--- a/apps/password-reset/src/app/components/password-reset-form/password-reset-form.component.ts
+++ b/apps/password-reset/src/app/components/password-reset-form/password-reset-form.component.ts
@@ -57,7 +57,14 @@ export class PasswordResetFormComponent implements OnInit {
         passwordCtrl: [
           '',
           Validators.required,
-          [loginAsyncValidator(this.namespace, this.usersService, this.apiRequestConfiguration)],
+          [
+            loginAsyncValidator(
+              this.namespace,
+              this.usersService,
+              this.apiRequestConfiguration,
+              !this.authWithoutToken
+            ),
+          ],
         ],
         passwordAgainCtrl: ['', Validators.required],
       },

--- a/libs/perun/namespace-password-form/src/lib/perun-namespace-password-form.ts
+++ b/libs/perun/namespace-password-form/src/lib/perun-namespace-password-form.ts
@@ -25,6 +25,7 @@ export const loginAsyncValidator =
     namespace: string,
     usersManager: UsersManagerService,
     apiRequestConfiguration: ApiRequestConfigurationService,
+    useNon = false,
     time = 500
   ) =>
   (input: UntypedFormControl): Observable<PasswordError | null> =>
@@ -39,7 +40,7 @@ export const loginAsyncValidator =
             password: input.value as string,
             namespace: namespace,
           },
-          true
+          useNon
         ) as Observable<PasswordError>;
       }),
       map(() => null),


### PR DESCRIPTION
…citly needed

* checkPasswordStrength in the password form component is no longer always called with 'non'
* this was an issue on certain instances that do not use an API calls only domain