### PR TITLE
feat(admin): user roles are split by source

### DIFF
--- a/apps/admin-gui/src/app/shared/components/roles-list/roles-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/roles-list/roles-page.component.html
@@ -1,9 +1,8 @@
-<h1 class="page-subtitle d-flex">{{'ROLES.TITLE'| translate}}</h1>
 <button
-  *ngIf="assignableRules.length !== 0"
+  *ngIf="assignableRules.length !== 0 && editable"
   mat-flat-button
   color="accent"
-  class="mb-3 mr-2"
+  class="mb-3 mr-2 mt-2"
   (click)="addRole()">
   {{'ROLES.ADD'| translate}}
 </button>
@@ -22,7 +21,7 @@
     </mat-expansion-panel-header>
     <ng-template matExpansionPanelContent>
       <span
-        *ngIf="role.roleName !== 'SELF' && role.roleName !== 'MEMBERSHIP' && role.roleName !== 'SPONSORSHIP'"
+        *ngIf="editable && role.roleName !== 'SELF' && role.roleName !== 'MEMBERSHIP' && role.roleName !== 'SPONSORSHIP'"
         matTooltip="{{'ROLES.REMOVE_DISABLED_TOOLTIP'| translate}}"
         matTooltipPosition="left"
         [matTooltipDisabled]="(selection.selected.length === 0 && selectedFacilities.selected.length === 0) || !disableRemove">
@@ -43,9 +42,11 @@
               {{('ROLES.' + role.roleName + '_VOS_' + entityType) | translate}}
             </div>
             <perun-web-apps-vos-list
-              [displayedColumns]="role.roleName === 'MEMBERSHIP' ? ['id', 'name', 'shortName'] : ['checkbox', 'id', 'name', 'shortName']"
+              [displayedColumns]="role.roleName === 'MEMBERSHIP' ? ['id', 'name', 'shortName'] : (editable ? ['checkbox', 'id', 'name', 'shortName'] : ['id', 'name', 'authzGroup', 'shortName'])"
               [vos]="vos | async"
-              [selection]="selection">
+              [selection]="selection"
+              [authzVoNames]="voNames"
+              [voWithAuthzGroupPairs]="_complementaryObjectsWithAuthzGroups?.get(role.roleName)?.get('vo')">
             </perun-web-apps-vos-list>
           </div>
           <div
@@ -55,9 +56,11 @@
               {{('ROLES.' + role.roleName + '_GROUPS_' + entityType) | translate}}
             </div>
             <perun-web-apps-groups-list
-              [displayedColumns]="role.roleName === 'MEMBERSHIP' ? ['id', 'vo', 'name', 'description'] : ['select', 'id', 'vo', 'name', 'description']"
+              [displayedColumns]="role.roleName === 'MEMBERSHIP' ? ['id', 'vo', 'name', 'description'] : (editable ? ['select', 'id', 'vo', 'name', 'description'] : ['id', 'vo', 'name', 'authzGroup', 'description'])"
               [groups]="groups | async"
-              [selection]="selection">
+              [selection]="selection"
+              [authzVoNames]="voNames"
+              [groupWithAuthzGroupPairs]="_complementaryObjectsWithAuthzGroups?.get(role.roleName)?.get('group')">
             </perun-web-apps-groups-list>
           </div>
           <div
@@ -68,9 +71,11 @@
             </div>
             <perun-web-apps-resources-list
               [resources]="resources | async"
-              [displayedColumns]="role.roleName === 'MEMBERSHIP' ? ['id', 'name', 'vo', 'facility', 'description'] : ['select', 'id', 'name', 'vo', 'facility', 'description']"
+              [displayedColumns]="role.roleName === 'MEMBERSHIP' ? ['id', 'name', 'vo', 'facility', 'description'] : (editable ? ['select', 'id', 'name', 'vo', 'facility', 'description'] : ['id', 'name', 'authzGroup', 'vo', 'facility', 'description'])"
               [routingVo]="true"
-              [selection]="selection">
+              [selection]="selection"
+              [authzVoNames]="voNames"
+              [resourceWithAuthzGroupPairs]="_complementaryObjectsWithAuthzGroups?.get(role.roleName)?.get('resource')">
             </perun-web-apps-resources-list>
           </div>
           <div
@@ -80,9 +85,11 @@
               {{('ROLES.' + role.roleName + '_FACILITIES_' + entityType) | translate}}
             </div>
             <perun-web-apps-facilities-list
-              [displayedColumns]="role.roleName === 'MEMBERSHIP' ? ['id', 'name', 'description'] : ['select', 'id', 'name', 'description']"
+              [displayedColumns]="role.roleName === 'MEMBERSHIP' ? ['id', 'name', 'description'] : (editable ? ['select', 'id', 'name', 'description'] : ['id', 'name', 'authzGroup', 'description'])"
               [facilities]="facilities | async"
-              [selection]="selectedFacilities">
+              [selection]="selectedFacilities"
+              [authzVoNames]="voNames"
+              [facilityWithAuthzGroupPairs]="_complementaryObjectsWithAuthzGroups?.get(role.roleName)?.get('facility')">
             </perun-web-apps-facilities-list>
           </div>
           <div *ngIf="role.roleName === 'SPONSORSHIP'" class="mb-3">

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-roles/user-roles.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-roles/user-roles.component.html
@@ -1,9 +1,39 @@
-<app-perun-web-apps-roles-page
-  [outerLoading]="this.outerLoading"
-  [roles]="this.roles"
-  [entityId]="this.userId"
-  [showDescription]="this.showDescription"
-  [entityType]="this.entityType"
-  (reload)="getData()"
-  (startLoading)="outerLoading = true;">
-</app-perun-web-apps-roles-page>
+<h1 class="page-subtitle d-flex">{{'ROLES.TITLE'| translate}}</h1>
+<mat-tab-group>
+  <mat-tab>
+    <ng-template matTabLabel>
+      {{'USER_DETAIL.DASHBOARD.DIRECT_ROLES' | translate}}
+    </ng-template>
+    <ng-template matTabContent>
+      <app-perun-web-apps-roles-page
+        [outerLoading]="this.outerLoading"
+        [roles]="this.roles"
+        [entityId]="this.userId"
+        [showDescription]="this.showDescription"
+        [entityType]="this.entityType"
+        [editable]="true"
+        (reload)="getData()"
+        (startLoading)="outerLoading = true;">
+      </app-perun-web-apps-roles-page>
+    </ng-template>
+  </mat-tab>
+
+  <mat-tab>
+    <ng-template matTabLabel>
+      {{'USER_DETAIL.DASHBOARD.AUTHORIZED_GROUP_BASED_ROLES' | translate}}
+    </ng-template>
+    <ng-template matTabContent>
+      <app-perun-web-apps-roles-page
+        [outerLoading]="this.outerLoading"
+        [roles]="this.indirectRoles"
+        [entityId]="this.userId"
+        [showDescription]="this.showDescription"
+        [entityType]="this.entityType"
+        [editable]="false"
+        [complementaryObjectsWithAuthzGroups]="this.rolesComplementaryObjectsWithAuthzGroups"
+        (reload)="getData()"
+        (startLoading)="outerLoading = true;">
+      </app-perun-web-apps-roles-page>
+    </ng-template>
+  </mat-tab>
+</mat-tab-group>

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2512,7 +2512,9 @@
       "SHOW_RECENTLY_VIEWED": "Show Recently viewed",
       "SHOW_ROLES": "Show roles",
       "MAIL_CHANGE_SUCCESS": "Preferred mail has been changed",
-      "ANONYMIZED": "User anonymized"
+      "ANONYMIZED": "User anonymized",
+      "DIRECT_ROLES": "User based",
+      "AUTHORIZED_GROUP_BASED_ROLES": "Group based"
     },
     "OVERVIEW": {
       "GENERAL_SETTINGS": "General settings"
@@ -2691,7 +2693,8 @@
         "TECHNICAL_OWNERS": "Technical owners",
         "DESTINATIONS": "Destinations",
         "HOSTS": "Hosts",
-        "NO_FACILITIES_WARNING": "No facilities found"
+        "NO_FACILITIES_WARNING": "No facilities found",
+        "AUTHZ_GROUP": "Authorized group"
       },
       "CONSENT_HUBS_LIST": {
         "ID": "Id",
@@ -2845,7 +2848,8 @@
           "CREATE_RELATION_AUTH_TOOLTIP": "You don't have permission to create relation with this group.",
           "SYNCHRONIZED_GROUP": "Group is filled with members from an external source",
           "INDIRECT_GROUP": "This group is assigned as a part of a groups tree.",
-          "MULTIPLE_ASSIGNMENTS": "This group is assigned manually and also as a part of a groups tree. You can remove only manual assignment."
+          "MULTIPLE_ASSIGNMENTS": "This group is assigned manually and also as a part of a groups tree. You can remove only manual assignment.",
+          "AUTHZ_GROUP": "Authorized group"
         },
         "GROUP_MENU": {
           "MOVE": "Move group",
@@ -2860,7 +2864,8 @@
         "VOS_LIST": {
           "ID": "Id",
           "NAME": "Name",
-          "SHORTNAME": "Short name"
+          "SHORTNAME": "Short name",
+          "AUTHZ_GROUP": "Authorized group"
         },
         "VO_SEARCH_SELECT": {
           "SELECT_VO": "Select organization",
@@ -2891,7 +2896,8 @@
           "TABLE_RESOURCE_DESCRIPTION": "Description",
           "TABLE_GROUP_RESOURCE_STATUS": "Status",
           "NO_RESOURCES_WARNING": "No resources assigned.",
-          "INDIRECT_RESOURCE": "This resource is assigned indirectly."
+          "INDIRECT_RESOURCE": "This resource is assigned indirectly.",
+          "AUTHZ_GROUP": "Authorized group"
         },
         "RESOURCE_SEARCH_SELECT": {
           "SELECT_RESOURCE": "Select resource",

--- a/libs/perun/components/src/lib/facilities-list/facilities-list.component.html
+++ b/libs/perun/components/src/lib/facilities-list/facilities-list.component.html
@@ -51,6 +51,16 @@
           {{facility.facility.name}}
         </td>
       </ng-container>
+      <ng-container matColumnDef="authzGroup">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>
+          {{'SHARED.COMPONENTS.FACILITIES_LIST.AUTHZ_GROUP' | translate}}
+        </th>
+        <td mat-cell *matCellDef="let facility">
+          {{ facilityWithAuthzGroupPairs.has(facility.facility.id)
+              ? authzVoNames.get(facilityWithAuthzGroupPairs.get(facility.facility.id)[0].voId) + ":" + facilityWithAuthzGroupPairs.get(facility.facility.id)[0].name
+              : "" }}
+        </td>
+      </ng-container>
       <ng-container matColumnDef="description">
         <th *matHeaderCellDef mat-header-cell>
           {{'SHARED.COMPONENTS.FACILITIES_LIST.DESCRIPTION' | translate}}

--- a/libs/perun/components/src/lib/facilities-list/facilities-list.component.ts
+++ b/libs/perun/components/src/lib/facilities-list/facilities-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-import { EnrichedFacility } from '@perun-web-apps/perun/openapi';
+import { EnrichedFacility, Group } from '@perun-web-apps/perun/openapi';
 import {
   customDataSourceFilterPredicate,
   customDataSourceSort,
@@ -21,6 +21,8 @@ import { TableWrapperComponent } from '@perun-web-apps/perun/utils';
 })
 export class FacilitiesListComponent implements OnChanges {
   @Input() facilities: EnrichedFacility[];
+  @Input() facilityWithAuthzGroupPairs: Map<number, Group[]>;
+  @Input() authzVoNames: Map<number, string>;
   @Input() recentIds: number[];
   @Input() filterValue: string;
   @Input() tableId: string;

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.html
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.html
@@ -90,6 +90,16 @@
           {{group.name}}
         </td>
       </ng-container>
+      <ng-container matColumnDef="authzGroup">
+        <th *matHeaderCellDef mat-header-cell mat-sort-header>
+          {{'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.AUTHZ_GROUP' | translate}}
+        </th>
+        <td *matCellDef="let group" mat-cell>
+          {{ groupWithAuthzGroupPairs.has(group.id)
+              ? authzVoNames.get(groupWithAuthzGroupPairs.get(group.id)[0].voId) + ":" + groupWithAuthzGroupPairs.get(group.id)[0].name
+              : ""}}
+        </td>
+      </ng-container>
       <ng-container matColumnDef="status">
         <th *matHeaderCellDef mat-header-cell mat-sort-header>
           {{'SHARED_LIB.PERUN.COMPONENTS.GROUPS_LIST.TABLE_GROUP_STATUS' | translate}}

--- a/libs/perun/components/src/lib/groups-list/groups-list.component.ts
+++ b/libs/perun/components/src/lib/groups-list/groups-list.component.ts
@@ -45,6 +45,8 @@ import { GroupUtilsService } from '@perun-web-apps/perun/services';
 export class GroupsListComponent {
   @Input() theme = 'group-theme';
   @Input() selection = new SelectionModel<GroupWithStatus>(true, []);
+  @Input() groupWithAuthzGroupPairs: Map<number, Group[]>;
+  @Input() authzVoNames: Map<number, string>;
   @Input() disableMembers: boolean;
   @Input() disableGroups: boolean;
   @Input() groupsToDisableCheckbox: Set<number> = new Set<number>();

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.html
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.html
@@ -76,6 +76,16 @@
           {{resource.name}}
         </td>
       </ng-container>
+      <ng-container matColumnDef="authzGroup">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>
+          {{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.AUTHZ_GROUP' | translate}}
+        </th>
+        <td mat-cell *matCellDef="let resource">
+          {{resourceWithAuthzGroupPairs.has(resource.id)
+              ? authzVoNames.get(resourceWithAuthzGroupPairs.get(resource.id)[0].voId) + ":" + resourceWithAuthzGroupPairs.get(resource.id)[0].name
+              : ""}}
+        </td>
+      </ng-container>
       <ng-container matColumnDef="vo">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>
           {{'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_VO_NAME' | translate}}

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.ts
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.ts
@@ -30,6 +30,8 @@ import { ResourceWithStatus } from '@perun-web-apps/perun/models';
 export class ResourcesListComponent implements OnInit, OnChanges {
   @ViewChild(TableWrapperComponent, { static: true }) child: TableWrapperComponent;
   @Input() resources: ResourceWithStatus[] = [];
+  @Input() resourceWithAuthzGroupPairs: Map<number, Group[]>;
+  @Input() authzVoNames: Map<number, string>;
   @Input() selection = new SelectionModel<ResourceWithStatus>(true, []);
   @Input() filterValue: string;
   @Input() disableRouting = false;

--- a/libs/perun/components/src/lib/vos-list/vos-list.component.html
+++ b/libs/perun/components/src/lib/vos-list/vos-list.component.html
@@ -60,6 +60,16 @@
         </th>
         <td *matCellDef="let vo" mat-cell>{{vo.name ?? vo.vo.name}}</td>
       </ng-container>
+      <ng-container matColumnDef="authzGroup">
+        <th *matHeaderCellDef mat-header-cell mat-sort-header>
+          {{'SHARED_LIB.PERUN.COMPONENTS.VOS_LIST.AUTHZ_GROUP' | translate}}
+        </th>
+        <td *matCellDef="let vo" mat-cell>
+          {{ voWithAuthzGroupPairs.has(vo.id ?? vo.vo.id)
+              ? authzVoNames.get(voWithAuthzGroupPairs.get(vo.id ?? vo.vo.id)[0].voId) + ":" + voWithAuthzGroupPairs.get(vo.id ?? vo.vo.id)[0].name
+              : ""}}
+        </td>
+      </ng-container>
       <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
       <tr
         *matRowDef="let vo; columns: displayedColumns;"

--- a/libs/perun/components/src/lib/vos-list/vos-list.component.ts
+++ b/libs/perun/components/src/lib/vos-list/vos-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-import { EnrichedVo, Vo } from '@perun-web-apps/perun/openapi';
+import { EnrichedVo, Group, Vo } from '@perun-web-apps/perun/openapi';
 import { SelectionModel } from '@angular/cdk/collections';
 import {
   customDataSourceFilterPredicate,
@@ -20,6 +20,8 @@ import { TableWrapperComponent } from '@perun-web-apps/perun/utils';
 })
 export class VosListComponent implements OnChanges {
   @Input() vos: Vo[] | EnrichedVo[] = [];
+  @Input() voWithAuthzGroupPairs: Map<number, Group[]>;
+  @Input() authzVoNames: Map<number, string>;
   @Input() recentIds: number[];
   @Input() filterValue: string;
   @Input() selection: SelectionModel<Vo>;

--- a/libs/perun/openapi/src/lib/api/authzResolver.service.ts
+++ b/libs/perun/openapi/src/lib/api/authzResolver.service.ts
@@ -1626,6 +1626,121 @@ export class AuthzResolverService {
   }
 
   /**
+   * Returns map of role names with map of corresponding complementary objects (perun beans) together with list of authorized groups where user is member.
+   * @param userId id of User
+   * @param useNon if set to true sends the request to the backend server as 'non' instead of the usual (oauth, krb...).
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getRoleComplementaryObjectsWithAuthorizedGroups(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'body',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<{ [key: string]: { [key: string]: { [key: string]: Array<Group> } } }>;
+  public getRoleComplementaryObjectsWithAuthorizedGroups(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'response',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<
+    HttpResponse<{ [key: string]: { [key: string]: { [key: string]: Array<Group> } } }>
+  >;
+  public getRoleComplementaryObjectsWithAuthorizedGroups(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'events',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpEvent<{ [key: string]: { [key: string]: { [key: string]: Array<Group> } } }>>;
+  public getRoleComplementaryObjectsWithAuthorizedGroups(
+    userId: number,
+    useNon: boolean = false,
+    observe: any = 'body',
+    reportProgress: boolean = false,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<any> {
+    if (userId === null || userId === undefined) {
+      throw new Error(
+        'Required parameter userId was null or undefined when calling getRoleComplementaryObjectsWithAuthorizedGroups.'
+      );
+    }
+
+    let localVarQueryParameters = new HttpParams({ encoder: this.encoder });
+    if (userId !== undefined && userId !== null) {
+      localVarQueryParameters = this.addToHttpParams(
+        localVarQueryParameters,
+        <any>userId,
+        'userId'
+      );
+    }
+
+    let localVarHeaders = this.defaultHeaders;
+
+    let localVarCredential: string | undefined;
+    // authentication (BasicAuth) required
+    localVarCredential = this.configuration.lookupCredential('BasicAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Basic ' + localVarCredential);
+    }
+
+    // authentication (BearerAuth) required
+    localVarCredential = this.configuration.lookupCredential('BearerAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+    }
+
+    let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+    if (localVarHttpHeaderAcceptSelected === undefined) {
+      // to determine the Accept header
+      const httpHeaderAccepts: string[] = ['application/json'];
+      localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    }
+    if (localVarHttpHeaderAcceptSelected !== undefined) {
+      localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+    }
+
+    let localVarHttpContext: HttpContext | undefined = options && options.context;
+    if (localVarHttpContext === undefined) {
+      localVarHttpContext = new HttpContext();
+    }
+
+    let responseType_: 'text' | 'json' | 'blob' = 'json';
+    if (localVarHttpHeaderAcceptSelected) {
+      if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+        responseType_ = 'text';
+      } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+        responseType_ = 'json';
+      } else {
+        responseType_ = 'blob';
+      }
+    }
+
+    let requestUrl = `${this.configuration.basePath}/json/authzResolver/getRoleComplementaryObjectsWithAuthorizedGroups`;
+    if (useNon) {
+      // replace the authentication part of url with 'non' authentication
+      let helperUrl = new URL(requestUrl);
+      let path = helperUrl.pathname.split('/');
+      path[1] = 'non';
+      helperUrl.pathname = path.join('/');
+      requestUrl = helperUrl.toString();
+    }
+    return this.httpClient.get<{
+      [key: string]: { [key: string]: { [key: string]: Array<Group> } };
+    }>(requestUrl, {
+      context: localVarHttpContext,
+      params: localVarQueryParameters,
+      responseType: <any>responseType_,
+      withCredentials: this.configuration.withCredentials,
+      headers: localVarHeaders,
+      observe: observe,
+      reportProgress: reportProgress,
+    });
+  }
+
+  /**
    * Get all SecurityTeams where the given user (principal if user not sent) has set one of the given roles or the given user is a member of an authorized group with such roles.
    * @param roles list of role names List&lt;String&gt;
    * @param user id of User
@@ -1736,6 +1851,117 @@ export class AuthzResolverService {
       requestUrl = helperUrl.toString();
     }
     return this.httpClient.get<Array<SecurityTeam>>(requestUrl, {
+      context: localVarHttpContext,
+      params: localVarQueryParameters,
+      responseType: <any>responseType_,
+      withCredentials: this.configuration.withCredentials,
+      headers: localVarHeaders,
+      observe: observe,
+      reportProgress: reportProgress,
+    });
+  }
+
+  /**
+   * Returns all roles except for those obtained from membership in authorized groups as an AuthzRoles object for a given user.
+   * @param userId id of User
+   * @param useNon if set to true sends the request to the backend server as 'non' instead of the usual (oauth, krb...).
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getUserDirectRoles(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'body',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<{ [key: string]: { [key: string]: Array<number> } }>;
+  public getUserDirectRoles(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'response',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpResponse<{ [key: string]: { [key: string]: Array<number> } }>>;
+  public getUserDirectRoles(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'events',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpEvent<{ [key: string]: { [key: string]: Array<number> } }>>;
+  public getUserDirectRoles(
+    userId: number,
+    useNon: boolean = false,
+    observe: any = 'body',
+    reportProgress: boolean = false,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<any> {
+    if (userId === null || userId === undefined) {
+      throw new Error(
+        'Required parameter userId was null or undefined when calling getUserDirectRoles.'
+      );
+    }
+
+    let localVarQueryParameters = new HttpParams({ encoder: this.encoder });
+    if (userId !== undefined && userId !== null) {
+      localVarQueryParameters = this.addToHttpParams(
+        localVarQueryParameters,
+        <any>userId,
+        'userId'
+      );
+    }
+
+    let localVarHeaders = this.defaultHeaders;
+
+    let localVarCredential: string | undefined;
+    // authentication (BasicAuth) required
+    localVarCredential = this.configuration.lookupCredential('BasicAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Basic ' + localVarCredential);
+    }
+
+    // authentication (BearerAuth) required
+    localVarCredential = this.configuration.lookupCredential('BearerAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+    }
+
+    let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+    if (localVarHttpHeaderAcceptSelected === undefined) {
+      // to determine the Accept header
+      const httpHeaderAccepts: string[] = ['application/json'];
+      localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    }
+    if (localVarHttpHeaderAcceptSelected !== undefined) {
+      localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+    }
+
+    let localVarHttpContext: HttpContext | undefined = options && options.context;
+    if (localVarHttpContext === undefined) {
+      localVarHttpContext = new HttpContext();
+    }
+
+    let responseType_: 'text' | 'json' | 'blob' = 'json';
+    if (localVarHttpHeaderAcceptSelected) {
+      if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+        responseType_ = 'text';
+      } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+        responseType_ = 'json';
+      } else {
+        responseType_ = 'blob';
+      }
+    }
+
+    let requestUrl = `${this.configuration.basePath}/json/authzResolver/getUserDirectRoles`;
+    if (useNon) {
+      // replace the authentication part of url with 'non' authentication
+      let helperUrl = new URL(requestUrl);
+      let path = helperUrl.pathname.split('/');
+      path[1] = 'non';
+      helperUrl.pathname = path.join('/');
+      requestUrl = helperUrl.toString();
+    }
+    return this.httpClient.get<{ [key: string]: { [key: string]: Array<number> } }>(requestUrl, {
       context: localVarHttpContext,
       params: localVarQueryParameters,
       responseType: <any>responseType_,
@@ -1943,6 +2169,117 @@ export class AuthzResolverService {
     }
 
     let requestUrl = `${this.configuration.basePath}/json/authzResolver/getUserRoles`;
+    if (useNon) {
+      // replace the authentication part of url with 'non' authentication
+      let helperUrl = new URL(requestUrl);
+      let path = helperUrl.pathname.split('/');
+      path[1] = 'non';
+      helperUrl.pathname = path.join('/');
+      requestUrl = helperUrl.toString();
+    }
+    return this.httpClient.get<{ [key: string]: { [key: string]: Array<number> } }>(requestUrl, {
+      context: localVarHttpContext,
+      params: localVarQueryParameters,
+      responseType: <any>responseType_,
+      withCredentials: this.configuration.withCredentials,
+      headers: localVarHeaders,
+      observe: observe,
+      reportProgress: reportProgress,
+    });
+  }
+
+  /**
+   * Returns roles resulting from membership in authorized groups as an AuthzRoles object for a given user.
+   * @param userId id of User
+   * @param useNon if set to true sends the request to the backend server as 'non' instead of the usual (oauth, krb...).
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getUserRolesObtainedFromAuthorizedGroupMemberships(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'body',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<{ [key: string]: { [key: string]: Array<number> } }>;
+  public getUserRolesObtainedFromAuthorizedGroupMemberships(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'response',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpResponse<{ [key: string]: { [key: string]: Array<number> } }>>;
+  public getUserRolesObtainedFromAuthorizedGroupMemberships(
+    userId: number,
+    useNon?: boolean,
+    observe?: 'events',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpEvent<{ [key: string]: { [key: string]: Array<number> } }>>;
+  public getUserRolesObtainedFromAuthorizedGroupMemberships(
+    userId: number,
+    useNon: boolean = false,
+    observe: any = 'body',
+    reportProgress: boolean = false,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<any> {
+    if (userId === null || userId === undefined) {
+      throw new Error(
+        'Required parameter userId was null or undefined when calling getUserRolesObtainedFromAuthorizedGroupMemberships.'
+      );
+    }
+
+    let localVarQueryParameters = new HttpParams({ encoder: this.encoder });
+    if (userId !== undefined && userId !== null) {
+      localVarQueryParameters = this.addToHttpParams(
+        localVarQueryParameters,
+        <any>userId,
+        'userId'
+      );
+    }
+
+    let localVarHeaders = this.defaultHeaders;
+
+    let localVarCredential: string | undefined;
+    // authentication (BasicAuth) required
+    localVarCredential = this.configuration.lookupCredential('BasicAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Basic ' + localVarCredential);
+    }
+
+    // authentication (BearerAuth) required
+    localVarCredential = this.configuration.lookupCredential('BearerAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+    }
+
+    let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+    if (localVarHttpHeaderAcceptSelected === undefined) {
+      // to determine the Accept header
+      const httpHeaderAccepts: string[] = ['application/json'];
+      localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    }
+    if (localVarHttpHeaderAcceptSelected !== undefined) {
+      localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+    }
+
+    let localVarHttpContext: HttpContext | undefined = options && options.context;
+    if (localVarHttpContext === undefined) {
+      localVarHttpContext = new HttpContext();
+    }
+
+    let responseType_: 'text' | 'json' | 'blob' = 'json';
+    if (localVarHttpHeaderAcceptSelected) {
+      if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+        responseType_ = 'text';
+      } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+        responseType_ = 'json';
+      } else {
+        responseType_ = 'blob';
+      }
+    }
+
+    let requestUrl = `${this.configuration.basePath}/json/authzResolver/getUserRolesObtainedFromAuthorizedGroupMemberships`;
     if (useNon) {
       // replace the authentication part of url with 'non' authentication
       let helperUrl = new URL(requestUrl);

--- a/libs/perun/services/src/lib/role.service.ts
+++ b/libs/perun/services/src/lib/role.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Group } from '@perun-web-apps/perun/openapi';
 
 @Injectable({
   providedIn: 'root',
@@ -20,5 +21,38 @@ export class RoleService {
       preparedRoles.set(roleName, innerMap);
     });
     return preparedRoles;
+  }
+
+  prepareComplementaryObjects(
+    roleNames: string[],
+    roleComplementaryObjectsWithAuthzGroups: {
+      [p: string]: { [p: string]: { [p: string]: Group[] } };
+    }
+  ): Map<string, Map<string, Map<number, Group[]>>> {
+    const mappedResult = new Map<string, Map<string, Map<number, Group[]>>>();
+    roleNames.forEach((roleName) => {
+      const beanNamesMap = new Map<string, Map<number, Group[]>>();
+      const beanNames = Object.keys(roleComplementaryObjectsWithAuthzGroups[roleName]);
+
+      beanNames.forEach((beanName) => {
+        const beanIdToGroupsMap = new Map<number, Group[]>();
+
+        // prepare all complementary objects IDs
+        const compObjectsIds = Object.keys(
+          roleComplementaryObjectsWithAuthzGroups[roleName][beanName]
+        ).map((value) => Number(value));
+
+        compObjectsIds.forEach((id) => {
+          beanIdToGroupsMap.set(
+            id,
+            roleComplementaryObjectsWithAuthzGroups[roleName][beanName][id]
+          );
+        });
+        beanNamesMap.set(beanName, beanIdToGroupsMap);
+      });
+
+      mappedResult.set(roleName, beanNamesMap);
+    });
+    return mappedResult;
   }
 }


### PR DESCRIPTION
* user-detail page splits his roles by source (directly assigned or obtained as a member of authorized group)
* tabs added to change what source we want to see
* authorized-group-based roles cannot be managed, only viewed