### PR TITLE
feat: improve loading of dialogs and tables

### DIFF
--- a/apps/admin-gui/src/app/admin/admin.module.ts
+++ b/apps/admin-gui/src/app/admin/admin.module.ts
@@ -15,6 +15,7 @@ import { UserDestinationGraphComponent } from './pages/admin-page/admin-visualiz
 import { AdminUsersComponent } from './pages/admin-page/admin-users/admin-users.component';
 import { AdminUserDetailPageComponent } from './pages/admin-user-detail-page/admin-user-detail-page.component';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { AdminExtSourcesComponent } from './pages/admin-page/admin-ext-sources/admin-ext-sources.component';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { PerunPipesModule } from '@perun-web-apps/perun/pipes';
@@ -59,6 +60,7 @@ import { AdminSearcherComponent } from './pages/admin-page/admin-searcher/admin-
     AdminRoutingModule,
     SharedModule,
     UiAlertsModule,
+    UiLoadersModule,
     PerunSharedComponentsModule,
     PerunPipesModule,
     UsersModule,

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-attributes/admin-attributes.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-attributes/admin-attributes.component.html
@@ -31,14 +31,18 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'ADMIN.ATTRIBUTES.SEARCH'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-attr-def-list
-    *ngIf="!loading"
-    (refreshEvent)="refreshTable()"
-    [definitions]="attrDefinitions"
-    [disableRouting]="!authResolver.isPerunAdminOrObserver()"
-    [filterValue]="filterValue"
-    [selection]="selected"
-    [tableId]="tableId">
-  </app-attr-def-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-attr-def-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      (refreshEvent)="refreshTable()"
+      [definitions]="attrDefinitions"
+      [disableRouting]="!authResolver.isPerunAdminOrObserver()"
+      [filterValue]="filterValue"
+      [selection]="selected"
+      [tableId]="tableId">
+    </app-attr-def-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-audit-log/admin-audit-log.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-audit-log/admin-audit-log.component.html
@@ -8,8 +8,15 @@
       (selectClosed)="refreshOnClosed()"></perun-web-apps-audit-log-search-select>
   </div>
 
-  <app-audit-messages-list
-    [refresh]="refresh"
-    [tableId]="tableId"
-    [selectedEvents]="selectedEvents"></app-audit-messages-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-audit-messages-list
+      *perunWebAppsLoader="loading$ | async; indicator: spinner"
+      (loading$)="loading$ = $event"
+      [refresh]="refresh"
+      [tableId]="tableId"
+      [selectedEvents]="selectedEvents"></app-audit-messages-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-audit-log/admin-audit-log.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-audit-log/admin-audit-log.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { TABLE_AUDIT_MESSAGES } from '@perun-web-apps/config/table-config';
 import { AuditMessagesManagerService } from '@perun-web-apps/perun/openapi';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'app-admin-audit-log',
@@ -10,13 +11,18 @@ import { AuditMessagesManagerService } from '@perun-web-apps/perun/openapi';
 export class AdminAuditLogComponent implements OnInit {
   tableId = TABLE_AUDIT_MESSAGES;
   refresh = false;
+  loading$: Observable<boolean>;
 
   selectedEvents: string[] = [];
   eventOptions: string[] = [];
 
-  constructor(private auditMessagesManagerService: AuditMessagesManagerService) {}
+  constructor(
+    private auditMessagesManagerService: AuditMessagesManagerService,
+    private cd: ChangeDetectorRef
+  ) {}
 
   ngOnInit(): void {
+    this.loading$ = of(true);
     this.auditMessagesManagerService.findAllPossibleEvents().subscribe((res) => {
       this.eventOptions = res.sort();
     });
@@ -24,6 +30,7 @@ export class AdminAuditLogComponent implements OnInit {
 
   refreshTable(): void {
     this.refresh = !this.refresh;
+    this.cd.detectChanges();
   }
 
   toggleEvent(events: string[]): void {
@@ -33,5 +40,6 @@ export class AdminAuditLogComponent implements OnInit {
 
   refreshOnClosed(): void {
     this.selectedEvents = [...this.selectedEvents];
+    this.cd.detectChanges();
   }
 }

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-consent-hubs/admin-consent-hubs.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-consent-hubs/admin-consent-hubs.component.html
@@ -22,12 +22,16 @@
     (filter)="applyFilter($event)">
   </perun-web-apps-immediate-filter>
 
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <app-perun-web-apps-consent-hubs-list
-    *ngIf="!loading"
-    [consentHubs]="consentHubs"
-    [selection]="selection"
-    [filterValue]="filterValue"
-    [tableId]="tableId">
-  </app-perun-web-apps-consent-hubs-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-perun-web-apps-consent-hubs-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [consentHubs]="consentHubs"
+      [selection]="selection"
+      [filterValue]="filterValue"
+      [tableId]="tableId">
+    </app-perun-web-apps-consent-hubs-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-ext-sources/admin-ext-sources.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-ext-sources/admin-ext-sources.component.html
@@ -5,13 +5,17 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'ADMIN.EXT_SOURCES.SEARCH'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
 
-  <app-ext-sources-list
-    *ngIf="!loading"
-    [extSources]="extSources"
-    [filterValue]="filterValue"
-    [displayedColumns]="['id', 'name', 'type']"
-    [tableId]="tableId">
-  </app-ext-sources-list>
+  <div class="position-relative">
+    <app-ext-sources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [extSources]="extSources"
+      [filterValue]="filterValue"
+      [displayedColumns]="['id', 'name', 'type']"
+      [tableId]="tableId">
+    </app-ext-sources-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-owners/admin-owners.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-owners/admin-owners.component.html
@@ -23,11 +23,15 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'ADMIN.OWNERS.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-owners-list
-    [selection]="selected"
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [owners]="owners"
-    [tableId]="tableId"></perun-web-apps-owners-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-owners-list
+      [selection]="selected"
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [filterValue]="filterValue"
+      [owners]="owners"
+      [tableId]="tableId"></perun-web-apps-owners-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/admin-services.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/admin-services.component.html
@@ -24,12 +24,16 @@
     (filter)="applyFilter($event)"
     [placeholder]="'ADMIN.SERVICES.FILTER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <app-services-list
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [selection]="selection"
-    [services]="services"
-    [tableId]="tableId">
-  </app-services-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-services-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [filterValue]="filterValue"
+      [selection]="selection"
+      [services]="services"
+      [tableId]="tableId">
+    </app-services-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-destinations/service-destinations.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-destinations/service-destinations.component.html
@@ -32,13 +32,17 @@
     (filter)="applyFilter($event)"
     [placeholder]="'SERVICE_DETAIL.DESTINATIONS.FILTER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-perun-web-apps-destination-list
-    *ngIf="!loading"
-    [destinations]="destinations"
-    [filterValue]="filterValue"
-    [selection]="selection"
-    [displayedColumns]="['select', 'destinationId', 'facility', 'destination', 'type', 'status', 'propagationType']"
-    [tableId]="tableId">
-  </app-perun-web-apps-destination-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-perun-web-apps-destination-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [destinations]="destinations"
+      [filterValue]="filterValue"
+      [selection]="selection"
+      [displayedColumns]="['select', 'destinationId', 'facility', 'destination', 'type', 'status', 'propagationType']"
+      [tableId]="tableId">
+    </app-perun-web-apps-destination-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-required-attributes/service-required-attributes.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-services/service-detail-page/service-required-attributes/service-required-attributes.component.html
@@ -22,14 +22,18 @@
     (filter)="applyFilter($event)"
     [placeholder]="'SERVICE_DETAIL.REQUIRED_ATTRIBUTES.FILTER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-attr-def-list
-    *ngIf="!loading"
-    (refreshEvent)="refreshTable()"
-    [definitions]="attrDefinitions"
-    [filterValue]="filterValue"
-    [selection]="selection"
-    [disableRouting]="!authResolver.isPerunAdmin()"
-    [tableId]="tableId">
-  </app-attr-def-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-attr-def-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      (refreshEvent)="refreshTable()"
+      [definitions]="attrDefinitions"
+      [filterValue]="filterValue"
+      [selection]="selection"
+      [disableRouting]="!authResolver.isPerunAdmin()"
+      [tableId]="tableId">
+    </app-attr-def-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-users/admin-users.component.html
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-users/admin-users.component.html
@@ -9,12 +9,19 @@
 <mat-checkbox (change)="findUsersWithoutVO()" [checked]="usersWithoutVo" color="primary">
   {{'ADMIN.USERS.USERS_WITHOUT_VO' | translate}}
 </mat-checkbox>
-<perun-web-apps-users-dynamic-list
-  [disableRouting]="false"
-  [searchString]="searchString"
-  [attrNames]="attributes"
-  [displayedColumns]="['user', 'id', 'name', 'email', 'logins', 'organization']"
-  [tableId]="tableId"
-  [withoutVo]="usersWithoutVo"
-  [updateTable]="update">
-</perun-web-apps-users-dynamic-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-users-dynamic-list
+    *perunWebAppsLoader="loading$ | async; indicator: spinner"
+    (loading$)="loading$ = $event"
+    [disableRouting]="false"
+    [searchString]="searchString"
+    [attrNames]="attributes"
+    [displayedColumns]="['user', 'id', 'name', 'email', 'logins', 'organization']"
+    [tableId]="tableId"
+    [withoutVo]="usersWithoutVo"
+    [updateTable]="update">
+  </perun-web-apps-users-dynamic-list>
+</div>

--- a/apps/admin-gui/src/app/admin/pages/admin-page/admin-users/admin-users.component.ts
+++ b/apps/admin-gui/src/app/admin/pages/admin-page/admin-users/admin-users.component.ts
@@ -1,7 +1,8 @@
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, HostBinding, OnInit } from '@angular/core';
 import { TABLE_ADMIN_USER_SELECT } from '@perun-web-apps/config/table-config';
 import { Urns } from '@perun-web-apps/perun/urns';
 import { StoreService } from '@perun-web-apps/perun/services';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'app-admin-users',
@@ -13,28 +14,33 @@ export class AdminUsersComponent implements OnInit {
 
   @HostBinding('class.router-component') true;
 
+  loading$: Observable<boolean>;
   usersWithoutVo = false;
   searchString: string;
   tableId = TABLE_ADMIN_USER_SELECT;
   attributes: string[] = [];
   update = false;
 
-  constructor(private storeService: StoreService) {}
+  constructor(private storeService: StoreService, private cd: ChangeDetectorRef) {}
 
   ngOnInit(): void {
+    this.loading$ = of(true);
     this.attributes = [Urns.USER_DEF_ORGANIZATION, Urns.USER_DEF_PREFERRED_MAIL];
     this.attributes = this.attributes.concat(this.storeService.getLoginAttributeNames());
   }
 
   onSearchByString(searchString: string): void {
     this.searchString = searchString;
+    this.cd.detectChanges();
   }
 
   findUsersWithoutVO(): void {
     this.usersWithoutVo = !this.usersWithoutVo;
+    this.cd.detectChanges();
   }
 
   refresh(): void {
     this.update = !this.update;
+    this.cd.detectChanges();
   }
 }

--- a/apps/admin-gui/src/app/facilities/facilities.module.ts
+++ b/apps/admin-gui/src/app/facilities/facilities.module.ts
@@ -17,6 +17,7 @@ import { ResourceSettingsComponent } from './pages/resource-detail-page/resource
 import { ResourceSettingsOverviewComponent } from './pages/resource-detail-page/resource-settings/resource-settings-overview/resource-settings-overview.component';
 import { ResourceAttributesComponent } from './pages/resource-detail-page/resource-attributes/resource-attributes.component';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { ResourceGroupsComponent } from './pages/resource-detail-page/resource-groups/resource-groups.component';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { FacilityServiceConfigComponent } from './pages/facility-detail-page/facility-service-config/facility-service-config.component';
@@ -87,6 +88,7 @@ import { ResourceSettingsBansComponent } from './pages/resource-detail-page/reso
     FacilitiesRoutingModule,
     SharedModule,
     UiAlertsModule,
+    UiLoadersModule,
     PerunSharedComponentsModule,
     PerunPipesModule,
     UsersModule,

--- a/apps/admin-gui/src/app/facilities/pages/facility-configuration-page/facility-configuration-page.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-configuration-page/facility-configuration-page.component.html
@@ -90,13 +90,17 @@
             class="service-search-select">
           </perun-web-apps-service-search-select>
         </div>
-        <mat-spinner *ngIf="processing" class="ml-auto mr-auto"></mat-spinner>
-        <perun-web-apps-attributes-list
-          *ngIf="!processing"
-          [emptyListText]="'FACILITY_CONFIGURATION.EMPTY_REQ_ATT'"
-          [attributes]="filteredAttributes"
-          [selection]="attSelection">
-        </perun-web-apps-attributes-list>
+        <ng-template #spinner>
+          <perun-web-apps-loading-table></perun-web-apps-loading-table>
+        </ng-template>
+        <div class="position-relative">
+          <perun-web-apps-attributes-list
+            *perunWebAppsLoader="processing; indicator: spinner"
+            [emptyListText]="'FACILITY_CONFIGURATION.EMPTY_REQ_ATT'"
+            [attributes]="filteredAttributes"
+            [selection]="attSelection">
+          </perun-web-apps-attributes-list>
+        </div>
       </ng-template>
     </mat-step>
     <mat-step
@@ -141,12 +145,16 @@
               </mat-panel-title>
             </mat-expansion-panel-header>
             <h1 class="page-subtitle">{{'FACILITY_CONFIGURATION.OWNERS' | translate}}</h1>
-            <mat-spinner *ngIf="processing" class="ml-auto mr-auto"></mat-spinner>
-            <perun-web-apps-owners-list
-              *ngIf="!processing"
-              [displayedColumns]="['id', 'name', 'contact', 'type']"
-              [owners]="owners">
-            </perun-web-apps-owners-list>
+            <ng-template #spinner>
+              <perun-web-apps-loading-table></perun-web-apps-loading-table>
+            </ng-template>
+            <div class="position-relative">
+              <perun-web-apps-owners-list
+                *perunWebAppsLoader="processing; indicator: spinner"
+                [displayedColumns]="['id', 'name', 'contact', 'type']"
+                [owners]="owners">
+              </perun-web-apps-owners-list>
+            </div>
           </mat-expansion-panel>
           <mat-expansion-panel [disabled]="hosts.length === 0">
             <mat-expansion-panel-header [class.cursor-default]="hosts.length === 0">
@@ -156,13 +164,17 @@
               </mat-panel-title>
             </mat-expansion-panel-header>
             <h1 class="page-subtitle">{{'FACILITY_CONFIGURATION.HOSTS' | translate}}</h1>
-            <mat-spinner *ngIf="processing" class="ml-auto mr-auto"></mat-spinner>
-            <app-hosts-list
-              *ngIf="!processing"
-              [disableRouting]="true"
-              [displayedColumns]="['id', 'name']"
-              [hosts]="hosts">
-            </app-hosts-list>
+            <ng-template #spinner>
+              <perun-web-apps-loading-table></perun-web-apps-loading-table>
+            </ng-template>
+            <div class="position-relative">
+              <app-hosts-list
+                *perunWebAppsLoader="processing; indicator: spinner"
+                [disableRouting]="true"
+                [displayedColumns]="['id', 'name']"
+                [hosts]="hosts">
+              </app-hosts-list>
+            </div>
           </mat-expansion-panel>
           <mat-expansion-panel [disabled]="selection.selected.length === 0">
             <mat-expansion-panel-header [class.cursor-default]="selection.selected.length === 0">
@@ -205,12 +217,17 @@
               </mat-panel-title>
             </mat-expansion-panel-header>
             <h1 class="page-subtitle">{{'FACILITY_CONFIGURATION.DESTINATION' | translate}}</h1>
-            <mat-spinner *ngIf="processing" class="ml-auto mr-auto"></mat-spinner>
-            <app-perun-web-apps-destination-list
-              [destinations]="destinations"
-              [displayedColumns]="['destinationId', 'service', 'warn', 'destination', 'type', 'propagationType']"
-              [services]="serviceIds">
-            </app-perun-web-apps-destination-list>
+            <ng-template #spinner>
+              <perun-web-apps-loading-table></perun-web-apps-loading-table>
+            </ng-template>
+            <div class="position-relative">
+              <app-perun-web-apps-destination-list
+                *perunWebAppsLoader="processing; indicator: spinner"
+                [destinations]="destinations"
+                [displayedColumns]="['destinationId', 'service', 'warn', 'destination', 'type', 'propagationType']"
+                [services]="serviceIds">
+              </app-perun-web-apps-destination-list>
+            </div>
           </mat-expansion-panel>
           <mat-expansion-panel>
             <mat-expansion-panel-header>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-groups/facility-allowed-groups.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-groups/facility-allowed-groups.component.html
@@ -14,14 +14,18 @@
     (filter)="applyFilter($event)"
     [placeholder]="'FACILITY_DETAIL.ALLOWED_GROUPS.FILTER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-groups-list
-    *ngIf="!loading"
-    [displayedColumns]="['id', 'vo', 'name', 'description']"
-    [groups]="groupsToShow"
-    [disableMembers]="false"
-    [filter]="filterValue"
-    [groupsToDisableRouting]="groupsWithoutRouteAuth"
-    [tableId]="tableId">
-  </perun-web-apps-groups-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-groups-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [displayedColumns]="['id', 'vo', 'name', 'description']"
+      [groups]="groupsToShow"
+      [disableMembers]="false"
+      [filter]="filterValue"
+      [groupsToDisableRouting]="groupsWithoutRouteAuth"
+      [tableId]="tableId">
+    </perun-web-apps-groups-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-users/facility-allowed-users.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-users/facility-allowed-users.component.html
@@ -60,20 +60,26 @@
       </mat-form-field>
     </div>
   </div>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-users-dynamic-list
-    *ngIf="!loading"
-    [attrNames]="attributes"
-    [disableRouting]="!routeAuth"
-    [displayedColumns]="['id', 'name', 'email', 'logins', 'organization']"
-    [onlyAllowed]="allowed"
-    [facilityId]="facility.id"
-    [searchString]="filterValue"
-    [resourceId]="selectedResource.id === -1 ? null : selectedResource.id"
-    [serviceId]="selectedService.id === -1 ? null : selectedService.id"
-    [tableId]="tableId"
-    [voId]="selectedVo.id === -1 ? null : selectedVo.id"
-    [consentStatuses]="selectedConsentStatuses"
-    [includeConsents]="globalForceConsents && facilityForceConsents">
-  </perun-web-apps-users-dynamic-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-users-dynamic-list
+      *perunWebAppsLoader="loading$ | async; indicator: spinner"
+      (loading$)="loading$ = $event"
+      [attrNames]="attributes"
+      [disableRouting]="!routeAuth"
+      [displayedColumns]="['id', 'name', 'email', 'logins', 'organization']"
+      [onlyAllowed]="allowed"
+      [facilityId]="facility.id"
+      [searchString]="filterValue"
+      [resourceId]="selectedResource.id === -1 ? null : selectedResource.id"
+      [serviceId]="selectedService.id === -1 ? null : selectedService.id"
+      [tableId]="tableId"
+      [voId]="selectedVo.id === -1 ? null : selectedVo.id"
+      [consentStatuses]="selectedConsentStatuses"
+      [includeConsents]="globalForceConsents && facilityForceConsents"
+      [updateTable]="update">
+    </perun-web-apps-users-dynamic-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-hosts/facility-hosts-detail/facility-hosts-detail.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-hosts/facility-hosts-detail/facility-hosts-detail.component.html
@@ -21,12 +21,16 @@
     mat-flat-button>
     {{'FACILITY_DETAIL.HOSTS.HOSTS_DETAIL.REMOVE' | translate}}
   </button>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-attributes-list
-    [selection]="selected"
-    #list
-    *ngIf="!loading"
-    [attributes]="attributes"
-    [tableId]="tableId">
-  </perun-web-apps-attributes-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-attributes-list
+      [selection]="selected"
+      #list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [attributes]="attributes"
+      [tableId]="tableId">
+    </perun-web-apps-attributes-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-hosts/facility-hosts.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-hosts/facility-hosts.component.html
@@ -21,15 +21,19 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'FACILITY_DETAIL.HOSTS.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-hosts-list
-    [disableRouting]="!routeAuth || disableRouting"
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [hosts]="hosts"
-    [selection]="selected"
-    [displayedColumns]="displayedColumns"
-    [facilityId]="facility.id"
-    [tableId]="tableId">
-  </app-hosts-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-hosts-list
+      [disableRouting]="!routeAuth || disableRouting"
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [filterValue]="filterValue"
+      [hosts]="hosts"
+      [selection]="selected"
+      [displayedColumns]="displayedColumns"
+      [facilityId]="facility.id"
+      [tableId]="tableId">
+    </app-hosts-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-resources/facility-resources.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-resources/facility-resources.component.html
@@ -33,14 +33,18 @@
       class="filter-field">
     </perun-web-apps-immediate-filter>
   </div>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <perun-web-apps-resources-list
-    [tableId]="tableId"
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [resources]="resources"
-    [selection]="selected"
-    [disableRouting]="!routeAuth"
-    [displayedColumns]="displayedColumns">
-  </perun-web-apps-resources-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-resources-list
+      [tableId]="tableId"
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [filterValue]="filterValue"
+      [resources]="resources"
+      [selection]="selected"
+      [disableRouting]="!routeAuth"
+      [displayedColumns]="displayedColumns">
+    </perun-web-apps-resources-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-security-teams/facility-security-teams.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-security-teams/facility-security-teams.component.html
@@ -20,13 +20,17 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'FACILITY_DETAIL.SECURITY_TEAMS.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-security-teams-list
-    [displayedColumns]="displayedColumns"
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [securityTeams]="securityTeams"
-    [selection]="selected"
-    [tableId]="tableId">
-  </app-security-teams-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-security-teams-list
+      [displayedColumns]="displayedColumns"
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [filterValue]="filterValue"
+      [securityTeams]="securityTeams"
+      [selection]="selected"
+      [tableId]="tableId">
+    </app-security-teams-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-service-status/facility-service-status.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-service-status/facility-service-status.component.html
@@ -4,7 +4,7 @@
   <button
     *ngIf="propagationAuth"
     (click)="forcePropagation()"
-    [disabled]="selected.selected.length === 0"
+    [disabled]="selected.selected.length === 0 || loading"
     class="mr-2"
     color="accent"
     mat-flat-button>
@@ -13,7 +13,7 @@
   <button
     *ngIf="allowAuth"
     (click)="allow()"
-    [disabled]="selected.selected.length === 0 || this.disableAllowButton"
+    [disabled]="selected.selected.length === 0 || this.disableAllowButton || loading"
     class="mr-2"
     color="accent"
     mat-flat-button>
@@ -24,14 +24,14 @@
     (click)="block()"
     class="mr-2"
     color="warn"
-    [disabled]="selected.selected.length === 0 || this.disableBlockButton"
+    [disabled]="selected.selected.length === 0 || this.disableBlockButton || loading"
     mat-flat-button>
     {{'FACILITY_DETAIL.SERVICES_STATUS.BLOCK' | translate}}
   </button>
   <button
     *ngIf="deleteAuth"
     mat-flat-button
-    [disabled]="disableRemoveButton"
+    [disabled]="disableRemoveButton || loading"
     [matMenuTriggerFor]="menu"
     [matTooltipDisabled]="!disableRemoveButton"
     class="mr-2 dropdown-toggle"
@@ -50,14 +50,18 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.SERVICES_STATUS_LIST.TABLE_SEARCH'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-services-status-list
-    [disableRouting]="!routeAuth"
-    (selectionChange)="selectionChanged()"
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [servicesStatus]="servicesStates"
-    [selection]="selected"
-    [tableId]="tableId">
-  </perun-web-apps-services-status-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-services-status-list
+      [disableRouting]="!routeAuth"
+      (selectionChange)="selectionChanged()"
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [filterValue]="filterValue"
+      [servicesStatus]="servicesStates"
+      [selection]="selected"
+      [tableId]="tableId">
+    </perun-web-apps-services-status-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-service-status/facility-task-results/facility-task-results.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-service-status/facility-task-results/facility-task-results.component.html
@@ -15,12 +15,16 @@
 <perun-web-apps-immediate-filter
   (filter)="applyFilter($event)"
   [placeholder]="'FACILITY_DETAIL.TASK_RESULTS.FILTER'"></perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<perun-web-apps-task-results-list
-  [tableId]="tableId"
-  *ngIf="!loading"
-  [displayedColumns]="displayedColumns"
-  [filterValue]="filterValue"
-  [selection]="selection"
-  [taskResults]="taskResults">
-</perun-web-apps-task-results-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-task-results-list
+    [tableId]="tableId"
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [displayedColumns]="displayedColumns"
+    [filterValue]="filterValue"
+    [selection]="selection"
+    [taskResults]="taskResults">
+  </perun-web-apps-task-results-list>
+</div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-services-destinations/facility-services-destinations.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-services-destinations/facility-services-destinations.component.html
@@ -42,14 +42,18 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'FACILITY_DETAIL.SERVICES_DESTINATIONS.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-perun-web-apps-destination-list
-    [filterValue]="filterValue"
-    *ngIf="!loading"
-    [selection]="selected"
-    [destinations]="destinations"
-    [services]="configServicesIds"
-    [displayedColumns]="displayedColumns"
-    [tableId]="tableId">
-  </app-perun-web-apps-destination-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-perun-web-apps-destination-list
+      [filterValue]="filterValue"
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [selection]="selected"
+      [destinations]="destinations"
+      [services]="configServicesIds"
+      [displayedColumns]="displayedColumns"
+      [tableId]="tableId">
+    </app-perun-web-apps-destination-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-services-destinations/facility-services-destinations.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-services-destinations/facility-services-destinations.component.ts
@@ -52,7 +52,7 @@ export class FacilityServicesDestinationsComponent implements OnInit {
   loading: boolean;
 
   facility: Facility;
-  destinations: RichDestination[];
+  destinations: RichDestination[] = [];
   selected = new SelectionModel<RichDestination>(true, []);
   filterValue = '';
   tableId = TABLE_FACILITY_SERVICES_DESTINATION_LIST;

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-settings/facility-settings-bans/facility-settings-bans.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-settings/facility-settings-bans/facility-settings-bans.component.html
@@ -32,7 +32,5 @@
   </perun-web-apps-ban-on-entity-list>
 </div>
 <ng-template #spinner>
-  <div class="spinner-container">
-    <mat-spinner></mat-spinner>
-  </div>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
 </ng-template>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-settings/facility-settings-bans/facility-settings-bans.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-settings/facility-settings-bans/facility-settings-bans.component.ts
@@ -107,6 +107,7 @@ export class FacilitySettingsBansComponent implements OnInit {
     const dialogRef = this.dialog.open(UniversalConfirmationItemsDialogComponent, config);
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
+        this.loading = true;
         this.facilityService
           .removeFacilityBanById(this.selection.selected[0].ban.id)
           .subscribe(() => {

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-settings/facility-settings-blacklist/facility-settings-blacklist.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-settings/facility-settings-blacklist/facility-settings-blacklist.component.html
@@ -4,12 +4,16 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'FACILITY_DETAIL.SETTINGS.BLACKLIST.FILTER' | translate"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-perun-web-apps-blacklist-list
-    [bansOnFacilitiesWithUsers]="bansOnFacilitiesWithUsers"
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [selection]="selected"
-    [tableId]="tableId">
-  </app-perun-web-apps-blacklist-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-perun-web-apps-blacklist-list
+      [bansOnFacilitiesWithUsers]="bansOnFacilitiesWithUsers"
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [filterValue]="filterValue"
+      [selection]="selected"
+      [tableId]="tableId">
+    </app-perun-web-apps-blacklist-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-settings/facility-settings-owners/facility-settings-owners.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-settings/facility-settings-owners/facility-settings-owners.component.html
@@ -20,12 +20,16 @@
 <perun-web-apps-immediate-filter
   (filter)="applyFilter($event)"
   [placeholder]="'VO_MANAGEMENT.FILTER_PLACEHOLDER'"></perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<perun-web-apps-owners-list
-  [displayedColumns]="displayedColumns"
-  *ngIf="!loading"
-  [filterValue]="filterValue"
-  [owners]="owners"
-  [selection]="selection"
-  [tableId]="tableId">
-</perun-web-apps-owners-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-owners-list
+    [displayedColumns]="displayedColumns"
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [filterValue]="filterValue"
+    [owners]="owners"
+    [selection]="selection"
+    [tableId]="tableId">
+  </perun-web-apps-owners-list>
+</div>

--- a/apps/admin-gui/src/app/facilities/pages/facility-select-page/facility-select-page.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-select-page/facility-select-page.component.html
@@ -32,13 +32,17 @@
     (filter)="applyFilter($event)"
     [placeholder]="'FACILITY_MANAGEMENT.FILTER_PLACEHOLDER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <perun-web-apps-facilities-list
-    [tableId]="tableId"
-    *ngIf="!loading"
-    [selection]="selection"
-    [filterValue]="filterValue"
-    [facilities]="facilities"
-    [recentIds]="recentIds">
-  </perun-web-apps-facilities-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-facilities-list
+      [tableId]="tableId"
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [selection]="selection"
+      [filterValue]="filterValue"
+      [facilities]="facilities"
+      [recentIds]="recentIds">
+    </perun-web-apps-facilities-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-assigned-members/resource-assigned-members.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-assigned-members/resource-assigned-members.component.html
@@ -4,13 +4,17 @@
   (filter)="applyFilter($event)"
   [placeholder]="'RESOURCE_DETAIL.ASSIGNED_MEMBERS.FILTER'">
 </perun-web-apps-debounce-filter>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
-<perun-web-apps-members-list
-  [displayedColumns]="['id', 'fullName']"
-  (updateTable)="refreshTable()"
-  *ngIf="!loading"
-  [disableRouting]="!routeAuth"
-  [filter]="filterValue"
-  [members]="members"
-  [tableId]="tableId">
-</perun-web-apps-members-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-members-list
+    [displayedColumns]="['id', 'fullName']"
+    (updateTable)="refreshTable()"
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [disableRouting]="!routeAuth"
+    [filter]="filterValue"
+    [members]="members"
+    [tableId]="tableId">
+  </perun-web-apps-members-list>
+</div>

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-assigned-members/resource-assigned-members.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-assigned-members/resource-assigned-members.component.ts
@@ -15,7 +15,7 @@ export class ResourceAssignedMembersComponent implements OnInit {
   tableId = TABLE_RESOURCE_MEMBERS;
 
   resource: Resource;
-  members: RichMember[];
+  members: RichMember[] = [];
 
   routeAuth: boolean;
 

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-assigned-services/resource-assigned-services.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-assigned-services/resource-assigned-services.component.html
@@ -21,13 +21,17 @@
   (filter)="applyFilter($event)"
   [placeholder]="'RESOURCE_DETAIL.ASSIGNED_SERVICES.FILTER_SERVICES'">
 </perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<app-services-list
-  *ngIf="!loading"
-  [disableRouting]="!serviceRoutingAuth"
-  [selection]="selected"
-  [displayedColumns]="displayedColumns"
-  [filterValue]="filterValue"
-  [services]="assignedServices"
-  [tableId]="tableId">
-</app-services-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <app-services-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [disableRouting]="!serviceRoutingAuth"
+    [selection]="selected"
+    [displayedColumns]="displayedColumns"
+    [filterValue]="filterValue"
+    [services]="assignedServices"
+    [tableId]="tableId">
+  </app-services-list>
+</div>

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-groups/resource-groups.component.html
@@ -26,18 +26,22 @@
   (filter)="applyFilter($event)"
   [placeholder]="'RESOURCE_DETAIL.ASSIGNED_GROUPS.FILTER_GROUPS'">
 </perun-web-apps-debounce-filter>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<perun-web-apps-groups-list
-  *ngIf="!loading"
-  [disableGroups]="true"
-  [groupsToDisableCheckbox]="groupsToDisable"
-  (refreshTable)="loadAllGroups()"
-  [disableMembers]="false"
-  [groups]="assignedGroups"
-  [disableRouting]="assignedGroups[0] ? !guiAuthResolver.isAuthorized('getGroupById_int_policy', [assignedGroups[0]]) : false"
-  [displayedColumns]="['select', 'id', 'indirectGroupAssigment', 'name', 'status', 'description']"
-  [filter]="filteredValue"
-  [resourceId]="resource.id"
-  [selection]="selected"
-  [tableId]="tableId">
-</perun-web-apps-groups-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-groups-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [disableGroups]="true"
+    [groupsToDisableCheckbox]="groupsToDisable"
+    (refreshTable)="loadAllGroups()"
+    [disableMembers]="false"
+    [groups]="assignedGroups"
+    [disableRouting]="assignedGroups[0] ? !guiAuthResolver.isAuthorized('getGroupById_int_policy', [assignedGroups[0]]) : false"
+    [displayedColumns]="['select', 'id', 'indirectGroupAssigment', 'name', 'status', 'description']"
+    [filter]="filteredValue"
+    [resourceId]="resource.id"
+    [selection]="selected"
+    [tableId]="tableId">
+  </perun-web-apps-groups-list>
+</div>

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-settings/resource-settings-bans/resource-settings-bans.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-settings/resource-settings-bans/resource-settings-bans.component.html
@@ -32,7 +32,5 @@
   </perun-web-apps-ban-on-entity-list>
 </div>
 <ng-template #spinner>
-  <div class="spinner-container">
-    <mat-spinner></mat-spinner>
-  </div>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
 </ng-template>

--- a/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-tags/resource-tags.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/resource-detail-page/resource-tags/resource-tags.component.html
@@ -32,14 +32,17 @@
   [placeholder]="'RESOURCE_DETAIL.TAGS.SEARCH'">
 </perun-web-apps-immediate-filter>
 
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-
-<app-resources-tags-list
-  *ngIf="!loading"
-  [displayedColumns]="displayedColumns"
-  [entity]="'resource'"
-  [resourceTags]="resourceTags"
-  [filterValue]="filterValue"
-  [selection]="selection"
-  [tableId]="tableId">
-</app-resources-tags-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <app-resources-tags-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [displayedColumns]="displayedColumns"
+    [entity]="'resource'"
+    [resourceTags]="resourceTags"
+    [filterValue]="filterValue"
+    [selection]="selection"
+    [tableId]="tableId">
+  </app-resources-tags-list>
+</div>

--- a/apps/admin-gui/src/app/shared/components/add-owner-dialog/add-owner-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/add-owner-dialog/add-owner-dialog.component.html
@@ -1,7 +1,9 @@
-<div class="admin-theme">
-  <h1 mat-dialog-title>{{"DIALOGS.ADD_OWNER.TITLE" | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="admin-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{"DIALOGS.ADD_OWNER.TITLE" | translate}}</h1>
     <div class="dialog-container" mat-dialog-content>
       <mat-form-field>
         <input

--- a/apps/admin-gui/src/app/shared/components/assign-groups-sponsored-members/assign-groups-sponsored-members-component.html
+++ b/apps/admin-gui/src/app/shared/components/assign-groups-sponsored-members/assign-groups-sponsored-members-component.html
@@ -1,64 +1,59 @@
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<div *ngIf="!loading">
-  <div class="mt-2">
-    <h5 class="mb-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GROUP_ASSIGMENT' | translate}}</h5>
-    <mat-radio-group
-      (change)="groupAssigmentChanged()"
-      [(ngModel)]="groupAssignment"
-      class="flex-container">
-      <mat-radio-button value="none" data-cy="no-assign-button">
-        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NO_ASSIGN' | translate}}
+<div class="mt-2">
+  <h5 class="mb-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GROUP_ASSIGMENT' | translate}}</h5>
+  <mat-radio-group
+    (change)="groupAssigmentChanged()"
+    [(ngModel)]="groupAssignment"
+    class="flex-container">
+    <mat-radio-button value="none" data-cy="no-assign-button">
+      {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NO_ASSIGN' | translate}}
+    </mat-radio-button>
+    <span
+      matTooltip="{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DISABLED_ASSIGN_NEW' | translate}}"
+      [matTooltipDisabled]="!manualMemberAddingBlocked && createGroupAuth"
+      matTooltipPosition="above">
+      <mat-radio-button [disabled]="manualMemberAddingBlocked || !createGroupAuth" value="new">
+        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ASSIGN_TO_NEW' | translate}}
       </mat-radio-button>
-      <span
-        matTooltip="{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DISABLED_ASSIGN_NEW' | translate}}"
-        [matTooltipDisabled]="!manualMemberAddingBlocked && createGroupAuth"
-        matTooltipPosition="above">
-        <mat-radio-button [disabled]="manualMemberAddingBlocked || !createGroupAuth" value="new">
-          {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ASSIGN_TO_NEW' | translate}}
-        </mat-radio-button>
-      </span>
-      <span
-        matTooltip="{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DISABLED_ASSIGN_EXISTING' | translate}}"
-        [matTooltipDisabled]="!manualMemberAddingBlocked && assignableGroups.length !== 0"
-        matTooltipPosition="above">
-        <mat-radio-button
-          [disabled]="manualMemberAddingBlocked || assignableGroups.length === 0"
-          value="existing">
-          {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ASSIGN_EXISTING' | translate}}
-        </mat-radio-button>
-      </span>
-    </mat-radio-group>
-  </div>
-  <div *ngIf="groupAssignment === 'none'">
-    <perun-web-apps-alert class="mt-4" alert_type="info"
-      >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DONT_ASSIGN_INFO' | translate}}</perun-web-apps-alert
-    >
-  </div>
-  <div *ngIf="groupAssignment === 'new'">
-    <h5 class="mt-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.CREATE_NEW_GROUP' | translate}}</h5>
-    <perun-web-apps-create-group-form
-      (asSubgroupChanged)="onAsSubgroupChange($event)"
-      (nameChanged)="onNameChange($event)"
-      (descriptionChanged)="onDescriptionChange($event)"
-      (parentGroupChanged)="onParentChange($event)"
-      [voGroups]="allVoGroups">
-    </perun-web-apps-create-group-form>
-  </div>
-  <div *ngIf="groupAssignment === 'existing'">
-    <h5 class="mt-4">
-      {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.SELECT_EXISTING_GROUPS' | translate}}
-    </h5>
-    <perun-web-apps-immediate-filter
-      (filter)="applyFilter($event)"
-      [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_SEARCH'">
-    </perun-web-apps-immediate-filter>
-    <perun-web-apps-groups-list
-      [groups]="assignableGroups"
-      [selection]="selection"
-      [disableRouting]="true"
-      [displayedColumns]="['select', 'id', 'name', 'description']"
-      [filter]="filterValue"
-      [tableId]="tableId">
-    </perun-web-apps-groups-list>
-  </div>
+    </span>
+    <span
+      matTooltip="{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DISABLED_ASSIGN_EXISTING' | translate}}"
+      [matTooltipDisabled]="!manualMemberAddingBlocked && assignableGroups.length !== 0"
+      matTooltipPosition="above">
+      <mat-radio-button
+        [disabled]="manualMemberAddingBlocked || assignableGroups.length === 0"
+        value="existing">
+        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ASSIGN_EXISTING' | translate}}
+      </mat-radio-button>
+    </span>
+  </mat-radio-group>
+</div>
+<div *ngIf="groupAssignment === 'none'">
+  <perun-web-apps-alert class="mt-4" alert_type="info"
+    >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DONT_ASSIGN_INFO' | translate}}</perun-web-apps-alert
+  >
+</div>
+<div *ngIf="groupAssignment === 'new'">
+  <h5 class="mt-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.CREATE_NEW_GROUP' | translate}}</h5>
+  <perun-web-apps-create-group-form
+    (asSubgroupChanged)="onAsSubgroupChange($event)"
+    (nameChanged)="onNameChange($event)"
+    (descriptionChanged)="onDescriptionChange($event)"
+    (parentGroupChanged)="onParentChange($event)"
+    [voGroups]="allVoGroups">
+  </perun-web-apps-create-group-form>
+</div>
+<div *ngIf="groupAssignment === 'existing'">
+  <h5 class="mt-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.SELECT_EXISTING_GROUPS' | translate}}</h5>
+  <perun-web-apps-immediate-filter
+    (filter)="applyFilter($event)"
+    [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_SEARCH'">
+  </perun-web-apps-immediate-filter>
+  <perun-web-apps-groups-list
+    [groups]="assignableGroups"
+    [selection]="selection"
+    [disableRouting]="true"
+    [displayedColumns]="['select', 'id', 'name', 'description']"
+    [filter]="filterValue"
+    [tableId]="tableId">
+  </perun-web-apps-groups-list>
 </div>

--- a/apps/admin-gui/src/app/shared/components/audit-messages-list/audit-messages-list.component.html
+++ b/apps/admin-gui/src/app/shared/components/audit-messages-list/audit-messages-list.component.html
@@ -1,15 +1,10 @@
-<div
-  [hidden]="this.dataSource.allObjectCount === 0 && (dataSource.loading$ | async) === false"
-  class="card mt-2">
+<div [hidden]="this.dataSource.allObjectCount === 0" class="card mt-2">
   <perun-web-apps-table-wrapper
     (exportDisplayedData)="exportDisplayedData($event)"
     [dataLength]="dataSource.allObjectCount"
     [pageSizeOptions]="pageSizeOptions"
     [tableId]="tableId"
     [allowExportAll]="false">
-    <div *ngIf="dataSource.loading$ | async" class="spinner-container">
-      <mat-spinner class="ml-auto mr-auto"></mat-spinner>
-    </div>
     <table
       [dataSource]="dataSource"
       class="w-100"
@@ -79,8 +74,6 @@
   </perun-web-apps-table-wrapper>
 </div>
 
-<perun-web-apps-alert
-  *ngIf="this.dataSource.allObjectCount === 0 && (dataSource.loading$ | async) === false"
-  alert_type="warn">
+<perun-web-apps-alert *ngIf="this.dataSource.allObjectCount === 0" alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_AUDIT_MESSAGES' | translate}}
 </perun-web-apps-alert>

--- a/apps/admin-gui/src/app/shared/components/audit-messages-list/audit-messages-list.component.ts
+++ b/apps/admin-gui/src/app/shared/components/audit-messages-list/audit-messages-list.component.ts
@@ -1,4 +1,13 @@
-import { AfterViewInit, Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { AuditMessage } from '@perun-web-apps/perun/openapi';
 import {
   downloadData,
@@ -16,7 +25,7 @@ import {
 } from '@perun-web-apps/perun/services';
 import { MatPaginatorIntl } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
-import { merge } from 'rxjs';
+import { merge, Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { TableConfigService } from '@perun-web-apps/config/table-config';
 import { formatDate } from '@angular/common';
@@ -33,14 +42,18 @@ import { formatDate } from '@angular/common';
   ],
 })
 export class AuditMessagesListComponent implements OnInit, OnChanges, AfterViewInit {
-  @Input()
-  tableId: string;
-  @Input()
-  refresh: boolean;
-  @Input()
-  displayedColumns: string[] = ['id', 'timestamp', 'name', 'actor', 'event.message', 'detail'];
-  @Input()
-  selectedEvents: string[];
+  @Input() tableId: string;
+  @Input() refresh: boolean;
+  @Input() displayedColumns: string[] = [
+    'id',
+    'timestamp',
+    'name',
+    'actor',
+    'event.message',
+    'detail',
+  ];
+  @Input() selectedEvents: string[];
+  @Output() loading$: EventEmitter<Observable<boolean>> = new EventEmitter<Observable<boolean>>();
 
   @ViewChild(TableWrapperComponent, { static: true }) child: TableWrapperComponent;
   @ViewChild(MatSort) sort: MatSort;
@@ -87,6 +100,7 @@ export class AuditMessagesListComponent implements OnInit, OnChanges, AfterViewI
       'DESCENDING',
       this.selectedEvents
     );
+    this.loading$.emit(this.dataSource.loading$);
   }
 
   ngOnChanges(): void {

--- a/apps/admin-gui/src/app/shared/components/create-service-member-dialog/create-service-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/create-service-member-dialog/create-service-member-dialog.component.html
@@ -1,192 +1,198 @@
-<div class="{{theme}}">
-  <h1 class="mat-dialog-title">{{'DIALOGS.CREATE_SERVICE_MEMBER.TITLE' | translate}}</h1>
-  <div *ngIf="!processing" class="dialog-container" mat-dialog-content>
-    <mat-stepper #stepper [linear]="true">
-      <mat-step [stepControl]="firstFormGroup">
-        <form [formGroup]="firstFormGroup">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="processing; indicator: spinner">
+    <h1 class="mat-dialog-title">{{'DIALOGS.CREATE_SERVICE_MEMBER.TITLE' | translate}}</h1>
+    <div *ngIf="firstFormGroup !== undefined" class="dialog-container" mat-dialog-content>
+      <mat-stepper #stepper [linear]="true">
+        <mat-step [stepControl]="firstFormGroup">
+          <form [formGroup]="firstFormGroup">
+            <ng-template
+              matStepLabel
+              >{{'DIALOGS.CREATE_SERVICE_MEMBER.CREATE_IDENTITY' | translate}}</ng-template
+            >
+            <div class="display-flex">
+              <mat-form-field>
+                <mat-label>{{'DIALOGS.CREATE_SERVICE_MEMBER.NAME' | translate}}</mat-label>
+                <input formControlName="nameCtrl" matInput required />
+                <mat-error
+                  *ngIf="firstFormGroup.get('nameCtrl').hasError('required')"
+                  >{{'DIALOGS.CREATE_SERVICE_MEMBER.FIELD_EMPTY' | translate}}</mat-error
+                >
+              </mat-form-field>
+
+              <mat-form-field>
+                <mat-label>{{'DIALOGS.CREATE_SERVICE_MEMBER.EMAIL' | translate}}</mat-label>
+                <input formControlName="emailCtrl" matInput required type="email" />
+                <mat-error
+                  *ngIf="firstFormGroup.get('emailCtrl').hasError('required')"
+                  >{{'DIALOGS.CREATE_SERVICE_MEMBER.FIELD_EMPTY' | translate}}</mat-error
+                >
+                <mat-error
+                  *ngIf="firstFormGroup.get('emailCtrl').hasError('pattern')"
+                  >{{'DIALOGS.CREATE_SERVICE_MEMBER.EMAIL_INVALID' | translate}}</mat-error
+                >
+              </mat-form-field>
+
+              <mat-form-field>
+                <mat-label>{{'DIALOGS.CREATE_SERVICE_MEMBER.SUBJECT_DN' | translate}}</mat-label>
+                <input
+                  [required]="!!firstFormGroup.get('issuerCtrl').value && firstFormGroup.get('issuerCtrl').value.trim().length !== 0"
+                  formControlName="subjectCtrl"
+                  matInput />
+                <mat-error
+                  *ngIf="firstFormGroup.get('subjectCtrl').hasError('required')"
+                  >{{'DIALOGS.CREATE_SERVICE_MEMBER.FIELD_EMPTY' | translate}}</mat-error
+                >
+              </mat-form-field>
+
+              <mat-form-field>
+                <mat-label>{{'DIALOGS.CREATE_SERVICE_MEMBER.ISSUER_DN' | translate}}</mat-label>
+                <input
+                  [required]="!!firstFormGroup.get('subjectCtrl').value && firstFormGroup.get('subjectCtrl').value.trim().length !== 0"
+                  formControlName="issuerCtrl"
+                  matInput />
+                <mat-error
+                  *ngIf="firstFormGroup.get('issuerCtrl').hasError('required')"
+                  >{{'DIALOGS.CREATE_SERVICE_MEMBER.FIELD_EMPTY' | translate}}</mat-error
+                >
+              </mat-form-field>
+            </div>
+          </form>
+        </mat-step>
+        <mat-step [stepControl]="secondFormGroup">
+          <form [formGroup]="secondFormGroup">
+            <ng-template
+              matStepLabel
+              >{{'DIALOGS.CREATE_SERVICE_MEMBER.SET_CREDENTIALS' | translate}}</ng-template
+            >
+            <app-login-password-form-with-generate-option
+              [formGroup]="secondFormGroup"
+              (parsedRulesOutput)="parsedRules = $event">
+            </app-login-password-form-with-generate-option>
+          </form>
+        </mat-step>
+        <mat-step>
           <ng-template
             matStepLabel
-            >{{'DIALOGS.CREATE_SERVICE_MEMBER.CREATE_IDENTITY' | translate}}</ng-template
+            >{{'DIALOGS.CREATE_SERVICE_MEMBER.ASSOCIATE_USERS' | translate}}</ng-template
           >
-          <div class="display-flex">
-            <mat-form-field>
-              <mat-label>{{'DIALOGS.CREATE_SERVICE_MEMBER.NAME' | translate}}</mat-label>
-              <input formControlName="nameCtrl" matInput required />
-              <mat-error
-                *ngIf="firstFormGroup.get('nameCtrl').hasError('required')"
-                >{{'DIALOGS.CREATE_SERVICE_MEMBER.FIELD_EMPTY' | translate}}</mat-error
-              >
-            </mat-form-field>
+          <h6>{{'DIALOGS.CREATE_SERVICE_MEMBER.ASSOCIATED_USERS' | translate}}</h6>
+          <mat-list>
+            <mat-list-item *ngFor="let member of assignedMembers">
+              <p class="truncate center-content">
+                {{member.user | userFullName}}
+                <span *ngIf="member.id" class="text-muted">#{{member.id}}</span>
+                <span
+                  [matTooltipDisabled]="assignedMembers.length > 1"
+                  [matTooltip]="'DIALOGS.CREATE_SERVICE_MEMBER.MINIMAL_USERS' | translate">
+                  <button
+                    (click)="removeUser(member)"
+                    [disabled]="assignedMembers.length === 1"
+                    class="ml-1"
+                    color="warn"
+                    mat-icon-button>
+                    <mat-icon class="margin-bottom">close</mat-icon>
+                  </button>
+                </span>
+              </p>
+            </mat-list-item>
+          </mat-list>
 
-            <mat-form-field>
-              <mat-label>{{'DIALOGS.CREATE_SERVICE_MEMBER.EMAIL' | translate}}</mat-label>
-              <input formControlName="emailCtrl" matInput required type="email" />
-              <mat-error
-                *ngIf="firstFormGroup.get('emailCtrl').hasError('required')"
-                >{{'DIALOGS.CREATE_SERVICE_MEMBER.FIELD_EMPTY' | translate}}</mat-error
-              >
-              <mat-error
-                *ngIf="firstFormGroup.get('emailCtrl').hasError('pattern')"
-                >{{'DIALOGS.CREATE_SERVICE_MEMBER.EMAIL_INVALID' | translate}}</mat-error
-              >
-            </mat-form-field>
-
-            <mat-form-field>
-              <mat-label>{{'DIALOGS.CREATE_SERVICE_MEMBER.SUBJECT_DN' | translate}}</mat-label>
-              <input
-                [required]="!!firstFormGroup.get('issuerCtrl').value && firstFormGroup.get('issuerCtrl').value.trim().length !== 0"
-                formControlName="subjectCtrl"
-                matInput />
-              <mat-error
-                *ngIf="firstFormGroup.get('subjectCtrl').hasError('required')"
-                >{{'DIALOGS.CREATE_SERVICE_MEMBER.FIELD_EMPTY' | translate}}</mat-error
-              >
-            </mat-form-field>
-
-            <mat-form-field>
-              <mat-label>{{'DIALOGS.CREATE_SERVICE_MEMBER.ISSUER_DN' | translate}}</mat-label>
-              <input
-                [required]="!!firstFormGroup.get('subjectCtrl').value && firstFormGroup.get('subjectCtrl').value.trim().length !== 0"
-                formControlName="issuerCtrl"
-                matInput />
-              <mat-error
-                *ngIf="firstFormGroup.get('issuerCtrl').hasError('required')"
-                >{{'DIALOGS.CREATE_SERVICE_MEMBER.FIELD_EMPTY' | translate}}</mat-error
-              >
-            </mat-form-field>
+          <h6 class="mt-3">{{'DIALOGS.CREATE_SERVICE_MEMBER.SEARCH_INFO' | translate}}</h6>
+          <mat-form-field class="mr-2 w-50">
+            <input
+              [formControl]="searchCtrl"
+              autocomplete="false"
+              matInput
+              (keyup.enter)="searchCtrl.value.length !== 0 && onSearchByString()"
+              placeholder="{{'DIALOGS.CREATE_SERVICE_MEMBER.SEARCH_PLACEHOLDER' | translate}}" />
+          </mat-form-field>
+          <button
+            (click)="onSearchByString()"
+            [disabled]="loading || searchCtrl.value.length === 0"
+            class="mr-2"
+            color="primary"
+            mat-flat-button>
+            <mat-icon>search</mat-icon>
+          </button>
+          <button
+            (click)="addUsers()"
+            [disabled]="selection.selected.length === 0"
+            color="accent"
+            mat-flat-button>
+            {{'DIALOGS.CREATE_SERVICE_MEMBER.ADD_USER' | translate}}
+          </button>
+          <ng-template #spinner>
+            <perun-web-apps-loading-table></perun-web-apps-loading-table>
+          </ng-template>
+          <div class="position-relative" *ngIf="firstSearchDone">
+            <perun-web-apps-members-list
+              *perunWebAppsLoader="loading; indicator: spinner"
+              [disableRouting]="true"
+              [displayedColumns]="['checkbox', 'id', 'fullName']"
+              [members]="members"
+              [tableId]="tableId"
+              [selection]="selection"></perun-web-apps-members-list>
           </div>
-        </form>
-      </mat-step>
-      <mat-step [stepControl]="secondFormGroup">
-        <form [formGroup]="secondFormGroup">
-          <ng-template
-            matStepLabel
-            >{{'DIALOGS.CREATE_SERVICE_MEMBER.SET_CREDENTIALS' | translate}}</ng-template
-          >
-          <app-login-password-form-with-generate-option
-            [formGroup]="secondFormGroup"
-            (parsedRulesOutput)="parsedRules = $event">
-          </app-login-password-form-with-generate-option>
-        </form>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.CREATE_SERVICE_MEMBER.ASSOCIATE_USERS' | translate}}</ng-template
-        >
-        <h6>{{'DIALOGS.CREATE_SERVICE_MEMBER.ASSOCIATED_USERS' | translate}}</h6>
-        <mat-list>
-          <mat-list-item *ngFor="let member of assignedMembers">
-            <p class="truncate center-content">
-              {{member.user | userFullName}}
-              <span *ngIf="member.id" class="text-muted">#{{member.id}}</span>
-              <span
-                [matTooltipDisabled]="assignedMembers.length > 1"
-                [matTooltip]="'DIALOGS.CREATE_SERVICE_MEMBER.MINIMAL_USERS' | translate">
-                <button
-                  (click)="removeUser(member)"
-                  [disabled]="assignedMembers.length === 1"
-                  class="ml-1"
-                  color="warn"
-                  mat-icon-button>
-                  <mat-icon class="margin-bottom">close</mat-icon>
-                </button>
-              </span>
-            </p>
-          </mat-list-item>
-        </mat-list>
-
-        <h6 class="mt-3">{{'DIALOGS.CREATE_SERVICE_MEMBER.SEARCH_INFO' | translate}}</h6>
-        <mat-form-field class="mr-2 w-50">
-          <input
-            [formControl]="searchCtrl"
-            autocomplete="false"
-            matInput
-            (keyup.enter)="searchCtrl.value.length !== 0 && onSearchByString()"
-            placeholder="{{'DIALOGS.CREATE_SERVICE_MEMBER.SEARCH_PLACEHOLDER' | translate}}" />
-        </mat-form-field>
-        <button
-          (click)="onSearchByString()"
-          [disabled]="loading || searchCtrl.value.length === 0"
-          class="mr-2"
-          color="primary"
-          mat-flat-button>
-          <mat-icon>search</mat-icon>
-        </button>
-        <button
-          (click)="addUsers()"
-          [disabled]="selection.selected.length === 0"
-          color="accent"
-          mat-flat-button>
-          {{'DIALOGS.CREATE_SERVICE_MEMBER.ADD_USER' | translate}}
-        </button>
-        <mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
-        <div *ngIf="!loading">
-          <perun-web-apps-members-list
-            *ngIf="firstSearchDone"
-            [disableRouting]="true"
-            [displayedColumns]="['checkbox', 'id', 'fullName']"
-            [members]="members"
-            [tableId]="tableId"
-            [selection]="selection"></perun-web-apps-members-list>
           <perun-web-apps-alert *ngIf="!firstSearchDone" alert_type="info">
             {{'DIALOGS.CREATE_SERVICE_MEMBER.SEARCH_INFO' | translate}}
           </perun-web-apps-alert>
-        </div>
-      </mat-step>
-      <mat-step *ngIf="findSponsorsAuth && voSponsors.length !== 0 && setSponsorshipAuth">
-        <ng-template matStepLabel>
-          {{'DIALOGS.CREATE_SERVICE_MEMBER.SPONSOR' | translate}}
-        </ng-template>
-        <perun-web-apps-alert alert_type="info">
-          {{'DIALOGS.CREATE_SERVICE_MEMBER.MANAGE_LIFECYCLE_INFO' | translate}}
-        </perun-web-apps-alert>
-      </mat-step>
-    </mat-stepper>
-  </div>
-  <mat-spinner *ngIf="processing" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!processing" mat-dialog-actions>
-    <button (click)="onCancel()" mat-flat-button>
-      {{'DIALOGS.CREATE_SERVICE_MEMBER.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="stepperPrevious()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
-      class="ml-auto"
-      mat-flat-button>
-      {{'DIALOGS.CREATE_SERVICE_MEMBER.BACK' | translate}}
-    </button>
-    <span
-      [matTooltipDisabled]="selection.selected.length === 0"
-      [matTooltip]="'DIALOGS.CREATE_SERVICE_MEMBER.NEXT_BUTTON_DISABLED_TOOLTIP' | translate">
+        </mat-step>
+        <mat-step *ngIf="findSponsorsAuth && voSponsors.length !== 0 && setSponsorshipAuth">
+          <ng-template matStepLabel>
+            {{'DIALOGS.CREATE_SERVICE_MEMBER.SPONSOR' | translate}}
+          </ng-template>
+          <perun-web-apps-alert alert_type="info">
+            {{'DIALOGS.CREATE_SERVICE_MEMBER.MANAGE_LIFECYCLE_INFO' | translate}}
+          </perun-web-apps-alert>
+        </mat-step>
+      </mat-stepper>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" mat-flat-button>
+        {{'DIALOGS.CREATE_SERVICE_MEMBER.CANCEL' | translate}}
+      </button>
       <button
-        (click)="stepperNext()"
-        *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
-        [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
-        [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
-        [disabled]="getStepperNextConditions()"
+        (click)="stepperPrevious()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
+        class="ml-auto"
+        mat-flat-button>
+        {{'DIALOGS.CREATE_SERVICE_MEMBER.BACK' | translate}}
+      </button>
+      <span
+        [matTooltipDisabled]="selection.selected.length === 0"
+        [matTooltip]="'DIALOGS.CREATE_SERVICE_MEMBER.NEXT_BUTTON_DISABLED_TOOLTIP' | translate">
+        <button
+          (click)="stepperNext()"
+          *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
+          [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
+          [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
+          [disabled]="getStepperNextConditions()"
+          color="accent"
+          mat-flat-button>
+          {{'DIALOGS.CREATE_SERVICE_MEMBER.NEXT' | translate}}
+        </button>
+      </span>
+      <button
+        (click)="onCreate(false)"
+        *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
+        [disabled]="firstFormGroup.invalid || (secondFormGroup.get('namespaceCtrl').value !== 'Not selected' && secondFormGroup.invalid)"
+        class="ml-2"
         color="accent"
         mat-flat-button>
-        {{'DIALOGS.CREATE_SERVICE_MEMBER.NEXT' | translate}}
+        {{"DIALOGS.CREATE_SERVICE_MEMBER.CREATE" | translate}}
       </button>
-    </span>
-    <button
-      (click)="onCreate(false)"
-      *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
-      [disabled]="firstFormGroup.invalid || (secondFormGroup.get('namespaceCtrl').value !== 'Not selected' && secondFormGroup.invalid)"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{"DIALOGS.CREATE_SERVICE_MEMBER.CREATE" | translate}}
-    </button>
-    <button
-      (click)="onCreate(true)"
-      *ngIf="(findSponsorsAuth && voSponsors.length !== 0 && setSponsorshipAuth) && stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
-      [disabled]="firstFormGroup.invalid || (secondFormGroup.get('namespaceCtrl').value !== 'Not selected' && secondFormGroup.invalid)"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{"DIALOGS.CREATE_SERVICE_MEMBER.CREATE_AND_SPONSOR" | translate}}
-    </button>
+      <button
+        (click)="onCreate(true)"
+        *ngIf="(findSponsorsAuth && voSponsors.length !== 0 && setSponsorshipAuth) && stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
+        [disabled]="firstFormGroup.invalid || (secondFormGroup.get('namespaceCtrl').value !== 'Not selected' && secondFormGroup.invalid)"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{"DIALOGS.CREATE_SERVICE_MEMBER.CREATE_AND_SPONSOR" | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/create-service-member-dialog/create-service-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/create-service-member-dialog/create-service-member-dialog.component.ts
@@ -332,11 +332,11 @@ export class CreateServiceMemberDialogComponent implements OnInit, AfterViewInit
 
   onSearchByString(): void {
     this.loading = true;
+    this.firstSearchDone = true;
     this.membersManagerService
       .findCompleteRichMembersForVo(this.data.vo.id, [''], this.searchCtrl.value as string)
       .subscribe((members) => {
         this.members = members.filter((m) => !m.user.specificUser);
-        this.firstSearchDone = true;
         this.loading = false;
       });
   }

--- a/apps/admin-gui/src/app/shared/components/delete-owner-dialog/delete-owner-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/delete-owner-dialog/delete-owner-dialog.component.html
@@ -1,31 +1,35 @@
-<h1 mat-dialog-title>{{'DIALOGS.DELETE_OWNER.TITLE' | translate}}</h1>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.DELETE_OWNER.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.DELETE_OWNER.DESCRIPTION' | translate}}
+      </p>
 
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
+      <div class="font-weight-bold">
+        {{'DIALOGS.DELETE_OWNER.ASK' | translate}}
+      </div>
 
-<div *ngIf="!loading" mat-dialog-content>
-  <p>
-    {{'DIALOGS.DELETE_OWNER.DESCRIPTION' | translate}}
-  </p>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let owner" mat-cell>{{owner.name}}</td>
+        </ng-container>
 
-  <div class="font-weight-bold">
-    {{'DIALOGS.DELETE_OWNER.ASK' | translate}}
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let owner; columns: displayedColumns;" mat-row></tr>
+      </table>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.DELETE_OWNER.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.DELETE_OWNER.DELETE' | translate}}
+      </button>
+    </div>
   </div>
-
-  <table [dataSource]="dataSource" class="w-100" mat-table>
-    <ng-container matColumnDef="name">
-      <th *matHeaderCellDef mat-header-cell></th>
-      <td *matCellDef="let owner" mat-cell>{{owner.name}}</td>
-    </ng-container>
-
-    <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-    <tr *matRowDef="let owner; columns: displayedColumns;" mat-row></tr>
-  </table>
-</div>
-<div *ngIf="!loading" mat-dialog-actions>
-  <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-    {{'DIALOGS.DELETE_OWNER.CANCEL' | translate}}
-  </button>
-  <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-    {{'DIALOGS.DELETE_OWNER.DELETE' | translate}}
-  </button>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-ban-dialog/add-ban-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-ban-dialog/add-ban-dialog.component.html
@@ -1,13 +1,15 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_BAN.TITLE' | translate}}</h1>
-  <div mat-dialog-content>
-    <mat-stepper [linear]="true" #stepper>
-      <mat-step [completed]="!disabled" [label]="'DIALOGS.ADD_BAN.SELECTION' | translate">
-        <ng-content></ng-content>
-      </mat-step>
-      <mat-step [label]="'DIALOGS.ADD_BAN.SPECIFICATION' | translate">
-        <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-        <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_BAN.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <mat-stepper [linear]="true" #stepper>
+        <mat-step [completed]="!disabled" [label]="'DIALOGS.ADD_BAN.SELECTION' | translate">
+          <ng-content></ng-content>
+        </mat-step>
+        <mat-step [label]="'DIALOGS.ADD_BAN.SPECIFICATION' | translate">
           <perun-web-apps-alert *ngIf="ban" [alert_type]="'info'">
             {{'DIALOGS.ADD_BAN.ALREADY_BANNED' | translate}}
           </perun-web-apps-alert>
@@ -15,36 +17,36 @@
             [description]="ban?.description"
             [validity]="ban?.validityTo">
           </perun-web-apps-ban-specification>
-        </div>
-      </mat-step>
-    </mat-stepper>
-  </div>
-  <div mat-dialog-actions>
-    <button mat-flat-button class="ml-auto mr-2" (click)="cancel.emit()">
-      {{'DIALOGS.ADD_BAN.CANCEL' | translate}}
-    </button>
-    <button
-      *ngIf="stepper.selectedIndex !== stepper?._steps?.length - 1"
-      mat-flat-button
-      class="mr-2"
-      color="accent"
-      (click)="stepper.next()"
-      [disabled]="disabled">
-      {{'DIALOGS.ADD_BAN.NEXT' | translate}}
-    </button>
-    <button
-      *ngIf="stepper.selectedIndex === stepper?._steps?.length - 1"
-      mat-flat-button
-      class="mr-2"
-      (click)="stepper.previous()">
-      {{'DIALOGS.ADD_BAN.BACK' | translate}}
-    </button>
-    <button
-      *ngIf="stepper.selectedIndex === stepper?._steps?.length - 1"
-      mat-flat-button
-      color="accent"
-      (click)="addBan()">
-      {{(!ban ? 'DIALOGS.ADD_BAN.ADD' : 'DIALOGS.ADD_BAN.UPDATE') | translate}}
-    </button>
+        </mat-step>
+      </mat-stepper>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-flat-button class="ml-auto mr-2" (click)="cancel.emit()">
+        {{'DIALOGS.ADD_BAN.CANCEL' | translate}}
+      </button>
+      <button
+        *ngIf="stepper.selectedIndex !== stepper?._steps?.length - 1"
+        mat-flat-button
+        class="mr-2"
+        color="accent"
+        (click)="stepper.next()"
+        [disabled]="disabled">
+        {{'DIALOGS.ADD_BAN.NEXT' | translate}}
+      </button>
+      <button
+        *ngIf="stepper.selectedIndex === stepper?._steps?.length - 1"
+        mat-flat-button
+        class="mr-2"
+        (click)="stepper.previous()">
+        {{'DIALOGS.ADD_BAN.BACK' | translate}}
+      </button>
+      <button
+        *ngIf="stepper.selectedIndex === stepper?._steps?.length - 1"
+        mat-flat-button
+        color="accent"
+        (click)="addBan()">
+        {{(!ban ? 'DIALOGS.ADD_BAN.ADD' : 'DIALOGS.ADD_BAN.UPDATE') | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-edit-notification-dialog/add-edit-notification-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-edit-notification-dialog/add-edit-notification-dialog.component.html
@@ -1,5 +1,8 @@
-<div class="{{theme}} h-100">
-  <div class="h-100 d-flex flex-column">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative h-100">
+  <div *perunWebAppsLoader="loading; indicator: spinner" class="h-100 d-flex flex-column">
     <div *ngIf="data.createMailNotification; else edit">
       <h1 mat-dialog-title>{{'DIALOGS.NOTIFICATIONS_ADD_EDIT_MAIL.TITLE_CREATE' | translate}}</h1>
     </div>
@@ -7,8 +10,7 @@
       <h1 mat-dialog-title>{{'DIALOGS.NOTIFICATIONS_ADD_EDIT_MAIL.TITLE_EDIT' | translate}}</h1>
     </ng-template>
 
-    <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-    <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
+    <div class="dialog-container" mat-dialog-content>
       <div [@openClose]="invalidNotification ? 'open' : 'closed'">
         <perun-web-apps-alert
           alert_type="error"
@@ -202,7 +204,7 @@
         *ngIf="data.createMailNotification"
         class="ml-2"
         color="accent"
-        [disabled]="invalidNotification || loading"
+        [disabled]="invalidNotification"
         mat-flat-button>
         {{'DIALOGS.NOTIFICATIONS_ADD_EDIT_MAIL.CREATE_BUTTON' | translate}}
       </button>
@@ -215,7 +217,7 @@
           *ngIf="!data.createMailNotification"
           class="ml-2"
           color="accent"
-          [disabled]="loading || !editAuth"
+          [disabled]="!editAuth"
           mat-flat-button>
           {{'DIALOGS.NOTIFICATIONS_ADD_EDIT_MAIL.SAVE_BUTTON' | translate}}
         </button>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-ext-source-dialog/add-ext-source-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-ext-source-dialog/add-ext-source-dialog.component.html
@@ -6,14 +6,19 @@
       [placeholder]="'DIALOGS.ADD_EXT_SOURCES.FILTER'"
       class="font-size-1rem"></perun-web-apps-immediate-filter>
   </div>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <app-ext-sources-list
-      [selection]="selection"
-      [extSources]="extSources"
-      [filterValue]="filterValue"
-      [tableId]="tableId">
-    </app-ext-sources-list>
+  <div mat-dialog-content>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
+    <div class="position-relative">
+      <app-ext-sources-list
+        *perunWebAppsLoader="loading; indicator: spinner"
+        [selection]="selection"
+        [extSources]="extSources"
+        [filterValue]="filterValue"
+        [tableId]="tableId">
+      </app-ext-sources-list>
+    </div>
   </div>
 
   <div mat-dialog-actions>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-facility-ban-dialog/add-facility-ban-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-facility-ban-dialog/add-facility-ban-dialog.component.html
@@ -8,13 +8,20 @@
   <perun-web-apps-debounce-filter
     (filter)="setFilter($event)"
     [placeholder]="'DIALOGS.ADD_BAN.FILTER'"></perun-web-apps-debounce-filter>
-  <perun-web-apps-users-dynamic-list
-    [attrNames]="attrNames"
-    [selection]="selection"
-    [tableId]="tableId"
-    [disableRouting]="true"
-    [displayedColumns]="displayedColumns"
-    [searchString]="filter"
-    [facilityId]="data.entityId">
-  </perun-web-apps-users-dynamic-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-users-dynamic-list
+      *perunWebAppsLoader="loading$ | async; indicator: spinner"
+      (loading$)="loading$ = $event"
+      [attrNames]="attrNames"
+      [selection]="selection"
+      [tableId]="tableId"
+      [disableRouting]="true"
+      [displayedColumns]="displayedColumns"
+      [searchString]="filter"
+      [facilityId]="data.entityId">
+    </perun-web-apps-users-dynamic-list>
+  </div>
 </app-add-ban-dialog>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-facility-ban-dialog/add-facility-ban-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-facility-ban-dialog/add-facility-ban-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { SelectionModel } from '@angular/cdk/collections';
 import { BanOnFacility, FacilitiesManagerService, RichUser } from '@perun-web-apps/perun/openapi';
 import { Urns } from '@perun-web-apps/perun/urns';
@@ -6,6 +6,7 @@ import { TABLE_BANS } from '@perun-web-apps/config/table-config';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { AddBanData, BanForm } from '../add-ban-dialog/add-ban-dialog.component';
 import { NotificatorService, StoreService } from '@perun-web-apps/perun/services';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'app-add-facility-ban-dialog',
@@ -15,6 +16,7 @@ import { NotificatorService, StoreService } from '@perun-web-apps/perun/services
 export class AddFacilityBanDialogComponent implements OnInit {
   selection = new SelectionModel<RichUser>(false, []);
   ban: BanOnFacility;
+  loading$: Observable<boolean>;
   loading = false;
   attrNames = [Urns.USER_DEF_PREFERRED_MAIL].concat(this.store.getLoginAttributeNames());
   displayedColumns = ['select', 'id', 'name', 'email', 'logins'];
@@ -26,10 +28,12 @@ export class AddFacilityBanDialogComponent implements OnInit {
     private dialogRef: MatDialogRef<AddFacilityBanDialogComponent>,
     private store: StoreService,
     private facilityService: FacilitiesManagerService,
-    private notificator: NotificatorService
+    private notificator: NotificatorService,
+    private cd: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
+    this.loading$ = of(true);
     this.selection.changed.subscribe((change) => {
       this.ban = this.data.bans.find((ban) => ban.userId === change.source.selected[0]?.id);
     });
@@ -50,6 +54,7 @@ export class AddFacilityBanDialogComponent implements OnInit {
   setFilter(filter: string): void {
     this.filter = filter;
     this.selection.clear();
+    this.cd.detectChanges();
   }
 
   private banUser(banForm: BanForm): void {

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-facility-owner-dialog/add-facility-owner-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-facility-owner-dialog/add-facility-owner-dialog.component.html
@@ -1,35 +1,39 @@
-<h1 mat-dialog-title>{{'DIALOGS.ADD_OWNERS.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_OWNERS.TITLE' | translate}}</h1>
 
-  <div *ngIf="!loading">
-    <perun-web-apps-immediate-filter
-      (filter)="applyFilter($event)"
-      [placeholder]="'DIALOGS.ADD_OWNERS.FILTER'"
-      class="font-size-1rem"></perun-web-apps-immediate-filter>
+    <div>
+      <perun-web-apps-immediate-filter
+        (filter)="applyFilter($event)"
+        [placeholder]="'DIALOGS.ADD_OWNERS.FILTER'"
+        class="font-size-1rem"></perun-web-apps-immediate-filter>
 
-    <div mat-dialog-content>
-      <perun-web-apps-owners-list
-        [filterValue]="filterValue"
-        [selection]="selection"
-        [owners]="owners"
-        [tableId]="tableId">
-      </perun-web-apps-owners-list>
-    </div>
+      <div mat-dialog-content>
+        <perun-web-apps-owners-list
+          [filterValue]="filterValue"
+          [selection]="selection"
+          [owners]="owners"
+          [tableId]="tableId">
+        </perun-web-apps-owners-list>
+      </div>
 
-    <div mat-dialog-actions>
-      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-        {{'DIALOGS.ADD_OWNERS.CANCEL' | translate}}
-      </button>
+      <div mat-dialog-actions>
+        <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+          {{'DIALOGS.ADD_OWNERS.CANCEL' | translate}}
+        </button>
 
-      <button
-        (click)="onAdd()"
-        [disabled]="selection.selected.length === 0 || loading"
-        class="ml-2"
-        color="accent"
-        mat-flat-button>
-        {{'DIALOGS.ADD_OWNERS.ADD' | translate}}
-      </button>
+        <button
+          (click)="onAdd()"
+          [disabled]="selection.selected.length === 0 || loading"
+          class="ml-2"
+          color="accent"
+          mat-flat-button>
+          {{'DIALOGS.ADD_OWNERS.ADD' | translate}}
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-hierarchical-include-dialog/add-group-hierarchical-include-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-hierarchical-include-dialog/add-group-hierarchical-include-dialog.component.html
@@ -10,25 +10,29 @@
       [placeholder]="'DIALOGS.ADD_GROUPS_HIERARCHICAL_INCLUSION.SEARCH'"
       (filter)="applyFilter($event)">
     </perun-web-apps-immediate-filter>
-    <perun-web-apps-groups-list
-      *ngIf="!loading"
-      [tableId]="tableId"
-      [groups]="groups"
-      [selection]="selected"
-      [filter]="filterValue"
-      [displayedColumns]="['select', 'id', 'name', 'description']"
-      [disableRouting]="true"
-      [noGroupsAlert]="'DIALOGS.ADD_GROUPS_HIERARCHICAL_INCLUSION.NO_GROUPS_FOUND_ALERT'"
-      theme="vo-theme">
-    </perun-web-apps-groups-list>
-    <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
+    <div class="position-relative">
+      <perun-web-apps-groups-list
+        *perunWebAppsLoader="loading; indicator: spinner"
+        [tableId]="tableId"
+        [groups]="groups"
+        [selection]="selected"
+        [filter]="filterValue"
+        [displayedColumns]="['select', 'id', 'name', 'description']"
+        [disableRouting]="true"
+        [noGroupsAlert]="'DIALOGS.ADD_GROUPS_HIERARCHICAL_INCLUSION.NO_GROUPS_FOUND_ALERT'"
+        theme="vo-theme">
+      </perun-web-apps-groups-list>
+    </div>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
   </div>
-  <div *ngIf="!loading" mat-dialog-actions>
-    <button (click)="close()" mat-flat-button class="ml-auto">
+  <div mat-dialog-actions>
+    <button [disabled]="loading" (click)="close()" mat-flat-button class="ml-auto">
       {{'DIALOGS.ADD_GROUPS_HIERARCHICAL_INCLUSION.CANCEL' | translate}}
     </button>
     <button
-      [disabled]="selected.selected.length === 0"
+      [disabled]="selected.selected.length === 0 || loading"
       (click)="confirm()"
       color="accent"
       mat-flat-button>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.html
@@ -36,11 +36,12 @@
       (filter)="applyFilter($event)"
       placeholder="{{'DIALOGS.ADD_GROUPS.FILTER_GROUPS' | translate}}">
     </perun-web-apps-debounce-filter>
-    <div class="overflow-hidden">
-      <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-    </div>
-    <div *ngIf="groups !== null && !loading" class="mt-3">
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
+    <div *ngIf="firstSearchDone" class="position-relative mt-3">
       <perun-web-apps-groups-list
+        *perunWebAppsLoader="loading; indicator: spinner"
         [disableMembers]="false"
         [disableRouting]="true"
         [displayedColumns]="['select', 'id', 'name', 'description']"

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.ts
@@ -118,11 +118,11 @@ export class AddGroupManagerDialogComponent implements OnInit {
 
   showVoGroups(event: MatAutocompleteSelectedEvent): void {
     this.loading = true;
+    this.firstSearchDone = true;
     this.groupService.getAllGroups((event.option.value as Vo).id).subscribe({
       next: (groups) => {
         this.groups = groups;
         this.loading = false;
-        this.firstSearchDone = true;
       },
       error: () => (this.loading = false),
     });

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-resource-dialog/add-group-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-resource-dialog/add-group-resource-dialog.component.html
@@ -1,104 +1,108 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_GROUP_RESOURCES.TITLE'| translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <mat-stepper #stepper [linear]="true">
-      <mat-step
-        [completed]="selection.selected.length !== 0 && (list !== undefined && list.addAuth)">
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.ADD_GROUP_RESOURCES.RESOURCES' | translate}}</ng-template
-        >
-        <perun-web-apps-debounce-filter
-          (filter)="applyFilter($event)"
-          placeholder="{{'DIALOGS.ADD_GROUP_RESOURCES.FILTER' | translate}}">
-        </perun-web-apps-debounce-filter>
-        <perun-web-apps-resources-list
-          #list
-          [filterValue]="filterValue"
-          [groupToResource]="this.data.group"
-          [disableRouting]="true"
-          [resources]="resources"
-          [selection]="selection"
-          [displayedColumns]="['select', 'id', 'name', 'facility', 'tags', 'description']"
-          [tableId]="tableId"></perun-web-apps-resources-list>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.ADD_GROUP_RESOURCES.OPTIONS' | translate}}</ng-template
-        >
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_GROUP_RESOURCES.TITLE'| translate}}</h1>
+    <div *ngIf="resources" mat-dialog-content>
+      <mat-stepper #stepper [linear]="true">
+        <mat-step
+          [completed]="selection.selected.length !== 0 && (list !== undefined && list.addAuth)">
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.ADD_GROUP_RESOURCES.RESOURCES' | translate}}</ng-template
+          >
+          <perun-web-apps-debounce-filter
+            (filter)="applyFilter($event)"
+            placeholder="{{'DIALOGS.ADD_GROUP_RESOURCES.FILTER' | translate}}">
+          </perun-web-apps-debounce-filter>
+          <perun-web-apps-resources-list
+            #list
+            [filterValue]="filterValue"
+            [groupToResource]="this.data.group"
+            [disableRouting]="true"
+            [resources]="resources"
+            [selection]="selection"
+            [displayedColumns]="['select', 'id', 'name', 'facility', 'tags', 'description']"
+            [tableId]="tableId"></perun-web-apps-resources-list>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.ADD_GROUP_RESOURCES.OPTIONS' | translate}}</ng-template
+          >
 
-        <mat-slide-toggle
-          (toggleChange)="changeSubgroupsMessage()"
-          class="mt-3 slide-text"
-          [(ngModel)]="autoAssignSubgroups"
-          labelPosition="before">
-          {{'DIALOGS.ADD_GROUP_RESOURCES.AUTO_SUBGROUPS' | translate}}
-        </mat-slide-toggle>
-        <div class="text-muted new-line mt-2">
-          <i [innerHTML]="autoAssignHint"></i>
-        </div>
+          <mat-slide-toggle
+            (toggleChange)="changeSubgroupsMessage()"
+            class="mt-3 slide-text"
+            [(ngModel)]="autoAssignSubgroups"
+            labelPosition="before">
+            {{'DIALOGS.ADD_GROUP_RESOURCES.AUTO_SUBGROUPS' | translate}}
+          </mat-slide-toggle>
+          <div class="text-muted new-line mt-2">
+            <i [innerHTML]="autoAssignHint"></i>
+          </div>
 
-        <mat-slide-toggle
-          (toggleChange)="changeInactiveMessage()"
-          class="mt-3 slide-text"
-          [(ngModel)]="asActive"
-          labelPosition="before">
-          {{'DIALOGS.ADD_GROUP_RESOURCES.AS_ACTIVE' | translate}}
-        </mat-slide-toggle>
-        <div class="text-muted new-line mt-2">
-          {{asActiveHint}}
-        </div>
+          <mat-slide-toggle
+            (toggleChange)="changeInactiveMessage()"
+            class="mt-3 slide-text"
+            [(ngModel)]="asActive"
+            labelPosition="before">
+            {{'DIALOGS.ADD_GROUP_RESOURCES.AS_ACTIVE' | translate}}
+          </mat-slide-toggle>
+          <div class="text-muted new-line mt-2">
+            {{asActiveHint}}
+          </div>
 
-        <mat-slide-toggle
-          (toggleChange)="changeAsyncMessage()"
-          class="mt-3 slide-text"
-          [(ngModel)]="async"
-          labelPosition="before">
-          {{'DIALOGS.ADD_GROUP_RESOURCES.ASYNC_OPT' | translate}}
-        </mat-slide-toggle>
-        <div class="text-muted new-line mt-2">
-          {{asyncHint}}
-        </div>
-      </mat-step>
-    </mat-stepper>
-  </div>
-  <div *ngIf="!loading && stepper !== undefined" mat-dialog-actions>
-    <button (click)="onCancel()" mat-flat-button>
-      {{'DIALOGS.ADD_GROUP_RESOURCES.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="stepperPrevious()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
-      class="ml-auto"
-      mat-flat-button>
-      {{'DIALOGS.ADD_GROUP_RESOURCES.BACK' | translate}}
-    </button>
-    <button
-      (click)="stepperNext()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
-      [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
-      [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
-      [disabled]="selection.selected.length === 0 || (list !== undefined && !list.addAuth)"
-      class="ml-auto"
-      color="accent"
-      mat-flat-button
-      type="button">
-      {{'DIALOGS.ADD_GROUP_RESOURCES.NEXT' | translate}}
-    </button>
-    <span
-      [matTooltipDisabled]="list === undefined || list.addAuth"
-      matTooltip="{{'DIALOGS.ADD_GROUP_RESOURCES.ADD_PERMISSION_TOOLTIP' | translate}}">
-      <button
-        (click)="onSubmit()"
-        class="ml-2"
-        color="accent"
-        *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
-        [disabled]="selection.selected.length === 0 || loading"
-        mat-flat-button>
-        {{'DIALOGS.ADD_GROUP_RESOURCES.ADD' | translate}}
+          <mat-slide-toggle
+            (toggleChange)="changeAsyncMessage()"
+            class="mt-3 slide-text"
+            [(ngModel)]="async"
+            labelPosition="before">
+            {{'DIALOGS.ADD_GROUP_RESOURCES.ASYNC_OPT' | translate}}
+          </mat-slide-toggle>
+          <div class="text-muted new-line mt-2">
+            {{asyncHint}}
+          </div>
+        </mat-step>
+      </mat-stepper>
+    </div>
+    <div *ngIf="stepper !== undefined" mat-dialog-actions>
+      <button (click)="onCancel()" mat-flat-button>
+        {{'DIALOGS.ADD_GROUP_RESOURCES.CANCEL' | translate}}
       </button>
-    </span>
+      <button
+        (click)="stepperPrevious()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
+        class="ml-auto"
+        mat-flat-button>
+        {{'DIALOGS.ADD_GROUP_RESOURCES.BACK' | translate}}
+      </button>
+      <button
+        (click)="stepperNext()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
+        [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
+        [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
+        [disabled]="selection.selected.length === 0 || (list !== undefined && !list.addAuth)"
+        class="ml-auto"
+        color="accent"
+        mat-flat-button
+        type="button">
+        {{'DIALOGS.ADD_GROUP_RESOURCES.NEXT' | translate}}
+      </button>
+      <span
+        [matTooltipDisabled]="list === undefined || list.addAuth"
+        matTooltip="{{'DIALOGS.ADD_GROUP_RESOURCES.ADD_PERMISSION_TOOLTIP' | translate}}">
+        <button
+          (click)="onSubmit()"
+          class="ml-2"
+          color="accent"
+          *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
+          [disabled]="selection.selected.length === 0 || loading"
+          mat-flat-button>
+          {{'DIALOGS.ADD_GROUP_RESOURCES.ADD' | translate}}
+        </button>
+      </span>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-resource-dialog/add-group-resource-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-resource-dialog/add-group-resource-dialog.component.ts
@@ -26,7 +26,7 @@ export class AddGroupResourceDialogComponent implements OnInit {
 
   loading: boolean;
   filterValue = '';
-  resources: RichResource[] = [];
+  resources: RichResource[] = null;
   selection = new SelectionModel<RichResource>(true, []);
   theme = '';
   async = true;
@@ -59,10 +59,11 @@ export class AddGroupResourceDialogComponent implements OnInit {
       'DIALOGS.ADD_GROUP_RESOURCES.ACTIVE_ON_HINT'
     ) as string;
     this.asyncHint = this.translate.instant('DIALOGS.ADD_GROUP_RESOURCES.ASYNC_ON_HINT') as string;
-    this.resourcesManager.getRichResources(this.data.group.voId).subscribe(
-      (allResources) => {
-        this.resourcesManager.getAssignedResourcesWithGroup(this.data.group.id).subscribe(
-          (assignedResources) => {
+    this.resourcesManager.getRichResources(this.data.group.voId).subscribe({
+      next: (allResources) => {
+        this.resourcesManager.getAssignedResourcesWithGroup(this.data.group.id).subscribe({
+          next: (assignedResources) => {
+            this.resources = [];
             for (const allResource of allResources) {
               if (
                 assignedResources.findIndex((item) => item.id === allResource.id) === -1 &&
@@ -77,11 +78,11 @@ export class AddGroupResourceDialogComponent implements OnInit {
             this.loading = false;
             this.cd.detectChanges();
           },
-          () => (this.loading = false)
-        );
+          error: () => (this.loading = false),
+        });
       },
-      () => (this.loading = false)
-    );
+      error: () => (this.loading = false),
+    });
   }
 
   applyFilter(filterValue: string): void {
@@ -103,8 +104,8 @@ export class AddGroupResourceDialogComponent implements OnInit {
         !this.asActive,
         this.autoAssignSubgroups
       )
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.translate
             .get('DIALOGS.ADD_GROUP_RESOURCES.SUCCESS')
             .subscribe((successMessage: string) => {
@@ -112,8 +113,8 @@ export class AddGroupResourceDialogComponent implements OnInit {
               this.dialogRef.close(true);
             });
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
   }
 
   changeSubgroupsMessage(): void {

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-to-registration/add-group-to-registration.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-to-registration/add-group-to-registration.component.html
@@ -1,32 +1,36 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_GROUP_TO_REGISTRATION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <perun-web-apps-debounce-filter
-      (filter)="applyFilter($event)"
-      placeholder="{{'DIALOGS.ADD_GROUP_TO_REGISTRATION.FILTER_DESCRIPTION' | translate}}">
-    </perun-web-apps-debounce-filter>
-    <perun-web-apps-groups-list
-      [disableMembers]="true"
-      [groups]="unAssignedGroups"
-      [selection]="selection"
-      [disableRouting]="true"
-      [displayedColumns]="['select', 'id', 'name', 'description']"
-      [filter]="filterValue"
-      [tableId]="tableId">
-    </perun-web-apps-groups-list>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.ADD_GROUP_TO_REGISTRATION.CANCEL_BUTTON' | translate}}
-    </button>
-    <button
-      (click)="onAdd()"
-      class="ml-2"
-      color="accent"
-      [disabled]="selection.selected.length === 0 || loading"
-      mat-flat-button>
-      {{'DIALOGS.ADD_GROUP_TO_REGISTRATION.ADD_BUTTON' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_GROUP_TO_REGISTRATION.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <perun-web-apps-debounce-filter
+        (filter)="applyFilter($event)"
+        placeholder="{{'DIALOGS.ADD_GROUP_TO_REGISTRATION.FILTER_DESCRIPTION' | translate}}">
+      </perun-web-apps-debounce-filter>
+      <perun-web-apps-groups-list
+        [disableMembers]="true"
+        [groups]="unAssignedGroups"
+        [selection]="selection"
+        [disableRouting]="true"
+        [displayedColumns]="['select', 'id', 'name', 'description']"
+        [filter]="filterValue"
+        [tableId]="tableId">
+      </perun-web-apps-groups-list>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ADD_GROUP_TO_REGISTRATION.CANCEL_BUTTON' | translate}}
+      </button>
+      <button
+        (click)="onAdd()"
+        class="ml-2"
+        color="accent"
+        [disabled]="selection.selected.length === 0 || loading"
+        mat-flat-button>
+        {{'DIALOGS.ADD_GROUP_TO_REGISTRATION.ADD_BUTTON' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-to-registration/add-group-to-registration.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-to-registration/add-group-to-registration.component.ts
@@ -22,7 +22,7 @@ export interface AddGroupToRegistrationDialogData {
 export class AddGroupToRegistrationComponent implements OnInit {
   loading = false;
   theme: string;
-  unAssignedGroups: Group[];
+  unAssignedGroups: Group[] = [];
   selection = new SelectionModel<Group>(true, []);
   filterValue = '';
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-host-dialog/add-host-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-host-dialog/add-host-dialog.component.html
@@ -1,44 +1,48 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_HOST.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-form-field>
-      <textarea
-        class="md-textarea form-control"
-        id="facilityAddHost"
-        name="facilityAddHost"
-        [formControl]="hostsCtrl"
-        [placeholder]="'DIALOGS.ADD_HOST.SUBTITLE' | translate"
-        cols="50"
-        required
-        matInput
-        perunWebAppsAutoFocus
-        rows="8">
-      </textarea>
-      <mat-error *ngIf="this.hostsCtrl.hasError('required')">
-        {{'DIALOGS.ADD_HOST.EMPTY_MESSAGE' | translate}}
-      </mat-error>
-      <mat-error *ngIf="this.hostsCtrl.hasError('invalidHost')">
-        {{'DIALOGS.ADD_HOST.INVALID_HOST' | translate}}
-        {{this.hostsCtrl.getError('invalidHost').value}}
-      </mat-error>
-    </mat-form-field>
-    <perun-web-apps-alert
-      alert_type="info"
-      >{{'DIALOGS.ADD_HOST.HINT'| translate}}</perun-web-apps-alert
-    >
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.ADD_HOST.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onAdd()"
-      class="ml-2"
-      color="accent"
-      [disabled]="hostsCtrl.invalid || loading"
-      mat-flat-button>
-      {{'DIALOGS.ADD_HOST.ADD' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_HOST.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-form-field>
+        <textarea
+          class="md-textarea form-control"
+          id="facilityAddHost"
+          name="facilityAddHost"
+          [formControl]="hostsCtrl"
+          [placeholder]="'DIALOGS.ADD_HOST.SUBTITLE' | translate"
+          cols="50"
+          required
+          matInput
+          perunWebAppsAutoFocus
+          rows="8">
+        </textarea>
+        <mat-error *ngIf="this.hostsCtrl.hasError('required')">
+          {{'DIALOGS.ADD_HOST.EMPTY_MESSAGE' | translate}}
+        </mat-error>
+        <mat-error *ngIf="this.hostsCtrl.hasError('invalidHost')">
+          {{'DIALOGS.ADD_HOST.INVALID_HOST' | translate}}
+          {{this.hostsCtrl.getError('invalidHost').value}}
+        </mat-error>
+      </mat-form-field>
+      <perun-web-apps-alert
+        alert_type="info"
+        >{{'DIALOGS.ADD_HOST.HINT'| translate}}</perun-web-apps-alert
+      >
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ADD_HOST.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onAdd()"
+        class="ml-2"
+        color="accent"
+        [disabled]="hostsCtrl.invalid || loading"
+        mat-flat-button>
+        {{'DIALOGS.ADD_HOST.ADD' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-manager-dialog/add-manager-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-manager-dialog/add-manager-dialog.component.html
@@ -36,15 +36,12 @@
       {{'DIALOGS.ADD_MANAGERS.SEARCH' | translate}}
     </button>
 
-    <div class="overflow-hidden">
-      <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-    </div>
-    <div class="mt-3" *ngIf="users !== null && !loading">
-      <perun-web-apps-alert *ngIf="users.length === 0 && firstSearchDone" alert_type="warn">
-        {{'DIALOGS.ADD_MANAGERS.NO_USERS_FOUND' | translate}}
-      </perun-web-apps-alert>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
+    <div class="position-relative mt-3" *ngIf="firstSearchDone">
       <app-users-list
-        *ngIf="users.length !== 0"
+        *perunWebAppsLoader="loading; indicator: spinner"
         [disableRouting]="true"
         [selection]="selection"
         [displayedColumns]="['select', 'id', 'name', 'email', 'logins', 'organization']"

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-manager-dialog/add-manager-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-manager-dialog/add-manager-dialog.component.ts
@@ -98,6 +98,7 @@ export class AddManagerDialogComponent implements OnInit {
       return;
     }
     this.loading = true;
+    this.firstSearchDone = true;
 
     this.selection.clear();
 
@@ -110,7 +111,6 @@ export class AddManagerDialogComponent implements OnInit {
         next: (users) => {
           this.users = users;
           this.loading = false;
-          this.firstSearchDone = true;
         },
         error: () => (this.loading = false),
       });

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-member-dialog/add-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-member-dialog/add-member-dialog.component.html
@@ -1,105 +1,110 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_MEMBERS.TITLE' | translate}}</h1>
+<ng-template #spinner1>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="members && loading; indicator: spinner1">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_MEMBERS.TITLE' | translate}}</h1>
 
-  <div *ngIf="failed.length === 0">
-    <div mat-dialog-content>
-      <perun-web-apps-debounce-filter
-        error="{{'DIALOGS.ADD_MEMBERS.EMPTY_SEARCH_MESSAGE' | translate}}"
-        placeholder="{{'DIALOGS.ADD_MEMBERS.DESCRIPTION' | translate}}"
-        data-cy="search-members"
-        [autoFocus]="true"
-        [control]="searchCtrl"
-        (filter)="search.emit($event)"></perun-web-apps-debounce-filter>
+    <div *ngIf="failed.length === 0">
+      <div mat-dialog-content>
+        <perun-web-apps-debounce-filter
+          error="{{'DIALOGS.ADD_MEMBERS.EMPTY_SEARCH_MESSAGE' | translate}}"
+          placeholder="{{'DIALOGS.ADD_MEMBERS.DESCRIPTION' | translate}}"
+          data-cy="search-members"
+          [autoFocus]="true"
+          [control]="searchCtrl"
+          (filter)="search.emit($event)"></perun-web-apps-debounce-filter>
 
-      <div class="no-bounce-scrollbar">
-        <mat-spinner *ngIf="members === null || loading" class="mr-auto ml-auto"></mat-spinner>
+        <ng-template #searchSpinner>
+          <perun-web-apps-loading-table></perun-web-apps-loading-table>
+        </ng-template>
+        <div class="position-relative mt-3">
+          <app-members-candidates-list
+            *perunWebAppsLoader="members === null; indicator: searchSpinner"
+            [tableId]="tableId"
+            [members]="members"
+            [selection]="selection"
+            [blockManualAdding]="manualAddingBlocked">
+          </app-members-candidates-list>
+        </div>
       </div>
-      <div class="mt-3" *ngIf="!!members && !loading">
-        <app-members-candidates-list
-          [tableId]="tableId"
-          [members]="members"
-          [selection]="selection"
-          [blockManualAdding]="manualAddingBlocked">
-        </app-members-candidates-list>
-      </div>
-    </div>
-    <div mat-dialog-actions>
-      <button mat-flat-button class="ml-auto" (click)="cancel.emit(false)">
-        {{'DIALOGS.ADD_MEMBERS.CANCEL' | translate}}
-      </button>
-      <span
-        matTooltip="{{(!showInvite ? 'DIALOGS.ADD_MEMBERS.INVITE_MEMBER_DISABLED' : 'DIALOGS.ADD_MEMBERS.ADD_MEMBER_PERMISSION_TOOLTIP') | translate}}"
-        [matTooltipPosition]="'below'"
-        [matTooltipDisabled]="selection.selected.length <= 0 || (showInvite && inviteAuth)">
-        <button
-          *ngIf="inviteAuth"
-          [disabled]="selection.selected.length === 0 || !inviteAuth || !showInvite"
-          [matMenuTriggerFor]="menu"
-          class="ml-2 dropdown-toggle"
-          color="accent"
-          mat-flat-button>
-          {{'DIALOGS.ADD_MEMBERS.INVITE' | translate}}
+      <div mat-dialog-actions>
+        <button mat-flat-button class="ml-auto" (click)="cancel.emit(false)">
+          {{'DIALOGS.ADD_MEMBERS.CANCEL' | translate}}
         </button>
-        <mat-menu #menu="matMenu">
-          <button (click)="invite.emit(lang)" *ngFor="let lang of languages" mat-menu-item>
-            {{'DIALOGS.ADD_MEMBERS.INVITE_IN_LANGUAGE' | translate}}
-            {{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}
-            {{'DIALOGS.ADD_MEMBERS.LANGUAGE' | translate}}
+        <span
+          matTooltip="{{(!showInvite ? 'DIALOGS.ADD_MEMBERS.INVITE_MEMBER_DISABLED' : 'DIALOGS.ADD_MEMBERS.ADD_MEMBER_PERMISSION_TOOLTIP') | translate}}"
+          [matTooltipPosition]="'below'"
+          [matTooltipDisabled]="selection.selected.length <= 0 || (showInvite && inviteAuth)">
+          <button
+            *ngIf="inviteAuth"
+            [disabled]="selection.selected.length === 0 || !inviteAuth || !showInvite"
+            [matMenuTriggerFor]="menu"
+            class="ml-2 dropdown-toggle"
+            color="accent"
+            mat-flat-button>
+            {{'DIALOGS.ADD_MEMBERS.INVITE' | translate}}
           </button>
-        </mat-menu>
-      </span>
-      <span
-        matTooltip="{{'DIALOGS.ADD_MEMBERS.ADD_MEMBER_PERMISSION_TOOLTIP' | translate}}"
-        matTooltipPosition="above"
-        [matTooltipDisabled]="selection.selected.length === 0 || addAuth">
-        <button
-          mat-flat-button
-          class="ml-2"
-          color="accent"
-          data-cy="add-button"
-          (click)="add.emit()"
-          [disabled]="selection.selected.length === 0 || !addAuth">
-          {{'DIALOGS.ADD_MEMBERS.CREATE' | translate}}
+          <mat-menu #menu="matMenu">
+            <button (click)="invite.emit(lang)" *ngFor="let lang of languages" mat-menu-item>
+              {{'DIALOGS.ADD_MEMBERS.INVITE_IN_LANGUAGE' | translate}}
+              {{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}
+              {{'DIALOGS.ADD_MEMBERS.LANGUAGE' | translate}}
+            </button>
+          </mat-menu>
+        </span>
+        <span
+          matTooltip="{{'DIALOGS.ADD_MEMBERS.ADD_MEMBER_PERMISSION_TOOLTIP' | translate}}"
+          matTooltipPosition="above"
+          [matTooltipDisabled]="selection.selected.length === 0 || addAuth">
+          <button
+            mat-flat-button
+            class="ml-2"
+            color="accent"
+            data-cy="add-button"
+            (click)="add.emit()"
+            [disabled]="selection.selected.length === 0 || !addAuth">
+            {{'DIALOGS.ADD_MEMBERS.CREATE' | translate}}
+          </button>
+        </span>
+      </div>
+    </div>
+    <div *ngIf="failed.length !== 0">
+      <div mat-dialog-content>
+        <perun-web-apps-alert
+          class="mb-2"
+          [alert_type]="'error'"
+          >{{'DIALOGS.ADD_MEMBERS.FAILED_DESC' | translate}}</perun-web-apps-alert
+        >
+        <table [dataSource]="failedCandidateDataSource" class="w-100" mat-table>
+          <ng-container matColumnDef="userName">
+            <th *matHeaderCellDef mat-header-cell>
+              {{'DIALOGS.ADD_MEMBERS.NAME_COLUMN' | translate}}
+            </th>
+            <td *matCellDef="let failedCandidate" mat-cell>
+              {{(failedCandidate.candidate.candidate ?? failedCandidate.candidate.richUser) | userFullName}}
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="error">
+            <th *matHeaderCellDef mat-header-cell>
+              {{'DIALOGS.ADD_MEMBERS.ERROR_COLUMN' | translate}}
+            </th>
+            <td *matCellDef="let failedCandidate" mat-cell>
+              {{failedCandidate.errorMsg}}
+              <div class="text-muted">
+                {{failedCandidate.errorName}}
+              </div>
+            </td>
+          </ng-container>
+          <tr *matHeaderRowDef="['userName', 'error']" mat-header-row></tr>
+          <tr *matRowDef="let failedCandidate; columns: ['userName', 'error'];" mat-row></tr>
+        </table>
+      </div>
+      <div mat-dialog-actions *ngIf="!loading">
+        <button mat-flat-button class="ml-auto" (click)="cancel.emit(true)">
+          {{'DIALOGS.ADD_MEMBERS.CLOSE' | translate}}
         </button>
-      </span>
-    </div>
-  </div>
-  <div *ngIf="failed.length !== 0">
-    <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-    <div mat-dialog-content *ngIf="!loading">
-      <perun-web-apps-alert
-        class="mb-2"
-        [alert_type]="'error'"
-        >{{'DIALOGS.ADD_MEMBERS.FAILED_DESC' | translate}}</perun-web-apps-alert
-      >
-      <table [dataSource]="failedCandidateDataSource" class="w-100" mat-table>
-        <ng-container matColumnDef="userName">
-          <th *matHeaderCellDef mat-header-cell>
-            {{'DIALOGS.ADD_MEMBERS.NAME_COLUMN' | translate}}
-          </th>
-          <td *matCellDef="let failedCandidate" mat-cell>
-            {{(failedCandidate.candidate.candidate ?? failedCandidate.candidate.richUser) | userFullName}}
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="error">
-          <th *matHeaderCellDef mat-header-cell>
-            {{'DIALOGS.ADD_MEMBERS.ERROR_COLUMN' | translate}}
-          </th>
-          <td *matCellDef="let failedCandidate" mat-cell>
-            {{failedCandidate.errorMsg}}
-            <div class="text-muted">
-              {{failedCandidate.errorName}}
-            </div>
-          </td>
-        </ng-container>
-        <tr *matHeaderRowDef="['userName', 'error']" mat-header-row></tr>
-        <tr *matRowDef="let failedCandidate; columns: ['userName', 'error'];" mat-row></tr>
-      </table>
-    </div>
-    <div mat-dialog-actions *ngIf="!loading">
-      <button mat-flat-button class="ml-auto" (click)="cancel.emit(true)">
-        {{'DIALOGS.ADD_MEMBERS.CLOSE' | translate}}
-      </button>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-member-dialog/add-member-dialog.component.scss
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-member-dialog/add-member-dialog.component.scss
@@ -2,10 +2,6 @@
   width: 270px;
 }
 
-.no-bounce-scrollbar {
-  overflow: hidden;
-}
-
 .error-row {
   display: flex;
   flex-direction: row;

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-member-group-dialog/add-member-group-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-member-group-dialog/add-member-group-dialog.component.html
@@ -1,35 +1,37 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_MEMBER_GROUP.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div class="dialog-container" mat-dialog-content>
-    <perun-web-apps-immediate-filter
-      (filter)="applyFilter($event)"
-      *ngIf="!loading"
-      [placeholder]="'DIALOGS.ADD_MEMBER_GROUP.FILTER'">
-    </perun-web-apps-immediate-filter>
-    <perun-web-apps-groups-list
-      *ngIf="!loading"
-      [disableGroups]="true"
-      [disableMembers]="true"
-      [displayedColumns]="['select', 'id', 'name', 'description']"
-      [groupsToDisableCheckbox]="membersGroups"
-      [disableRouting]="true"
-      [groups]="groups"
-      [filter]="filterValue"
-      [selection]="selection">
-    </perun-web-apps-groups-list>
-  </div>
-  <div *ngIf="!loading" mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.ADD_MEMBER_GROUP.CANCEL' | translate}}
-    </button>
-    <button
-      [disabled]="selection.selected.length === 0"
-      (click)="onAdd()"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.ADD_MEMBER_GROUP.ADD' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_MEMBER_GROUP.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <perun-web-apps-immediate-filter
+        (filter)="applyFilter($event)"
+        [placeholder]="'DIALOGS.ADD_MEMBER_GROUP.FILTER'">
+      </perun-web-apps-immediate-filter>
+      <perun-web-apps-groups-list
+        [disableGroups]="true"
+        [disableMembers]="true"
+        [displayedColumns]="['select', 'id', 'name', 'description']"
+        [groupsToDisableCheckbox]="membersGroups"
+        [disableRouting]="true"
+        [groups]="groups"
+        [filter]="filterValue"
+        [selection]="selection">
+      </perun-web-apps-groups-list>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ADD_MEMBER_GROUP.CANCEL' | translate}}
+      </button>
+      <button
+        [disabled]="selection.selected.length === 0"
+        (click)="onAdd()"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.ADD_MEMBER_GROUP.ADD' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-member-to-resource-dialog/add-member-to-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-member-to-resource-dialog/add-member-to-resource-dialog.component.html
@@ -1,14 +1,15 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_MEMBER_TO_RESOURCE.TITLE' | translate}}</h1>
-  <div class="dialog-container" mat-dialog-content>
-    <mat-stepper [linear]="true">
-      <mat-step completed="false">
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.ADD_MEMBER_TO_RESOURCE.SELECT_RESOURCE' | translate}}</ng-template
-        >
-        <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-        <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_MEMBER_TO_RESOURCE.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-stepper [linear]="true">
+        <mat-step completed="false">
+          <ng-template matStepLabel>
+            {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.SELECT_RESOURCE' | translate}}
+          </ng-template>
           <div class="input-style">
             <perun-web-apps-facility-search-select
               (facilitySelected)="filterResources($event.name); stepper.selected.completed = true"
@@ -45,60 +46,63 @@
             >
             <div *ngFor="let service of services" class="ml-5">{{service.name}}</div>
           </div>
-        </div>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.ADD_MEMBER_TO_RESOURCE.ADD_GROUP' | translate}}</ng-template
-        >
-        <mat-spinner *ngIf="processing" class="mr-auto ml-auto"></mat-spinner>
-        <div *ngIf="groups.length !== 0 && !processing">
-          <perun-web-apps-groups-list
-            [disableGroups]="true"
-            [disableHeadCheckbox]="true"
-            [disableRouting]="true"
-            [groupsToDisableCheckbox]="membersGroupsId"
-            [groups]="groups"
-            [displayedColumns]="['select', 'id', 'name', 'description']"
-            [selection]="selectedGroups">
-          </perun-web-apps-groups-list>
-        </div>
-        <perun-web-apps-alert *ngIf="groups.length === 0 && !processing" alert_type="warn">
-          {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.NO_GROUPS' | translate}}
-        </perun-web-apps-alert>
-      </mat-step>
-    </mat-stepper>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" mat-flat-button>
-      {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="stepperPrevious()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
-      class="ml-auto"
-      mat-flat-button>
-      {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.BACK' | translate}}
-    </button>
-    <button
-      (click)="stepperNext(); loadGroups()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
-      [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
-      [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
-      [disabled]="selectedResource === null || processing || loading"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.CONTINUE' | translate}}
-    </button>
-    <button
-      (click)="onFinish()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
-      [disabled]="selectedGroups.selected.length === 0 || processing"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.SUBMIT' | translate}}
-    </button>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.ADD_MEMBER_TO_RESOURCE.ADD_GROUP' | translate}}</ng-template
+          >
+          <ng-template #spinner>
+            <perun-web-apps-loading-table></perun-web-apps-loading-table>
+          </ng-template>
+          <div class="position-relative">
+            <perun-web-apps-groups-list
+              *perunWebAppsLoader="processing; indicator: spinner"
+              [disableGroups]="true"
+              [disableHeadCheckbox]="true"
+              [disableRouting]="true"
+              [groupsToDisableCheckbox]="membersGroupsId"
+              [groups]="groups"
+              [displayedColumns]="['select', 'id', 'name', 'description']"
+              [selection]="selectedGroups">
+            </perun-web-apps-groups-list>
+          </div>
+          <perun-web-apps-alert *ngIf="groups.length === 0 && !processing" alert_type="warn">
+            {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.NO_GROUPS' | translate}}
+          </perun-web-apps-alert>
+        </mat-step>
+      </mat-stepper>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" mat-flat-button>
+        {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="stepperPrevious()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
+        class="ml-auto"
+        mat-flat-button>
+        {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.BACK' | translate}}
+      </button>
+      <button
+        (click)="stepperNext(); loadGroups()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
+        [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
+        [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
+        [disabled]="selectedResource === null || processing || loading"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.CONTINUE' | translate}}
+      </button>
+      <button
+        (click)="onFinish()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
+        [disabled]="selectedGroups.selected.length === 0 || processing"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.ADD_MEMBER_TO_RESOURCE.SUBMIT' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-member-to-resource-dialog/add-member-to-resource-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-member-to-resource-dialog/add-member-to-resource-dialog.component.ts
@@ -118,18 +118,18 @@ export class AddMemberToResourceDialogComponent implements OnInit, AfterViewInit
   }
 
   onFinish(): void {
-    this.processing = true;
+    this.loading = true;
     const groupId = this.selectedGroups.selected[0].id;
 
-    this.groupManager.addMembers(groupId, [this.data.memberId]).subscribe(
-      () => {
+    this.groupManager.addMembers(groupId, [this.data.memberId]).subscribe({
+      next: () => {
         this.notificator.showSuccess(
           this.translate.instant('DIALOGS.ADD_MEMBER_TO_RESOURCE.SUCCESS') as string
         );
         this.dialogRef.close(true);
       },
-      () => (this.processing = false)
-    );
+      error: () => (this.loading = false),
+    });
   }
 
   onCancel(): void {
@@ -161,11 +161,13 @@ export class AddMemberToResourceDialogComponent implements OnInit, AfterViewInit
 
   private getResourceFacilities(): void {
     const distinctFacilities = new Set<string>();
+    const facilitiesToAdd: Facility[] = [];
     for (const resource of this.resources) {
       distinctFacilities.add(resource.facility.name);
-      if (this.facilities.length !== distinctFacilities.size) {
-        this.facilities.push(resource.facility);
+      if (facilitiesToAdd.length !== distinctFacilities.size) {
+        facilitiesToAdd.push(resource.facility);
       }
     }
+    this.facilities = facilitiesToAdd;
   }
 }

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-required-attributes-dialog/add-required-attributes-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-required-attributes-dialog/add-required-attributes-dialog.component.html
@@ -1,36 +1,40 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_REQUIRED_ATTRIBUTES.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content class="dialog-container">
-    <perun-web-apps-alert
-      *ngIf="serviceEnabled$ | async"
-      [alert_type]="'warn'"
-      >{{'DIALOGS.ADD_REQUIRED_ATTRIBUTES.ACTIVE_WARN' | translate}}</perun-web-apps-alert
-    >
-    <perun-web-apps-immediate-filter
-      (filter)="applyFilter($event)"
-      [placeholder]="'DIALOGS.ADD_REQUIRED_ATTRIBUTES.FILTER'">
-    </perun-web-apps-immediate-filter>
-    <app-attr-def-list
-      [selection]="selection"
-      [definitions]="attrDefinitions"
-      [disableRouting]="true"
-      [filterValue]="filterValue"
-      [serviceEnabled]="serviceEnabled$ | async"
-      [consentRequired]="consentRequired$ | async">
-    </app-attr-def-list>
-  </div>
-  <div *ngIf="!loading" mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.ADD_REQUIRED_ATTRIBUTES.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onAdd()"
-      class="ml-2"
-      color="accent"
-      [disabled]="selection.selected.length === 0"
-      mat-flat-button>
-      {{'DIALOGS.ADD_REQUIRED_ATTRIBUTES.ADD' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_REQUIRED_ATTRIBUTES.TITLE' | translate}}</h1>
+    <div mat-dialog-content class="dialog-container">
+      <perun-web-apps-alert
+        *ngIf="serviceEnabled$ | async"
+        [alert_type]="'warn'"
+        >{{'DIALOGS.ADD_REQUIRED_ATTRIBUTES.ACTIVE_WARN' | translate}}</perun-web-apps-alert
+      >
+      <perun-web-apps-immediate-filter
+        (filter)="applyFilter($event)"
+        [placeholder]="'DIALOGS.ADD_REQUIRED_ATTRIBUTES.FILTER'">
+      </perun-web-apps-immediate-filter>
+      <app-attr-def-list
+        [selection]="selection"
+        [definitions]="attrDefinitions"
+        [disableRouting]="true"
+        [filterValue]="filterValue"
+        [serviceEnabled]="serviceEnabled$ | async"
+        [consentRequired]="consentRequired$ | async">
+      </app-attr-def-list>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ADD_REQUIRED_ATTRIBUTES.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onAdd()"
+        class="ml-2"
+        color="accent"
+        [disabled]="selection.selected.length === 0"
+        mat-flat-button>
+        {{'DIALOGS.ADD_REQUIRED_ATTRIBUTES.ADD' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-resource-tag-to-resource-dialog/add-resource-tag-to-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-resource-tag-to-resource-dialog/add-resource-tag-to-resource-dialog.component.html
@@ -2,18 +2,20 @@
   <h1 mat-dialog-title>{{'RESOURCE_DETAIL.TAGS.ADD_TAGS' | translate}}</h1>
 
   <div mat-dialog-content>
-    <div class="overflow-hidden">
-      <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
+    <div class="position-relative">
+      <app-resources-tags-list
+        *perunWebAppsLoader="loading; indicator: spinner"
+        [selection]="selection"
+        [displayedColumns]="displayedColumns"
+        [entity]="'resource'"
+        [filterValue]="filterValue"
+        [resourceTags]="resourceTags"
+        [tableId]="tableId">
+      </app-resources-tags-list>
     </div>
-    <app-resources-tags-list
-      *ngIf="!loading"
-      [selection]="selection"
-      [displayedColumns]="displayedColumns"
-      [entity]="'resource'"
-      [filterValue]="filterValue"
-      [resourceTags]="resourceTags"
-      [tableId]="tableId">
-    </app-resources-tags-list>
   </div>
 
   <div mat-dialog-actions>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-role-dialog/add-role-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-role-dialog/add-role-dialog.component.html
@@ -1,67 +1,65 @@
-<div class="{{theme}}">
-  <div mat-dialog-title>
-    <h1 mat-dialog-title>{{'DIALOGS.ADD_ROLE.TITLE' | translate}}</h1>
-  </div>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content class="dialog-container">
-    <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-    <perun-web-apps-role-search-select [roles]="rules" (roleSelected)="resetSelection($event)">
-    </perun-web-apps-role-search-select>
-    <perun-web-apps-immediate-filter
-      *ngIf="selectedRule?.primaryObject"
-      (filter)="filterValue = $event"
-      [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_OBJECTS_LIST.FILTER'"
-      class="font-size-1rem"></perun-web-apps-immediate-filter>
-    <perun-web-apps-vos-list
-      [filterValue]="filterValue"
-      *ngIf="!loading && selectedRule?.primaryObject === 'Vo'"
-      [vos]="vos | manageableEntities: selectedRule | unassignedRole: roles : selectedRule"
-      [displayedColumns]="['checkbox', 'id', 'shortName', 'name']"
-      [selection]="selected"
-      [disableRouting]="true">
-    </perun-web-apps-vos-list>
-    <perun-web-apps-groups-list
-      *ngIf="!loading && selectedRule?.primaryObject === 'Group'"
-      [groups]="groups | manageableEntities: selectedRule | unassignedRole: roles : selectedRule"
-      [displayedColumns]="['select', 'id', 'vo', 'name', 'description']"
-      [selection]="selected"
-      [filter]="filterValue"
-      [disableRouting]="true">
-    </perun-web-apps-groups-list>
-    <perun-web-apps-facilities-list
-      [filterValue]="filterValue"
-      *ngIf="!loading && selectedRule?.primaryObject === 'Facility'"
-      [facilities]="facilities | extractFacility | manageableEntities: selectedRule | unassignedRole: roles : selectedRule | toEnrichedFacility"
-      [displayedColumns]="['select', 'id', 'name', 'description']"
-      [selection]="selectedFacilities"
-      [disableRouting]="true">
-    </perun-web-apps-facilities-list>
-    <perun-web-apps-resources-list
-      [filterValue]="filterValue"
-      *ngIf="!loading && selectedRule?.primaryObject === 'Resource'"
-      [resources]="resources | manageableEntities: selectedRule | unassignedRole: roles : selectedRule"
-      [displayedColumns]="['select', 'id', 'name']"
-      [selection]="selected"
-      [disableRouting]="true">
-    </perun-web-apps-resources-list>
-  </div>
-  <div *ngIf="!loading" mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.ADD_ROLE.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="addRole()"
-      [disabled]="selectedRule === null || ((selectedRule.primaryObject === 'Facility' && selectedFacilities.isEmpty())
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <div mat-dialog-title>
+      <h1 mat-dialog-title>{{'DIALOGS.ADD_ROLE.TITLE' | translate}}</h1>
+    </div>
+    <div mat-dialog-content class="dialog-container">
+      <perun-web-apps-role-search-select [roles]="rules" (roleSelected)="resetSelection($event)">
+      </perun-web-apps-role-search-select>
+      <perun-web-apps-immediate-filter
+        *ngIf="selectedRule?.primaryObject"
+        (filter)="filterValue = $event"
+        [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_OBJECTS_LIST.FILTER'"
+        class="font-size-1rem"></perun-web-apps-immediate-filter>
+      <perun-web-apps-vos-list
+        [filterValue]="filterValue"
+        *ngIf="selectedRule?.primaryObject === 'Vo'"
+        [vos]="vos | manageableEntities: selectedRule | unassignedRole: roles : selectedRule"
+        [displayedColumns]="['checkbox', 'id', 'shortName', 'name']"
+        [selection]="selected"
+        [disableRouting]="true">
+      </perun-web-apps-vos-list>
+      <perun-web-apps-groups-list
+        *ngIf="selectedRule?.primaryObject === 'Group'"
+        [groups]="groups | manageableEntities: selectedRule | unassignedRole: roles : selectedRule"
+        [displayedColumns]="['select', 'id', 'vo', 'name', 'description']"
+        [selection]="selected"
+        [filter]="filterValue"
+        [disableRouting]="true">
+      </perun-web-apps-groups-list>
+      <perun-web-apps-facilities-list
+        [filterValue]="filterValue"
+        *ngIf="selectedRule?.primaryObject === 'Facility'"
+        [facilities]="facilities | extractFacility | manageableEntities: selectedRule | unassignedRole: roles : selectedRule | toEnrichedFacility"
+        [displayedColumns]="['select', 'id', 'name', 'description']"
+        [selection]="selectedFacilities"
+        [disableRouting]="true">
+      </perun-web-apps-facilities-list>
+      <perun-web-apps-resources-list
+        [filterValue]="filterValue"
+        *ngIf="selectedRule?.primaryObject === 'Resource'"
+        [resources]="resources | manageableEntities: selectedRule | unassignedRole: roles : selectedRule"
+        [displayedColumns]="['select', 'id', 'name']"
+        [selection]="selected"
+        [disableRouting]="true">
+      </perun-web-apps-resources-list>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ADD_ROLE.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="addRole()"
+        [disabled]="selectedRule === null || ((selectedRule.primaryObject === 'Facility' && selectedFacilities.isEmpty())
         || (selectedRule.primaryObject && selectedRule.primaryObject !== 'Facility' && selected.isEmpty()))"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.ADD_ROLE.ADD' | translate}}
-    </button>
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.ADD_ROLE.ADD' | translate}}
+      </button>
+    </div>
   </div>
 </div>
-<ng-template #spinner>
-  <div class="spinner-container">
-    <mat-spinner></mat-spinner>
-  </div>
-</ng-template>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-services-destination-dialog/add-services-destination-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-services-destination-dialog/add-services-destination-dialog.component.html
@@ -1,90 +1,94 @@
-<div class="{{data.theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_SERVICE_DESTINATION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <div class="font-italic">{{'DIALOGS.ADD_SERVICE_DESTINATION.DESCRIPTION' | translate}}</div>
-    <mat-form-field>
-      <mat-select
-        [formControl]="serviceControl"
-        placeholder="{{'DIALOGS.ADD_SERVICE_DESTINATION.SERVICE' | translate}}"
-        required>
-        <mat-option
-          *ngIf="services.length !== 0"
-          value="all"
-          >{{'DIALOGS.ADD_SERVICE_DESTINATION.SELECTION_ALL' | translate}}</mat-option
-        >
-        <mat-option
-          *ngIf="services.length === 0"
-          value="noService"
-          >{{'DIALOGS.ADD_SERVICE_DESTINATION.NO_SERVICE' | translate}}</mat-option
-        >
-        <mat-option *ngFor="let service of services" [value]="service">
-          {{service.name}}
-        </mat-option>
-      </mat-select>
-      <mat-error *ngIf="serviceControl.value === undefined">
-        {{'DIALOGS.ADD_SERVICE_DESTINATION.CHOOSE_SERVICE' | translate}}
-      </mat-error>
-    </mat-form-field>
-    <mat-checkbox
-      (change)="getServices()"
-      [(ngModel)]="servicesOnFacility"
-      >{{'DIALOGS.ADD_SERVICE_DESTINATION.IS_SERVICES_ONLY_ON_FACILITY' | translate}}</mat-checkbox
-    >
-    <mat-form-field>
-      <mat-select
-        [(ngModel)]="selectedType"
-        (selectionChange)="this.destinationControl.updateValueAndValidity()"
-        placeholder="{{'DIALOGS.ADD_SERVICE_DESTINATION.TYPE' | translate}}">
-        <mat-option *ngFor="let type of types" [value]="type">
-          {{getTypeForView(type)}}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{data.theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_SERVICE_DESTINATION.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <div class="font-italic">{{'DIALOGS.ADD_SERVICE_DESTINATION.DESCRIPTION' | translate}}</div>
+      <mat-form-field>
+        <mat-select
+          [formControl]="serviceControl"
+          placeholder="{{'DIALOGS.ADD_SERVICE_DESTINATION.SERVICE' | translate}}"
+          required>
+          <mat-option
+            *ngIf="services.length !== 0"
+            value="all"
+            >{{'DIALOGS.ADD_SERVICE_DESTINATION.SELECTION_ALL' | translate}}</mat-option
+          >
+          <mat-option
+            *ngIf="services.length === 0"
+            value="noService"
+            >{{'DIALOGS.ADD_SERVICE_DESTINATION.NO_SERVICE' | translate}}</mat-option
+          >
+          <mat-option *ngFor="let service of services" [value]="service">
+            {{service.name}}
+          </mat-option>
+        </mat-select>
+        <mat-error *ngIf="serviceControl.value === undefined">
+          {{'DIALOGS.ADD_SERVICE_DESTINATION.CHOOSE_SERVICE' | translate}}
+        </mat-error>
+      </mat-form-field>
+      <mat-checkbox
+        (change)="getServices()"
+        [(ngModel)]="servicesOnFacility"
+        >{{'DIALOGS.ADD_SERVICE_DESTINATION.IS_SERVICES_ONLY_ON_FACILITY' | translate}}</mat-checkbox
+      >
+      <mat-form-field>
+        <mat-select
+          [(ngModel)]="selectedType"
+          (selectionChange)="this.destinationControl.updateValueAndValidity()"
+          placeholder="{{'DIALOGS.ADD_SERVICE_DESTINATION.TYPE' | translate}}">
+          <mat-option *ngFor="let type of types" [value]="type">
+            {{getTypeForView(type)}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
 
-    <mat-form-field *ngIf="!(selectedType === 'host' && useFacilityHost)" class="w-100">
-      <input
-        [formControl]="destinationControl"
-        matInput
-        placeholder="{{getTypeForView(selectedType)}}"
-        required />
-      <mat-error
-        *ngIf="selectedType === 'host' && !useFacilityHost && destinationControl.hasError('required')">
-        {{'DIALOGS.ADD_SERVICE_DESTINATION.REQUIRED_FIELD' | translate}}
-      </mat-error>
-      <mat-error *ngIf="destinationControl.hasError('invalidDestination')">
-        {{'DIALOGS.ADD_SERVICE_DESTINATION.INVALID_DESTINATION' | translate}}
-      </mat-error>
-    </mat-form-field>
+      <mat-form-field *ngIf="!(selectedType === 'host' && useFacilityHost)" class="w-100">
+        <input
+          [formControl]="destinationControl"
+          matInput
+          placeholder="{{getTypeForView(selectedType)}}"
+          required />
+        <mat-error
+          *ngIf="selectedType === 'host' && !useFacilityHost && destinationControl.hasError('required')">
+          {{'DIALOGS.ADD_SERVICE_DESTINATION.REQUIRED_FIELD' | translate}}
+        </mat-error>
+        <mat-error *ngIf="destinationControl.hasError('invalidDestination')">
+          {{'DIALOGS.ADD_SERVICE_DESTINATION.INVALID_DESTINATION' | translate}}
+        </mat-error>
+      </mat-form-field>
 
-    <mat-checkbox *ngIf="selectedType === 'host'" [(ngModel)]="useFacilityHost">
-      {{'DIALOGS.ADD_SERVICE_DESTINATION.USE_FACILITY_HOST' | translate}}
-    </mat-checkbox>
+      <mat-checkbox *ngIf="selectedType === 'host'" [(ngModel)]="useFacilityHost">
+        {{'DIALOGS.ADD_SERVICE_DESTINATION.USE_FACILITY_HOST' | translate}}
+      </mat-checkbox>
 
-    <mat-form-field>
-      <mat-select
-        [(ngModel)]="selectedPropagation"
-        placeholder="{{'DIALOGS.ADD_SERVICE_DESTINATION.PROPAGATION' | translate}}">
-        <mat-option *ngFor="let propagation of propagations" [value]="propagation">
-          {{propagation}}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <div class="font-italic">
-      {{'DIALOGS.ADD_SERVICE_DESTINATION.PROPAGATION_TYPE_' + selectedPropagation | translate}}
+      <mat-form-field>
+        <mat-select
+          [(ngModel)]="selectedPropagation"
+          placeholder="{{'DIALOGS.ADD_SERVICE_DESTINATION.PROPAGATION' | translate}}">
+          <mat-option *ngFor="let propagation of propagations" [value]="propagation">
+            {{propagation}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <div class="font-italic">
+        {{'DIALOGS.ADD_SERVICE_DESTINATION.PROPAGATION_TYPE_' + selectedPropagation | translate}}
+      </div>
     </div>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.ADD_SERVICE_DESTINATION.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      [disabled]="loading || invalidDestination() || serviceControl.invalid || serviceControl.value === 'noService'"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.ADD_SERVICE_DESTINATION.ADD' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ADD_SERVICE_DESTINATION.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        [disabled]="loading || invalidDestination() || serviceControl.invalid || serviceControl.value === 'noService'"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.ADD_SERVICE_DESTINATION.ADD' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-user-ext-source-dialog/add-user-ext-source-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-user-ext-source-dialog/add-user-ext-source-dialog.component.html
@@ -1,46 +1,50 @@
-<h1 mat-dialog-title>{{'DIALOGS.ADD_USER_EXT_SOURCE.TITLE'|translate}}</h1>
-<div class="dialog-container user-theme" mat-dialog-content>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading">
-    <mat-form-field class="center-self w-100">
-      <input
-        [formControl]="loginControl"
-        matInput
-        placeholder="{{'DIALOGS.ADD_USER_EXT_SOURCE.LOGIN' | translate}}"
-        required />
-      <mat-error>
-        {{'DIALOGS.ADD_USER_EXT_SOURCE.EMPTY_LOGIN' | translate}}
-      </mat-error>
-    </mat-form-field>
-    <mat-form-field class="center-self w-100">
-      <input
-        [formControl]="extSourcesControl"
-        [matAutocomplete]="auto"
-        matInput
-        placeholder="{{'DIALOGS.ADD_USER_EXT_SOURCE.EXT_SOURCE' | translate}}"
-        required
-        type="text" />
-      <mat-error>
-        {{'DIALOGS.ADD_USER_EXT_SOURCE.EMPTY_EXT_SOURCE' | translate}}
-      </mat-error>
-      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
-        <mat-option *ngFor="let extSource of filteredExtSources | async" [value]="extSource">
-          {{extSource.name}}
-        </mat-option>
-      </mat-autocomplete>
-    </mat-form-field>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_USER_EXT_SOURCE.TITLE'|translate}}</h1>
+    <div class="dialog-container user-theme" mat-dialog-content>
+      <mat-form-field class="center-self w-100">
+        <input
+          [formControl]="loginControl"
+          matInput
+          placeholder="{{'DIALOGS.ADD_USER_EXT_SOURCE.LOGIN' | translate}}"
+          required />
+        <mat-error>
+          {{'DIALOGS.ADD_USER_EXT_SOURCE.EMPTY_LOGIN' | translate}}
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="center-self w-100">
+        <input
+          [formControl]="extSourcesControl"
+          [matAutocomplete]="auto"
+          matInput
+          placeholder="{{'DIALOGS.ADD_USER_EXT_SOURCE.EXT_SOURCE' | translate}}"
+          required
+          type="text" />
+        <mat-error>
+          {{'DIALOGS.ADD_USER_EXT_SOURCE.EMPTY_EXT_SOURCE' | translate}}
+        </mat-error>
+        <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
+          <mat-option *ngFor="let extSource of filteredExtSources | async" [value]="extSource">
+            {{extSource.name}}
+          </mat-option>
+        </mat-autocomplete>
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ADD_USER_EXT_SOURCE.CANCEL'|translate}}
+      </button>
+      <button
+        (click)="onAdd()"
+        [disabled]="loginControl.invalid || extSourcesControl.invalid || loading"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.ADD_USER_EXT_SOURCE.ADD'|translate}}
+      </button>
+    </div>
   </div>
-</div>
-<div mat-dialog-actions>
-  <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-    {{'DIALOGS.ADD_USER_EXT_SOURCE.CANCEL'|translate}}
-  </button>
-  <button
-    (click)="onAdd()"
-    [disabled]="loginControl.invalid || extSourcesControl.invalid || loading"
-    class="ml-2"
-    color="accent"
-    mat-flat-button>
-    {{'DIALOGS.ADD_USER_EXT_SOURCE.ADD'|translate}}
-  </button>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-vo-ban-dialog/add-vo-ban-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-vo-ban-dialog/add-vo-ban-dialog.component.html
@@ -8,13 +8,20 @@
   <perun-web-apps-debounce-filter
     (filter)="setFilter($event)"
     [placeholder]="'DIALOGS.ADD_BAN.FILTER'"></perun-web-apps-debounce-filter>
-  <perun-web-apps-members-dynamic-list
-    [attrNames]="attrNames"
-    [selection]="selection"
-    [tableId]="tableId"
-    [disableRouting]="true"
-    [displayedColumns]="displayedColumns"
-    [searchString]="filter"
-    [voId]="data.entityId">
-  </perun-web-apps-members-dynamic-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-members-dynamic-list
+      *perunWebAppsLoader="loading$ | async; indicator: spinner"
+      (loading$)="loading$ = $event"
+      [attrNames]="attrNames"
+      [selection]="selection"
+      [tableId]="tableId"
+      [disableRouting]="true"
+      [displayedColumns]="displayedColumns"
+      [searchString]="filter"
+      [voId]="data.entityId">
+    </perun-web-apps-members-dynamic-list>
+  </div>
 </app-add-ban-dialog>

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-vo-ban-dialog/add-vo-ban-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-vo-ban-dialog/add-vo-ban-dialog.component.ts
@@ -6,6 +6,7 @@ import { Urns } from '@perun-web-apps/perun/urns';
 import { TABLE_BANS } from '@perun-web-apps/config/table-config';
 import { NotificatorService, StoreService } from '@perun-web-apps/perun/services';
 import { AddBanData, BanForm } from '../add-ban-dialog/add-ban-dialog.component';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'app-add-vo-ban-dialog',
@@ -22,6 +23,7 @@ export class AddVoBanDialogComponent implements OnInit {
   displayedColumns = ['checkbox', 'id', 'fullName', 'email', 'logins'];
   tableId = TABLE_BANS;
   filter = '';
+  loading$: Observable<boolean> = of(true);
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: AddBanData<BanOnVo>,

--- a/apps/admin-gui/src/app/shared/components/dialogs/application-form-copy-items-dialog/application-form-copy-items-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/application-form-copy-items-dialog/application-form-copy-items-dialog.component.html
@@ -1,39 +1,43 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div [hidden]="loading" class="dialog-container" mat-dialog-content>
-    <div class="mb-2 font-italic">
-      {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.DESCRIPTION' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <div class="mb-2 font-italic">
+        {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.DESCRIPTION' | translate}}
+      </div>
+      {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.SOURCE_VO' | translate}}:
+
+      <perun-web-apps-vo-search-select
+        (voSelected)="voSelected($event)"
+        [vos]="vos"
+        class="long-input">
+      </perun-web-apps-vo-search-select>
+
+      {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.SOURCE_GROUP' | translate}}:
+
+      <perun-web-apps-group-search-select
+        (groupSelected)="selectedGroup = ($event)"
+        [groups]="groups"
+        [disableAutoSelect]="true"
+        class="long-input">
+      </perun-web-apps-group-search-select>
     </div>
-    {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.SOURCE_VO' | translate}}:
 
-    <perun-web-apps-vo-search-select
-      (voSelected)="voSelected($event)"
-      [vos]="vos"
-      class="long-input">
-    </perun-web-apps-vo-search-select>
-
-    {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.SOURCE_GROUP' | translate}}:
-
-    <perun-web-apps-group-search-select
-      (groupSelected)="selectedGroup = ($event)"
-      [groups]="groups"
-      [disableAutoSelect]="true"
-      class="long-input">
-    </perun-web-apps-group-search-select>
-  </div>
-
-  <div mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.CANCEL_BUTTON' | translate}}
-    </button>
-    <button
-      (click)="submit()"
-      class="ml-2"
-      color="accent"
-      [disabled]="(!selectedVo && !selectedGroup) || loading"
-      mat-flat-button>
-      {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.SUBMIT_BUTTON' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.CANCEL_BUTTON' | translate}}
+      </button>
+      <button
+        (click)="submit()"
+        class="ml-2"
+        color="accent"
+        [disabled]="(!selectedVo && !selectedGroup) || loading"
+        mat-flat-button>
+        {{'DIALOGS.APPLICATION_FORM_COPY_ITEMS.SUBMIT_BUTTON' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/application-re-send-notification-dialog/application-re-send-notification-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/application-re-send-notification-dialog/application-re-send-notification-dialog.component.html
@@ -1,55 +1,59 @@
-<div class="{{theme}}}">
-  <h1 mat-dialog-title>{{'DIALOGS.RE_SEND_NOTIFICATION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    {{'DIALOGS.RE_SEND_NOTIFICATION.SELECT' | translate}}:
-    <mat-form-field class="w-100">
-      <mat-select [(value)]="mailType" disableOptionCentering>
-        <mat-option
-          value="APP_CREATED_USER"
-          >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_CREATED_USER' | translate}}</mat-option
-        >
-        <mat-option
-          *ngIf="data.groupId"
-          value="APPROVABLE_GROUP_APP_USER"
-          >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APPROVABLE_GROUP_APP_USER' | translate}}</mat-option
-        >
-        <mat-option
-          value="APP_CREATED_VO_ADMIN"
-          >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_CREATED_VO_ADMIN' | translate}}</mat-option
-        >
-        <mat-option
-          value="MAIL_VALIDATION"
-          >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.MAIL_VALIDATION' | translate}}</mat-option
-        >
-        <mat-option
-          value="APP_APPROVED_USER"
-          >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_APPROVED_USER' | translate}}</mat-option
-        >
-        <mat-option
-          value="APP_REJECTED_USER"
-          >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_REJECTED_USER' | translate}}</mat-option
-        >
-        <mat-option
-          value="APP_ERROR_VO_ADMIN"
-          >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_ERROR_VO_ADMIN' | translate}}</mat-option
-        >
-      </mat-select>
-    </mat-form-field>
-
-    <div *ngIf="mailType === 'APP_REJECTED_USER'">
-      {{'DIALOGS.RE_SEND_NOTIFICATION.REASON' | translate}}:
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.RE_SEND_NOTIFICATION.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      {{'DIALOGS.RE_SEND_NOTIFICATION.SELECT' | translate}}:
       <mat-form-field class="w-100">
-        <textarea [(ngModel)]="reason" matInput></textarea>
+        <mat-select [(value)]="mailType" disableOptionCentering>
+          <mat-option
+            value="APP_CREATED_USER"
+            >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_CREATED_USER' | translate}}</mat-option
+          >
+          <mat-option
+            *ngIf="data.groupId"
+            value="APPROVABLE_GROUP_APP_USER"
+            >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APPROVABLE_GROUP_APP_USER' | translate}}</mat-option
+          >
+          <mat-option
+            value="APP_CREATED_VO_ADMIN"
+            >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_CREATED_VO_ADMIN' | translate}}</mat-option
+          >
+          <mat-option
+            value="MAIL_VALIDATION"
+            >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.MAIL_VALIDATION' | translate}}</mat-option
+          >
+          <mat-option
+            value="APP_APPROVED_USER"
+            >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_APPROVED_USER' | translate}}</mat-option
+          >
+          <mat-option
+            value="APP_REJECTED_USER"
+            >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_REJECTED_USER' | translate}}</mat-option
+          >
+          <mat-option
+            value="APP_ERROR_VO_ADMIN"
+            >{{'DIALOGS.RE_SEND_NOTIFICATION.NOTIFICATION_TYPE.APP_ERROR_VO_ADMIN' | translate}}</mat-option
+          >
+        </mat-select>
       </mat-form-field>
+
+      <div *ngIf="mailType === 'APP_REJECTED_USER'">
+        {{'DIALOGS.RE_SEND_NOTIFICATION.REASON' | translate}}:
+        <mat-form-field class="w-100">
+          <textarea [(ngModel)]="reason" matInput></textarea>
+        </mat-form-field>
+      </div>
     </div>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.RE_SEND_NOTIFICATION.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="accent" mat-flat-button>
-      {{'DIALOGS.RE_SEND_NOTIFICATION.SEND' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.RE_SEND_NOTIFICATION.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="accent" mat-flat-button>
+        {{'DIALOGS.RE_SEND_NOTIFICATION.SEND' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/application-reject-dialog/application-reject-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/application-reject-dialog/application-reject-dialog.component.html
@@ -1,19 +1,23 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REJECT_APPLICATION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    {{'DIALOGS.REJECT_APPLICATION.TEXT' | translate}}
-    <mat-form-field class="w-100">
-      <textarea [(ngModel)]="reason" matInput></textarea>
-    </mat-form-field>
-  </div>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REJECT_APPLICATION.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      {{'DIALOGS.REJECT_APPLICATION.TEXT' | translate}}
+      <mat-form-field class="w-100">
+        <textarea [(ngModel)]="reason" matInput></textarea>
+      </mat-form-field>
+    </div>
 
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REJECT_APPLICATION.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REJECT_APPLICATION.SUBMIT' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REJECT_APPLICATION.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REJECT_APPLICATION.SUBMIT' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/applications-list-columns-change-dialog/applications-list-columns-change-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/applications-list-columns-change-dialog/applications-list-columns-change-dialog.component.html
@@ -1,36 +1,40 @@
-<h1 mat-dialog-title>{{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <perun-web-apps-alert alert_type="warn">
-      {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.WARN' | translate}}
-    </perun-web-apps-alert>
-    <mat-form-field class="w-100">
-      <mat-label
-        >{{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.FILTER_COLUMNS' | translate}}</mat-label
-      >
-      <mat-select
-        (closed)="attribute.value = selectedColumns.value"
-        [formControl]="selectedColumns"
-        multiple>
-        <mat-option class="{{theme}}" *ngFor="let column of columnOptions" [value]="column">
-          {{column | applicationColumnSelectLabel}}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <perun-web-apps-alert alert_type="info">
-      {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.DEFAULT_TEXT' | translate}}
-    </perun-web-apps-alert>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="cancel()" mat-flat-button>
-      {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.CANCEL' | translate}}
-    </button>
-    <button (click)="default()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.DEFAULT' | translate}}
-    </button>
-    <button (click)="confirm()" [disabled]="loading" class="ml-2" color="accent" mat-flat-button>
-      {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.CONFIRM' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <perun-web-apps-alert alert_type="warn">
+        {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.WARN' | translate}}
+      </perun-web-apps-alert>
+      <mat-form-field class="w-100">
+        <mat-label
+          >{{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.FILTER_COLUMNS' | translate}}</mat-label
+        >
+        <mat-select
+          (closed)="attribute.value = selectedColumns.value"
+          [formControl]="selectedColumns"
+          multiple>
+          <mat-option class="{{theme}}" *ngFor="let column of columnOptions" [value]="column">
+            {{column | applicationColumnSelectLabel}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <perun-web-apps-alert alert_type="info">
+        {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.DEFAULT_TEXT' | translate}}
+      </perun-web-apps-alert>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="cancel()" mat-flat-button>
+        {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.CANCEL' | translate}}
+      </button>
+      <button (click)="default()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.DEFAULT' | translate}}
+      </button>
+      <button (click)="confirm()" [disabled]="loading" class="ml-2" color="accent" mat-flat-button>
+        {{'DIALOGS.APPLICATIONS_LIST_COLUMNS_CHANGE.CONFIRM' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/assign-group-to-resource-dialog/assign-group-to-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/assign-group-to-resource-dialog/assign-group-to-resource-dialog.component.html
@@ -1,100 +1,104 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-stepper #stepper [linear]="true">
-      <mat-step [completed]="selection.selected.length !== 0 && canAddGroups()">
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.GROUPS' | translate}}</ng-template
-        >
-        <perun-web-apps-debounce-filter
-          (filter)="applyFilter($event)"
-          placeholder="{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.FILTER_DESCRIPTION' | translate}}">
-        </perun-web-apps-debounce-filter>
-        <perun-web-apps-groups-list
-          [disableMembers]="false"
-          [groups]="unAssignedGroups"
-          [selection]="selection"
-          [disableRouting]="true"
-          [displayedColumns]="['select', 'id', 'name', 'description']"
-          [filter]="filterValue"
-          [tableId]="tableId">
-        </perun-web-apps-groups-list>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.OPTIONS' | translate}}</ng-template
-        >
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.TITLE' | translate}}</h1>
+    <div *ngIf="unAssignedGroups" class="dialog-container" mat-dialog-content>
+      <mat-stepper #stepper [linear]="true">
+        <mat-step [completed]="selection.selected.length !== 0 && canAddGroups()">
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.GROUPS' | translate}}</ng-template
+          >
+          <perun-web-apps-debounce-filter
+            (filter)="applyFilter($event)"
+            placeholder="{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.FILTER_DESCRIPTION' | translate}}">
+          </perun-web-apps-debounce-filter>
+          <perun-web-apps-groups-list
+            [disableMembers]="false"
+            [groups]="unAssignedGroups"
+            [selection]="selection"
+            [disableRouting]="true"
+            [displayedColumns]="['select', 'id', 'name', 'description']"
+            [filter]="filterValue"
+            [tableId]="tableId">
+          </perun-web-apps-groups-list>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.OPTIONS' | translate}}</ng-template
+          >
 
-        <mat-slide-toggle
-          (toggleChange)="changeSubgroupsMessage()"
-          class="mt-3 slide-text"
-          [(ngModel)]="autoAssignSubgroups"
-          labelPosition="before">
-          {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.AUTO_SUBGROUPS' | translate}}
-        </mat-slide-toggle>
-        <div class="text-muted new-line mt-2">
-          <i [innerHTML]="autoAssignHint"></i>
-        </div>
+          <mat-slide-toggle
+            (toggleChange)="changeSubgroupsMessage()"
+            class="mt-3 slide-text"
+            [(ngModel)]="autoAssignSubgroups"
+            labelPosition="before">
+            {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.AUTO_SUBGROUPS' | translate}}
+          </mat-slide-toggle>
+          <div class="text-muted new-line mt-2">
+            <i [innerHTML]="autoAssignHint"></i>
+          </div>
 
-        <mat-slide-toggle
-          (toggleChange)="changeInactiveMessage()"
-          class="mt-3 slide-text"
-          [(ngModel)]="asActive"
-          labelPosition="before">
-          {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.AS_ACTIVE' | translate}}
-        </mat-slide-toggle>
-        <div class="text-muted new-line mt-2">
-          {{asActiveHint}}
-        </div>
+          <mat-slide-toggle
+            (toggleChange)="changeInactiveMessage()"
+            class="mt-3 slide-text"
+            [(ngModel)]="asActive"
+            labelPosition="before">
+            {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.AS_ACTIVE' | translate}}
+          </mat-slide-toggle>
+          <div class="text-muted new-line mt-2">
+            {{asActiveHint}}
+          </div>
 
-        <mat-slide-toggle
-          (toggleChange)="changeAsyncMessage()"
-          class="mt-3 slide-text"
-          [(ngModel)]="async"
-          labelPosition="before">
-          {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.ASYNC_OPT' | translate}}
-        </mat-slide-toggle>
-        <div class="text-muted new-line mt-2">
-          {{asyncHint}}
-        </div>
-      </mat-step>
-    </mat-stepper>
-  </div>
-  <div *ngIf="!loading && stepper" mat-dialog-actions>
-    <button (click)="onCancel()" mat-flat-button>
-      {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.CANCEL_BUTTON' | translate}}
-    </button>
-    <button
-      (click)="stepperPrevious()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
-      class="ml-auto"
-      mat-flat-button>
-      {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.BACK' | translate}}
-    </button>
-    <button
-      (click)="stepperNext()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
-      [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
-      [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
-      [disabled]="selection.selected.length === 0 || !canAddGroups()"
-      color="accent"
-      mat-flat-button
-      type="button"
-      data-cy="next-button">
-      {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.NEXT' | translate}}
-    </button>
-    <button
-      (click)="onAdd()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
-      class="ml-2"
-      color="accent"
-      mat-flat-button
-      type="button"
-      data-cy="assign-button">
-      {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.ADD_BUTTON' | translate}}
-    </button>
+          <mat-slide-toggle
+            (toggleChange)="changeAsyncMessage()"
+            class="mt-3 slide-text"
+            [(ngModel)]="async"
+            labelPosition="before">
+            {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.ASYNC_OPT' | translate}}
+          </mat-slide-toggle>
+          <div class="text-muted new-line mt-2">
+            {{asyncHint}}
+          </div>
+        </mat-step>
+      </mat-stepper>
+    </div>
+    <div *ngIf="stepper" mat-dialog-actions>
+      <button (click)="onCancel()" mat-flat-button>
+        {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.CANCEL_BUTTON' | translate}}
+      </button>
+      <button
+        (click)="stepperPrevious()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
+        class="ml-auto"
+        mat-flat-button>
+        {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.BACK' | translate}}
+      </button>
+      <button
+        (click)="stepperNext()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
+        [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
+        [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
+        [disabled]="selection.selected.length === 0 || !canAddGroups()"
+        color="accent"
+        mat-flat-button
+        type="button"
+        data-cy="next-button">
+        {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.NEXT' | translate}}
+      </button>
+      <button
+        (click)="onAdd()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
+        class="ml-2"
+        color="accent"
+        mat-flat-button
+        type="button"
+        data-cy="assign-button">
+        {{'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.ADD_BUTTON' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/assign-group-to-resource-dialog/assign-group-to-resource-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/assign-group-to-resource-dialog/assign-group-to-resource-dialog.component.ts
@@ -28,7 +28,7 @@ export class AssignGroupToResourceDialogComponent implements OnInit {
 
   loading = false;
   theme: string;
-  unAssignedGroups: Group[] = this.data.onlyAutoAssignedGroups;
+  unAssignedGroups: Group[] = null;
   async = true;
   autoAssignSubgroups = false;
   asActive = true;
@@ -64,10 +64,11 @@ export class AssignGroupToResourceDialogComponent implements OnInit {
     this.asyncHint = this.translate.instant(
       'DIALOGS.ASSIGN_GROUP_TO_RESOURCE.ASYNC_ON_HINT'
     ) as string;
-    this.resourceManager.getAssignedGroups(this.resource.id).subscribe(
-      (assignedGroups) => {
-        this.groupService.getAllGroups(this.resource.voId).subscribe(
-          (allGroups) => {
+    this.resourceManager.getAssignedGroups(this.resource.id).subscribe({
+      next: (assignedGroups) => {
+        this.groupService.getAllGroups(this.resource.voId).subscribe({
+          next: (allGroups) => {
+            this.unAssignedGroups = this.data.onlyAutoAssignedGroups;
             for (const allGroup of allGroups) {
               if (
                 assignedGroups.findIndex((item) => item.id === allGroup.id) === -1 &&
@@ -82,11 +83,11 @@ export class AssignGroupToResourceDialogComponent implements OnInit {
             this.loading = false;
             this.cd.detectChanges();
           },
-          () => (this.loading = false)
-        );
+          error: () => (this.loading = false),
+        });
       },
-      () => (this.loading = false)
-    );
+      error: () => (this.loading = false),
+    });
   }
 
   onCancel(): void {

--- a/apps/admin-gui/src/app/shared/components/dialogs/assign-service-to-resource-dialog/assign-service-to-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/assign-service-to-resource-dialog/assign-service-to-resource-dialog.component.html
@@ -1,56 +1,64 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <mat-tab-group (selectedTabChange)="tabChanged()">
-      <mat-tab label="{{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.SELECT_SERVICE' | translate}}">
-        <div class="mt-2">
-          <perun-web-apps-debounce-filter
-            (filter)="applyFilter($event)"
-            placeholder="{{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.FILTER_DESCRIPTION' | translate}}">
-          </perun-web-apps-debounce-filter>
-        </div>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <mat-tab-group (selectedTabChange)="tabChanged()">
+        <mat-tab
+          [disabled]="loading"
+          label="{{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.SELECT_SERVICE' | translate}}">
+          <div class="mt-2">
+            <perun-web-apps-debounce-filter
+              (filter)="applyFilter($event)"
+              placeholder="{{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.FILTER_DESCRIPTION' | translate}}">
+            </perun-web-apps-debounce-filter>
+          </div>
 
-        <app-services-list
-          [services]="unAssignedServices"
-          [disableRouting]="true"
-          [displayedColumns]="['select', 'id', 'name', 'enabled', 'description']"
-          [filterValue]="filterValue"
-          [selection]="selection"
-          [tableId]="tableId">
-        </app-services-list>
-      </mat-tab>
-      <mat-tab label="{{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.SELECT_PACKAGE' | translate}}">
-        <div class="mt-3">
-          <perun-web-apps-service-package-search-select
-            (packageSelected)="servicePackageSelected($event)"
-            [selectedPackage]="selectedPackage"
-            [servicePackages]="servicePackages">
-          </perun-web-apps-service-package-search-select>
-        </div>
+          <app-services-list
+            [services]="unAssignedServices"
+            [disableRouting]="true"
+            [displayedColumns]="['select', 'id', 'name', 'enabled', 'description']"
+            [filterValue]="filterValue"
+            [selection]="selection"
+            [tableId]="tableId">
+          </app-services-list>
+        </mat-tab>
+        <mat-tab
+          [disabled]="loading"
+          label="{{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.SELECT_PACKAGE' | translate}}">
+          <div class="mt-3">
+            <perun-web-apps-service-package-search-select
+              (packageSelected)="servicePackageSelected($event)"
+              [selectedPackage]="selectedPackage"
+              [servicePackages]="servicePackages">
+            </perun-web-apps-service-package-search-select>
+          </div>
 
-        <app-services-list
-          *ngIf="selectedPackage.id !== -1"
-          [disableRouting]="true"
-          [services]="filteredServices"
-          [displayedColumns]="['id', 'name', 'enabled', 'description']"
-          [selection]="selection"
-          [tableId]="tableId">
-        </app-services-list>
-      </mat-tab>
-    </mat-tab-group>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.CANCEL_BUTTON' | translate}}
-    </button>
-    <button
-      (click)="onAdd()"
-      class="ml-2"
-      color="accent"
-      [disabled]="(selection.selected.length === 0 && selectedPackage.id === -1) || loading"
-      mat-flat-button>
-      {{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.'+(selectedPackage.id === -1 ? 'ADD_SERVICES' : 'ADD_PACKAGE') | translate}}
-    </button>
+          <app-services-list
+            *ngIf="selectedPackage.id !== -1"
+            [disableRouting]="true"
+            [services]="filteredServices"
+            [displayedColumns]="['id', 'name', 'enabled', 'description']"
+            [selection]="selection"
+            [tableId]="tableId">
+          </app-services-list>
+        </mat-tab>
+      </mat-tab-group>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.CANCEL_BUTTON' | translate}}
+      </button>
+      <button
+        (click)="onAdd()"
+        class="ml-2"
+        color="accent"
+        [disabled]="(selection.selected.length === 0 && selectedPackage.id === -1) || loading"
+        mat-flat-button>
+        {{'DIALOGS.ASSIGN_SERVICE_TO_RESOURCE.'+(selectedPackage.id === -1 ? 'ADD_SERVICES' : 'ADD_PACKAGE') | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/attribute-import-dialog/attribute-import-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/attribute-import-dialog/attribute-import-dialog.component.html
@@ -1,31 +1,35 @@
-<div class="admin-theme">
-  <h1 mat-dialog-title>
-    {{'DIALOGS.IMPORT_ATTRIBUTE.TITLE' | translate}}
-  </h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <perun-web-apps-alert alert_type="info">
-      {{'DIALOGS.IMPORT_ATTRIBUTE.INFO' | translate}}
-    </perun-web-apps-alert>
-    <mat-form-field class="w-100">
-      <input
-        matInput
-        [(ngModel)]="value"
-        [placeholder]="'DIALOGS.IMPORT_ATTRIBUTE.HINT' | translate"
-        required />
-    </mat-form-field>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="dialogRef.close()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.IMPORT_ATTRIBUTE.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="create()"
-      [disabled]="value.trim().length === 0 || loading"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.IMPORT_ATTRIBUTE.CREATE' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="admin-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>
+      {{'DIALOGS.IMPORT_ATTRIBUTE.TITLE' | translate}}
+    </h1>
+    <div mat-dialog-content>
+      <perun-web-apps-alert alert_type="info">
+        {{'DIALOGS.IMPORT_ATTRIBUTE.INFO' | translate}}
+      </perun-web-apps-alert>
+      <mat-form-field class="w-100">
+        <input
+          matInput
+          [(ngModel)]="value"
+          [placeholder]="'DIALOGS.IMPORT_ATTRIBUTE.HINT' | translate"
+          required />
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="dialogRef.close()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.IMPORT_ATTRIBUTE.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="create()"
+        [disabled]="value.trim().length === 0 || loading"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.IMPORT_ATTRIBUTE.CREATE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/bulk-invite-members-dialog/bulk-invite-members-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/bulk-invite-members-dialog/bulk-invite-members-dialog.component.html
@@ -1,77 +1,81 @@
-<div class="{{data.theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.BULK_INVITE_MEMBERS.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <div *ngIf="state === 'input'">
-      <div *ngIf="!data.groupId" class="font-italic">
-        {{'DIALOGS.BULK_INVITE_MEMBERS.DESCRIPTION_VO' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{data.theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.BULK_INVITE_MEMBERS.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <div *ngIf="state === 'input'">
+        <div *ngIf="!data.groupId" class="font-italic">
+          {{'DIALOGS.BULK_INVITE_MEMBERS.DESCRIPTION_VO' | translate}}
+        </div>
+        <div *ngIf="data.groupId" class="font-italic">
+          {{'DIALOGS.BULK_INVITE_MEMBERS.DESCRIPTION_GROUP' | translate}}
+        </div>
+        <mat-form-field class="w-100 pt-2">
+          <mat-label>{{'DIALOGS.BULK_INVITE_MEMBERS.LANGUAGE' | translate}}</mat-label>
+          <mat-select [(value)]="currentLanguage">
+            <mat-option *ngFor="let lang of languages" value="{{lang}}">
+              {{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <p [innerHTML]="'DIALOGS.BULK_INVITE_MEMBERS.HINT' | translate"></p>
+        <mat-form-field class="pt-2 flex-container">
+          <mat-label>{{'DIALOGS.BULK_INVITE_MEMBERS.INSERT_HERE'| translate}}</mat-label>
+          <textarea
+            cols="50"
+            class="md-textarea form-control"
+            [formControl]="invitedMembers"
+            required
+            matInput
+            placeholder="{{'DIALOGS.BULK_INVITE_MEMBERS.PLACEHOLDER' | translate}}"
+            rows="8">
+          </textarea>
+          <mat-error *ngIf="invitedMembers.hasError('required')">
+            {{'DIALOGS.BULK_INVITE_MEMBERS.NAMES_ERROR' | translate}}
+          </mat-error>
+          <mat-error *ngIf="invitedMembers.hasError('invalidFormat')">
+            {{'DIALOGS.BULK_INVITE_MEMBERS.ERROR_FORMAT'| translate}}:
+            {{invitedMembers.getError('invalidFormat').value}}
+          </mat-error>
+          <mat-error *ngIf="invitedMembers.hasError('invalidEmail')">
+            {{'DIALOGS.BULK_INVITE_MEMBERS.ERROR_EMAIL'| translate}}:
+            {{invitedMembers.getError('invalidEmail').value}}
+          </mat-error>
+        </mat-form-field>
       </div>
-      <div *ngIf="data.groupId" class="font-italic">
-        {{'DIALOGS.BULK_INVITE_MEMBERS.DESCRIPTION_GROUP' | translate}}
-      </div>
-      <mat-form-field class="w-100 pt-2">
-        <mat-label>{{'DIALOGS.BULK_INVITE_MEMBERS.LANGUAGE' | translate}}</mat-label>
-        <mat-select [(value)]="currentLanguage">
-          <mat-option *ngFor="let lang of languages" value="{{lang}}">
-            {{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-      <p [innerHTML]="'DIALOGS.BULK_INVITE_MEMBERS.HINT' | translate"></p>
-      <mat-form-field class="pt-2 flex-container">
-        <mat-label>{{'DIALOGS.BULK_INVITE_MEMBERS.INSERT_HERE'| translate}}</mat-label>
-        <textarea
-          cols="50"
-          class="md-textarea form-control"
-          [formControl]="invitedMembers"
-          required
-          matInput
-          placeholder="{{'DIALOGS.BULK_INVITE_MEMBERS.PLACEHOLDER' | translate}}"
-          rows="8">
-        </textarea>
-        <mat-error *ngIf="invitedMembers.hasError('required')">
-          {{'DIALOGS.BULK_INVITE_MEMBERS.NAMES_ERROR' | translate}}
-        </mat-error>
-        <mat-error *ngIf="invitedMembers.hasError('invalidFormat')">
-          {{'DIALOGS.BULK_INVITE_MEMBERS.ERROR_FORMAT'| translate}}:
-          {{invitedMembers.getError('invalidFormat').value}}
-        </mat-error>
-        <mat-error *ngIf="invitedMembers.hasError('invalidEmail')">
-          {{'DIALOGS.BULK_INVITE_MEMBERS.ERROR_EMAIL'| translate}}:
-          {{invitedMembers.getError('invalidEmail').value}}
-        </mat-error>
-      </mat-form-field>
     </div>
-  </div>
-  <div *ngIf="state === 'results'">
-    <perun-web-apps-alert *ngIf="!this.finishedWithErrors" [alert_type]="'success'">
-      {{'DIALOGS.BULK_INVITE_MEMBERS.SUCCESS' | translate}}
-    </perun-web-apps-alert>
-    <perun-web-apps-alert *ngIf="this.finishedWithErrors" [alert_type]="'warn'">
-      {{'DIALOGS.BULK_INVITE_MEMBERS.FINISHED_WITH_ERRORS' | translate}}
-    </perun-web-apps-alert>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.BULK_INVITE_MEMBERS.CANCEL' | translate}}
-    </button>
-    <button
-      *ngIf="state === 'input'"
-      (click)="onSubmit()"
-      class="ml-2"
-      color="accent"
-      [disabled]="loading || invitedMembers.invalid"
-      mat-flat-button>
-      {{'DIALOGS.BULK_INVITE_MEMBERS.INVITE' | translate}}
-    </button>
-    <button
-      *ngIf="state === 'results'"
-      [disabled]="!resultData"
-      (click)="downloadCsv()"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.BULK_INVITE_MEMBERS.DOWNLOAD_CSV' | translate}}
-    </button>
+    <div *ngIf="state === 'results'">
+      <perun-web-apps-alert *ngIf="!this.finishedWithErrors" [alert_type]="'success'">
+        {{'DIALOGS.BULK_INVITE_MEMBERS.SUCCESS' | translate}}
+      </perun-web-apps-alert>
+      <perun-web-apps-alert *ngIf="this.finishedWithErrors" [alert_type]="'warn'">
+        {{'DIALOGS.BULK_INVITE_MEMBERS.FINISHED_WITH_ERRORS' | translate}}
+      </perun-web-apps-alert>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.BULK_INVITE_MEMBERS.CANCEL' | translate}}
+      </button>
+      <button
+        *ngIf="state === 'input'"
+        (click)="onSubmit()"
+        class="ml-2"
+        color="accent"
+        [disabled]="loading || invitedMembers.invalid"
+        mat-flat-button>
+        {{'DIALOGS.BULK_INVITE_MEMBERS.INVITE' | translate}}
+      </button>
+      <button
+        *ngIf="state === 'results'"
+        [disabled]="!resultData"
+        (click)="downloadCsv()"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.BULK_INVITE_MEMBERS.DOWNLOAD_CSV' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/connect-identity-dialog/connect-identity-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/connect-identity-dialog/connect-identity-dialog.component.html
@@ -1,55 +1,60 @@
-<div (keyup)="onKeyInput($event)" class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.CONNECT_IDENTITY.TITLE_'+target | translate}}</h1>
-  <div class="dialog-container" mat-dialog-content>
-    <mat-form-field class="mr-2 search-field no-border-mat-input">
-      <input
-        matInput
-        autocomplete="false"
-        placeholder="{{'DIALOGS.CONNECT_IDENTITY.SEARCH' | translate}}"
-        [formControl]="searchCtrl" />
-      <mat-error>
-        {{'DIALOGS.CONNECT_IDENTITY.EMPTY_SEARCH_MESSAGE' | translate}}
-      </mat-error>
-    </mat-form-field>
-    <button
-      (click)="onSearchByString()"
-      [disabled]="loading"
-      class="mr-2 search-btn"
-      color="primary"
-      mat-flat-button>
-      <mat-icon>search</mat-icon>
-    </button>
-    <div *ngIf="!loading">
-      <app-users-list
-        [displayedColumns]="displayedColumns"
-        [selection]="selection"
-        *ngIf="identities !== undefined && identities.length > 0"
-        [tableId]="tableId"
-        [disableRouting]="true"
-        [users]="identities">
-      </app-users-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="finalLoading; indicator: spinner">
+    <div (keyup)="onKeyInput($event)" class="{{theme}}">
+      <h1 mat-dialog-title>{{'DIALOGS.CONNECT_IDENTITY.TITLE_'+target | translate}}</h1>
+      <div class="dialog-container" mat-dialog-content>
+        <mat-form-field class="mr-2 search-field no-border-mat-input">
+          <input
+            matInput
+            autocomplete="false"
+            placeholder="{{'DIALOGS.CONNECT_IDENTITY.SEARCH' | translate}}"
+            [formControl]="searchCtrl" />
+          <mat-error>
+            {{'DIALOGS.CONNECT_IDENTITY.EMPTY_SEARCH_MESSAGE' | translate}}
+          </mat-error>
+        </mat-form-field>
+        <button
+          (click)="onSearchByString()"
+          [disabled]="loading"
+          class="mr-2 search-btn"
+          color="primary"
+          mat-flat-button>
+          <mat-icon>search</mat-icon>
+        </button>
+        <ng-template #searchSpinner>
+          <perun-web-apps-loading-table></perun-web-apps-loading-table>
+        </ng-template>
+        <div class="position-relative" *ngIf="firstSearchDone">
+          <app-users-list
+            *perunWebAppsLoader="loading; indicator: searchSpinner"
+            [displayedColumns]="displayedColumns"
+            [selection]="selection"
+            [tableId]="tableId"
+            [disableRouting]="true"
+            [users]="identities"
+            [noUsersFoundLabel]="'DIALOGS.CONNECT_IDENTITY.NO_IDENTITIES' | translate">
+          </app-users-list>
+        </div>
+        <perun-web-apps-alert *ngIf="!firstSearchDone" alert_type="info">
+          {{'DIALOGS.CONNECT_IDENTITY.SEARCH_HINT' | translate}}
+        </perun-web-apps-alert>
+      </div>
+      <div mat-dialog-actions>
+        <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+          {{'DIALOGS.CONNECT_IDENTITY.CANCEL' | translate}}
+        </button>
+        <button
+          class="ml-2"
+          (click)="onAdd()"
+          [disabled]="selection.selected.length === 0"
+          color="accent"
+          mat-flat-button>
+          {{'DIALOGS.CONNECT_IDENTITY.CONNECT' | translate}}
+        </button>
+      </div>
     </div>
-    <perun-web-apps-alert *ngIf="!firstSearchDone" alert_type="info">
-      {{'DIALOGS.CONNECT_IDENTITY.SEARCH_HINT' | translate}}
-    </perun-web-apps-alert>
-    <perun-web-apps-alert
-      *ngIf="!loading && firstSearchDone && identities.length === 0"
-      alert_type="warn">
-      {{'DIALOGS.CONNECT_IDENTITY.NO_IDENTITIES' | translate}}
-    </perun-web-apps-alert>
-  </div>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.CONNECT_IDENTITY.CANCEL' | translate}}
-    </button>
-    <button
-      class="ml-2"
-      (click)="onAdd()"
-      [disabled]="selection.selected.length === 0"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.CONNECT_IDENTITY.CONNECT' | translate}}
-    </button>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/connect-identity-dialog/connect-identity-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/connect-identity-dialog/connect-identity-dialog.component.ts
@@ -23,8 +23,9 @@ export interface AddUserServiceIdentityData {
 export class ConnectIdentityDialogComponent implements OnInit {
   theme: string;
   loading = false;
+  finalLoading = false;
   target: string;
-  identities: RichUser[];
+  identities: RichUser[] = [];
   selection = new SelectionModel<RichUser>(false, []);
   firstSearchDone = false;
   displayedColumns = ['select', 'id', 'user', 'name', 'email', 'logins', 'organization'];
@@ -54,7 +55,7 @@ export class ConnectIdentityDialogComponent implements OnInit {
   }
 
   onAdd(): void {
-    this.loading = true;
+    this.finalLoading = true;
     let owner: number;
     let specificUser: number;
 
@@ -73,7 +74,7 @@ export class ConnectIdentityDialogComponent implements OnInit {
         );
         this.dialogRef.close(true);
       },
-      error: () => (this.loading = false),
+      error: () => (this.finalLoading = false),
     });
   }
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/copy-members-dialog/copy-members-dialog-component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/copy-members-dialog/copy-members-dialog-component.html
@@ -1,48 +1,52 @@
-<div class="{{data.theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.COPY_MEMBERS.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-radio-group [(ngModel)]="copyType" class="flex-container">
-      <span
-        matTooltip="{{'DIALOGS.COPY_MEMBERS.DISABLED_COPY_SELECTION' | translate}}"
-        [matTooltipDisabled]="data.members.length > 0"
-        matTooltipPosition="above">
-        <mat-radio-button [disabled]="data.members.length === 0" value="selection">
-          {{'DIALOGS.COPY_MEMBERS.COPY_SELECTION' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{data.theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.COPY_MEMBERS.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-radio-group [(ngModel)]="copyType" class="flex-container">
+        <span
+          matTooltip="{{'DIALOGS.COPY_MEMBERS.DISABLED_COPY_SELECTION' | translate}}"
+          [matTooltipDisabled]="data.members.length > 0"
+          matTooltipPosition="above">
+          <mat-radio-button [disabled]="data.members.length === 0" value="selection">
+            {{'DIALOGS.COPY_MEMBERS.COPY_SELECTION' | translate}}
+          </mat-radio-button>
+        </span>
+        <mat-radio-button value="all">
+          {{'DIALOGS.COPY_MEMBERS.COPY_ALL' | translate}}
         </mat-radio-button>
-      </span>
-      <mat-radio-button value="all">
-        {{'DIALOGS.COPY_MEMBERS.COPY_ALL' | translate}}
-      </mat-radio-button>
-    </mat-radio-group>
-    <perun-web-apps-alert class="mt-4" alert_type="warn">
-      {{'DIALOGS.COPY_MEMBERS.ATTRIBUTES_WARN' | translate}}
-    </perun-web-apps-alert>
-    <h5 class="mt-4">{{'DIALOGS.COPY_MEMBERS.SELECT_GROUPS' | translate}}</h5>
-    <perun-web-apps-immediate-filter
-      (filter)="applyFilter($event)"
-      [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_SEARCH'">
-    </perun-web-apps-immediate-filter>
-    <perun-web-apps-groups-list
-      [groups]="assignableGroups"
-      [selection]="selection"
-      [disableRouting]="true"
-      [displayedColumns]="['select', 'id', 'name', 'description']"
-      [filter]="filterValue"
-      [tableId]="tableId">
-    </perun-web-apps-groups-list>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.COPY_MEMBERS.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      [disabled]="loading || selection.isEmpty()"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.COPY_MEMBERS.COPY' | translate}}
-    </button>
+      </mat-radio-group>
+      <perun-web-apps-alert class="mt-4" alert_type="warn">
+        {{'DIALOGS.COPY_MEMBERS.ATTRIBUTES_WARN' | translate}}
+      </perun-web-apps-alert>
+      <h5 class="mt-4">{{'DIALOGS.COPY_MEMBERS.SELECT_GROUPS' | translate}}</h5>
+      <perun-web-apps-immediate-filter
+        (filter)="applyFilter($event)"
+        [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_SEARCH'">
+      </perun-web-apps-immediate-filter>
+      <perun-web-apps-groups-list
+        [groups]="assignableGroups"
+        [selection]="selection"
+        [disableRouting]="true"
+        [displayedColumns]="['select', 'id', 'name', 'description']"
+        [filter]="filterValue"
+        [tableId]="tableId">
+      </perun-web-apps-groups-list>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.COPY_MEMBERS.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        [disabled]="loading || selection.isEmpty()"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.COPY_MEMBERS.COPY' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-attribute-definition-dialog/create-attribute-definition-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-attribute-definition-dialog/create-attribute-definition-dialog.component.html
@@ -1,108 +1,112 @@
-<div class="admin-theme">
-  <h1 mat-dialog-title>{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <form [formGroup]="attributeControl" class="dialog-container">
-      <mat-form-field>
-        <input
-          matInput
-          formControlName="friendlyName"
-          placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.FRIENDLY_NAME' | translate}}"
-          data-cy="attribute-friendly-name-input"
-          required />
-        <mat-error *ngIf="attributeControl.hasError('required', 'friendlyName')">
-          {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
-        </mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <input
-          matInput
-          formControlName="displayName"
-          placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.DISPLAY_NAME' | translate}}"
-          data-cy="attribute-display-name-input"
-          required />
-        <mat-error *ngIf="attributeControl.hasError('required', 'displayName')">
-          {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
-        </mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <textarea
-          matInput
-          formControlName="description"
-          cdkTextareaAutosize
-          placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.DESCRIPTION' | translate}}"
-          data-cy="attribute-description-input"
-          required>
-        </textarea>
-        <mat-error *ngIf="attributeControl.hasError('required', 'description')">
-          {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
-        </mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <mat-select
-          placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ENTITY' | translate}}"
-          formControlName="entity"
-          data-cy="attribute-entity-input"
-          required>
-          <mat-option *ngFor="let entity of entities" [value]="entity">{{entity}}</mat-option>
-        </mat-select>
-        <mat-error *ngIf="attributeControl.hasError('required', 'entity')">
-          {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
-        </mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <mat-select
-          placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.DEFINITION' | translate}}"
-          formControlName="definitionType"
-          data-cy="attribute-definition-type-input"
-          required>
-          <mat-option *ngFor="let defType of definitionTypes" [value]="defType"
-            >{{defType}}
-          </mat-option>
-        </mat-select>
-        <mat-error *ngIf="attributeControl.hasError('required', 'definitionType')">
-          {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
-        </mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <mat-select
-          placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.VALUE_TYPE' | translate}}"
-          formControlName="valueType"
-          data-cy="attribute-value-type-input"
-          required>
-          <mat-option *ngFor="let valType of valueTypes" [value]="valType">
-            {{valType | attributeTypeClean}}
-          </mat-option>
-        </mat-select>
-        <mat-error *ngIf="attributeControl.hasError('required', 'valueType')">
-          {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
-        </mat-error>
-      </mat-form-field>
-    </form>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="admin-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <form [formGroup]="attributeControl" class="dialog-container">
+        <mat-form-field>
+          <input
+            matInput
+            formControlName="friendlyName"
+            placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.FRIENDLY_NAME' | translate}}"
+            data-cy="attribute-friendly-name-input"
+            required />
+          <mat-error *ngIf="attributeControl.hasError('required', 'friendlyName')">
+            {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field>
+          <input
+            matInput
+            formControlName="displayName"
+            placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.DISPLAY_NAME' | translate}}"
+            data-cy="attribute-display-name-input"
+            required />
+          <mat-error *ngIf="attributeControl.hasError('required', 'displayName')">
+            {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field>
+          <textarea
+            matInput
+            formControlName="description"
+            cdkTextareaAutosize
+            placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.DESCRIPTION' | translate}}"
+            data-cy="attribute-description-input"
+            required>
+          </textarea>
+          <mat-error *ngIf="attributeControl.hasError('required', 'description')">
+            {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field>
+          <mat-select
+            placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ENTITY' | translate}}"
+            formControlName="entity"
+            data-cy="attribute-entity-input"
+            required>
+            <mat-option *ngFor="let entity of entities" [value]="entity">{{entity}}</mat-option>
+          </mat-select>
+          <mat-error *ngIf="attributeControl.hasError('required', 'entity')">
+            {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field>
+          <mat-select
+            placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.DEFINITION' | translate}}"
+            formControlName="definitionType"
+            data-cy="attribute-definition-type-input"
+            required>
+            <mat-option *ngFor="let defType of definitionTypes" [value]="defType"
+              >{{defType}}
+            </mat-option>
+          </mat-select>
+          <mat-error *ngIf="attributeControl.hasError('required', 'definitionType')">
+            {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field>
+          <mat-select
+            placeholder="{{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.VALUE_TYPE' | translate}}"
+            formControlName="valueType"
+            data-cy="attribute-value-type-input"
+            required>
+            <mat-option *ngFor="let valType of valueTypes" [value]="valType">
+              {{valType | attributeTypeClean}}
+            </mat-option>
+          </mat-select>
+          <mat-error *ngIf="attributeControl.hasError('required', 'valueType')">
+            {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
+          </mat-error>
+        </mat-form-field>
+      </form>
 
-    <perun-web-apps-attribute-unique-toggle [attDef]="attDef | async">
-    </perun-web-apps-attribute-unique-toggle>
+      <perun-web-apps-attribute-unique-toggle [attDef]="attDef | async">
+      </perun-web-apps-attribute-unique-toggle>
 
-    <perun-web-apps-attribute-critical-operations-toggles
-      (readOperationChanged)="finalReadOperations=$event"
-      (writeOperationChanged)="finalWriteOperations=$event">
-    </perun-web-apps-attribute-critical-operations-toggles>
+      <perun-web-apps-attribute-critical-operations-toggles
+        (readOperationChanged)="finalReadOperations=$event"
+        (writeOperationChanged)="finalWriteOperations=$event">
+      </perun-web-apps-attribute-critical-operations-toggles>
 
-    <perun-web-apps-attribute-rights-tab-group [collections]="collections">
-    </perun-web-apps-attribute-rights-tab-group>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.CANCEL' | translate}}
-    </button>
-    <button
-      class="ml-2"
-      color="accent"
-      (click)="submit()"
-      [disabled]="loading || attributeControl.invalid"
-      data-cy="create-attr-definition-button"
-      mat-flat-button>
-      {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.CONFIRM' | translate}}
-    </button>
+      <perun-web-apps-attribute-rights-tab-group [collections]="collections">
+      </perun-web-apps-attribute-rights-tab-group>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.CANCEL' | translate}}
+      </button>
+      <button
+        class="ml-2"
+        color="accent"
+        (click)="submit()"
+        [disabled]="loading || attributeControl.invalid"
+        data-cy="create-attr-definition-button"
+        mat-flat-button>
+        {{'DIALOGS.CREATE_ATTRIBUTE_DEFINITION.CONFIRM' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-attribute-dialog/create-attribute-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-attribute-dialog/create-attribute-dialog.component.html
@@ -11,17 +11,21 @@
     </perun-web-apps-alert>
   </div>
   <div mat-dialog-content>
-    <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-    <perun-web-apps-attributes-list
-      #list
-      [emptyListText]="'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTES_LIST.EMPTY_ATTRIBUTES'"
-      *ngIf="!loading"
-      [attributes]="attributes"
-      [filterValue]="filterValue"
-      [inDialog]="true"
-      [selection]="selected"
-      [tableId]="tableId">
-    </perun-web-apps-attributes-list>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
+    <div class="position-relative">
+      <perun-web-apps-attributes-list
+        *perunWebAppsLoader="loading; indicator: spinner"
+        #list
+        [emptyListText]="'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTES_LIST.EMPTY_ATTRIBUTES'"
+        [attributes]="attributes"
+        [filterValue]="filterValue"
+        [inDialog]="true"
+        [selection]="selected"
+        [tableId]="tableId">
+      </perun-web-apps-attributes-list>
+    </div>
   </div>
   <div mat-dialog-actions>
     <button (click)="onCancel()" class="ml-auto" mat-flat-button>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-edit-service-dialog/create-edit-service-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-edit-service-dialog/create-edit-service-dialog.component.html
@@ -1,85 +1,88 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{title}}</h1>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{title}}</h1>
 
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-form-field>
+        <input
+          matInput
+          placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.NAME' | translate}}"
+          (change)="makePath()"
+          [formControl]="nameControl"
+          data-cy="service-name-input"
+          required />
+        <mat-error>{{'DIALOGS.CREATE_EDIT_SERVICE.RESTRICTION_NAME' | translate}}</mat-error>
+      </mat-form-field>
 
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-form-field>
-      <input
-        matInput
-        placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.NAME' | translate}}"
-        (change)="makePath()"
-        [formControl]="nameControl"
-        data-cy="service-name-input"
-        required />
-      <mat-error>{{'DIALOGS.CREATE_EDIT_SERVICE.RESTRICTION_NAME' | translate}}</mat-error>
-    </mat-form-field>
+      <mat-form-field>
+        <input
+          [(ngModel)]="description"
+          matInput
+          data-cy="service-description-input"
+          placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.DESCRIPTION' | translate}}" />
+      </mat-form-field>
 
-    <mat-form-field>
-      <input
-        [(ngModel)]="description"
-        matInput
-        data-cy="service-description-input"
-        placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.DESCRIPTION' | translate}}" />
-    </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          [formControl]="delayControl"
+          placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.DELAY' | translate}}"
+          required />
+        <mat-error>{{'DIALOGS.CREATE_EDIT_SERVICE.INVALID_DELAY' | translate}}</mat-error>
+      </mat-form-field>
 
-    <mat-form-field>
-      <input
-        matInput
-        [formControl]="delayControl"
-        placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.DELAY' | translate}}"
-        required />
-      <mat-error>{{'DIALOGS.CREATE_EDIT_SERVICE.INVALID_DELAY' | translate}}</mat-error>
-    </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.RECURRENCE' | translate}}"
+          [formControl]="recurrenceControl"
+          required />
+        <mat-error>{{'DIALOGS.CREATE_EDIT_SERVICE.INVALID_RECURRENCE' | translate}}</mat-error>
+      </mat-form-field>
 
-    <mat-form-field>
-      <input
-        matInput
-        placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.RECURRENCE' | translate}}"
-        [formControl]="recurrenceControl"
-        required />
-      <mat-error>{{'DIALOGS.CREATE_EDIT_SERVICE.INVALID_RECURRENCE' | translate}}</mat-error>
-    </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          [formControl]="pathControl"
+          placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.PATH' | translate}}"
+          required />
+        <mat-error>{{'DIALOGS.CREATE_EDIT_SERVICE.REQUIRE_PATH' | translate}}</mat-error>
+      </mat-form-field>
 
-    <mat-form-field>
-      <input
-        matInput
-        [formControl]="pathControl"
-        placeholder="{{'DIALOGS.CREATE_EDIT_SERVICE.PATH' | translate}}"
-        required />
-      <mat-error>{{'DIALOGS.CREATE_EDIT_SERVICE.REQUIRE_PATH' | translate}}</mat-error>
-    </mat-form-field>
+      <span class="d-flex"
+        >{{'DIALOGS.CREATE_EDIT_SERVICE.STATUS' | translate}}
+        <mat-checkbox
+          class="ml-3"
+          [(ngModel)]="status"
+          >{{'DIALOGS.CREATE_EDIT_SERVICE.STATUS_HINT' | translate}}</mat-checkbox
+        >
+      </span>
 
-    <span class="d-flex"
-      >{{'DIALOGS.CREATE_EDIT_SERVICE.STATUS' | translate}}
-      <mat-checkbox
-        class="ml-3"
-        [(ngModel)]="status"
-        >{{'DIALOGS.CREATE_EDIT_SERVICE.STATUS_HINT' | translate}}</mat-checkbox
-      >
-    </span>
-
-    <span class="d-flex"
-      >{{'DIALOGS.CREATE_EDIT_SERVICE.EXPIRED_MEMBERS' | translate}}
-      <mat-checkbox
-        class="ml-3"
-        [(ngModel)]="propagateExpiredMembers"
-        >{{'DIALOGS.CREATE_EDIT_SERVICE.EXPIRED_MEMBERS_HINT' | translate}}</mat-checkbox
-      >
-    </span>
-  </div>
-  <div *ngIf="!loading" mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.CREATE_EDIT_SERVICE.CANCEL' | translate}}
-    </button>
-    <button
-      [disabled]="nameControl.invalid || delayControl.invalid || recurrenceControl.invalid || pathControl.invalid"
-      class="ml-2"
-      color="accent"
-      (click)="asEdit ? onEdit() : onCreate()"
-      data-cy="service-create-edit-dialog-button"
-      mat-flat-button>
-      {{buttonText}}
-    </button>
+      <span class="d-flex"
+        >{{'DIALOGS.CREATE_EDIT_SERVICE.EXPIRED_MEMBERS' | translate}}
+        <mat-checkbox
+          class="ml-3"
+          [(ngModel)]="propagateExpiredMembers"
+          >{{'DIALOGS.CREATE_EDIT_SERVICE.EXPIRED_MEMBERS_HINT' | translate}}</mat-checkbox
+        >
+      </span>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.CREATE_EDIT_SERVICE.CANCEL' | translate}}
+      </button>
+      <button
+        [disabled]="nameControl.invalid || delayControl.invalid || recurrenceControl.invalid || pathControl.invalid || loading"
+        class="ml-2"
+        color="accent"
+        (click)="asEdit ? onEdit() : onCreate()"
+        data-cy="service-create-edit-dialog-button"
+        mat-flat-button>
+        {{buttonText}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-facility-dialog/create-facility-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-facility-dialog/create-facility-dialog.component.html
@@ -1,62 +1,66 @@
-<div class="{{theme}}">
-  <h1 class="mat-dialog-title">{{'DIALOGS.CREATE_FACILITY.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-form-field>
-      <input
-        matInput
-        required
-        data-cy="facility-name-input"
-        [formControl]="nameControl"
-        placeholder="{{'DIALOGS.CREATE_FACILITY.NAME' | translate}}" />
-      <mat-error>{{"DIALOGS.CREATE_FACILITY.REQUIRE_NAME" | translate}}</mat-error>
-    </mat-form-field>
-    <mat-form-field>
-      <input
-        matInput
-        data-cy="facility-description-input"
-        [formControl]="descControl"
-        placeholder="{{'DIALOGS.CREATE_FACILITY.DESCRIPTION' | translate}}" />
-    </mat-form-field>
-    <mat-form-field>
-      <mat-select
-        disableOptionCentering="true"
-        placeholder="{{ 'DIALOGS.CREATE_FACILITY.AS_COPY' | translate}}">
-        <mat-option (click)="srcFacility = null">
-          {{'DIALOGS.CREATE_FACILITY.NO_COPY' | translate}}
-        </mat-option>
-        <mat-option
-          (click)="srcFacility = facility"
-          *ngFor="let facility of facilities"
-          [value]="facility">
-          {{facility.name}}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <perun-web-apps-alert alert_type="info">
-      <i [innerHTML]="'DIALOGS.CREATE_FACILITY.HINT' | translate"></i>
-    </perun-web-apps-alert>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{"DIALOGS.CREATE_FACILITY.CANCEL" | translate}}
-    </button>
-    <button
-      (click)="onCreate(false)"
-      class="ml2"
-      data-cy="create-facility-button"
-      [disabled]="nameControl.value.trim().length === 0 || loading"
-      color="accent"
-      mat-flat-button>
-      {{"DIALOGS.CREATE_FACILITY.CREATE" | translate}}
-    </button>
-    <button
-      (click)="onCreate(true)"
-      class="ml2"
-      [disabled]="nameControl.value.trim().length === 0 || !!srcFacility || loading"
-      color="accent"
-      mat-flat-button>
-      {{"DIALOGS.CREATE_FACILITY.CREATE_AND_CONFIGURE" | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 class="mat-dialog-title">{{'DIALOGS.CREATE_FACILITY.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-form-field>
+        <input
+          matInput
+          required
+          data-cy="facility-name-input"
+          [formControl]="nameControl"
+          placeholder="{{'DIALOGS.CREATE_FACILITY.NAME' | translate}}" />
+        <mat-error>{{"DIALOGS.CREATE_FACILITY.REQUIRE_NAME" | translate}}</mat-error>
+      </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          data-cy="facility-description-input"
+          [formControl]="descControl"
+          placeholder="{{'DIALOGS.CREATE_FACILITY.DESCRIPTION' | translate}}" />
+      </mat-form-field>
+      <mat-form-field>
+        <mat-select
+          disableOptionCentering="true"
+          placeholder="{{ 'DIALOGS.CREATE_FACILITY.AS_COPY' | translate}}">
+          <mat-option (click)="srcFacility = null">
+            {{'DIALOGS.CREATE_FACILITY.NO_COPY' | translate}}
+          </mat-option>
+          <mat-option
+            (click)="srcFacility = facility"
+            *ngFor="let facility of facilities"
+            [value]="facility">
+            {{facility.name}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <perun-web-apps-alert alert_type="info">
+        <i [innerHTML]="'DIALOGS.CREATE_FACILITY.HINT' | translate"></i>
+      </perun-web-apps-alert>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{"DIALOGS.CREATE_FACILITY.CANCEL" | translate}}
+      </button>
+      <button
+        (click)="onCreate(false)"
+        class="ml2"
+        data-cy="create-facility-button"
+        [disabled]="nameControl.value.trim().length === 0 || loading"
+        color="accent"
+        mat-flat-button>
+        {{"DIALOGS.CREATE_FACILITY.CREATE" | translate}}
+      </button>
+      <button
+        (click)="onCreate(true)"
+        class="ml2"
+        [disabled]="nameControl.value.trim().length === 0 || !!srcFacility || loading"
+        color="accent"
+        mat-flat-button>
+        {{"DIALOGS.CREATE_FACILITY.CREATE_AND_CONFIGURE" | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-group-dialog/create-group-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-group-dialog/create-group-dialog.component.html
@@ -1,7 +1,9 @@
-<h1 mat-dialog-title>{{title}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{title}}</h1>
     <div class="dialog-container" mat-dialog-content>
       <mat-form-field>
         <label class="w-100">

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-relation-dialog/create-relation-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-relation-dialog/create-relation-dialog.component.html
@@ -1,43 +1,49 @@
-<h1 mat-dialog-title>{{"DIALOGS.CREATE_RELATION.TITLE" | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="initLoading" class="ml-auto mr-auto"></mat-spinner>
-</div>
-<div *ngIf="!initLoading" class="{{theme}}">
-  <perun-web-apps-vo-search-select
-    *ngIf="vosToSelect.length > 1"
-    [vo]="thisVo.vo"
-    [vos]="vosToSelect"
-    (voSelected)="getGroupsToInclude($event.id)"></perun-web-apps-vo-search-select>
-  <perun-web-apps-immediate-filter
-    (filter)="applyFilter($event)"
-    [placeholder]="'GROUP_DETAIL.SETTINGS.RELATIONS.FILTER'"></perun-web-apps-immediate-filter>
-  <div class="dialog-container" mat-dialog-content>
-    <perun-web-apps-groups-list
-      *ngIf="!loading"
-      [groupsToDisableCheckbox]="groupsToDisable"
-      [disableGroups]="true"
-      [groups]="groups"
-      [selection]="selection"
-      [disableHeadCheckbox]="true"
-      [disableRouting]="true"
-      [displayedColumns]="['select', 'id', 'name', 'description']"
-      [filter]="filterValue"
-      [tableId]="tableId"
-      [relation]="true">
-    </perun-web-apps-groups-list>
-  </div>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.CREATE_RELATION.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      class="ml-2"
-      color="accent"
-      [disabled]="loading || initLoading || selection.selected.length === 0"
-      mat-flat-button>
-      {{'DIALOGS.CREATE_RELATION.CREATE' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="initLoading; indicator: spinner">
+    <h1 mat-dialog-title>{{"DIALOGS.CREATE_RELATION.TITLE" | translate}}</h1>
+    <perun-web-apps-vo-search-select
+      *ngIf="vosToSelect.length > 1"
+      [vo]="thisVo.vo"
+      [vos]="vosToSelect"
+      (voSelected)="getGroupsToInclude($event.id)"></perun-web-apps-vo-search-select>
+    <perun-web-apps-immediate-filter
+      (filter)="applyFilter($event)"
+      [placeholder]="'GROUP_DETAIL.SETTINGS.RELATIONS.FILTER'"></perun-web-apps-immediate-filter>
+    <div class="dialog-container" mat-dialog-content>
+      <ng-template #spinner>
+        <perun-web-apps-loading-table></perun-web-apps-loading-table>
+      </ng-template>
+      <div class="position-relative">
+        <perun-web-apps-groups-list
+          *perunWebAppsLoader="loading; indicator: spinner"
+          [groupsToDisableCheckbox]="groupsToDisable"
+          [disableGroups]="true"
+          [groups]="groups"
+          [selection]="selection"
+          [disableHeadCheckbox]="true"
+          [disableRouting]="true"
+          [displayedColumns]="['select', 'id', 'name', 'description']"
+          [filter]="filterValue"
+          [tableId]="tableId"
+          [relation]="true">
+        </perun-web-apps-groups-list>
+      </div>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.CREATE_RELATION.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        class="ml-2"
+        color="accent"
+        [disabled]="loading || initLoading || selection.selected.length === 0"
+        mat-flat-button>
+        {{'DIALOGS.CREATE_RELATION.CREATE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-relation-dialog/create-relation-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-relation-dialog/create-relation-dialog.component.ts
@@ -27,7 +27,7 @@ export interface CreateRelationDialogData {
 })
 export class CreateRelationDialogComponent implements OnInit {
   selection = new SelectionModel<Group>(false, []);
-  groups: Group[];
+  groups: Group[] = [];
   theme: string;
   filterValue = '';
   initLoading: boolean;
@@ -55,8 +55,8 @@ export class CreateRelationDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.initLoading = true;
-    this.groupService.getGroupUnions(this.data.group.id, !this.data.reverse).subscribe(
-      (unionGroups) => {
+    this.groupService.getGroupUnions(this.data.group.id, !this.data.reverse).subscribe({
+      next: (unionGroups) => {
         unionGroups = unionGroups.concat(this.data.groups);
         this.groupsToNotInclude = unionGroups.map((elem) => elem.id);
         this.voService.getEnrichedVoById(this.data.voId).subscribe((enrichedVo) => {
@@ -69,8 +69,8 @@ export class CreateRelationDialogComponent implements OnInit {
           this.initLoading = false;
         });
       },
-      () => (this.initLoading = false)
-    );
+      error: () => (this.initLoading = false),
+    });
     this.theme = this.data.theme;
   }
 
@@ -81,32 +81,34 @@ export class CreateRelationDialogComponent implements OnInit {
   getGroupsToInclude(voId: number): void {
     this.loading = true;
     if (voId === this.data.voId) {
-      this.groupService.getAllGroups(this.data.voId).subscribe(
-        (allGroups) => {
+      this.groupService.getAllGroups(this.data.voId).subscribe({
+        next: (allGroups) => {
           this.finishLoadingGroups(allGroups);
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
     } else {
-      this.groupService.getVoAllAllowedGroupsToHierarchicalVo(this.data.voId, voId).subscribe(
-        (groups) => {
+      this.groupService.getVoAllAllowedGroupsToHierarchicalVo(this.data.voId, voId).subscribe({
+        next: (groups) => {
           this.finishLoadingGroups(groups);
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
     }
   }
 
   onSubmit(): void {
     this.loading = true;
-    this.groupService.createGroupUnion(this.data.group.id, this.selection.selected[0].id).subscribe(
-      () => {
-        this.notificator.showSuccess(this.successMessage);
-        this.loading = false;
-        this.dialogRef.close(true);
-      },
-      () => (this.loading = false)
-    );
+    this.groupService
+      .createGroupUnion(this.data.group.id, this.selection.selected[0].id)
+      .subscribe({
+        next: () => {
+          this.notificator.showSuccess(this.successMessage);
+          this.loading = false;
+          this.dialogRef.close(true);
+        },
+        error: () => (this.loading = false),
+      });
   }
 
   applyFilter(filterValue: string): void {

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-resource-dialog/create-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-resource-dialog/create-resource-dialog.component.html
@@ -1,46 +1,50 @@
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <perun-web-apps-vo-search-select
-      (voSelected)="selectedVo = $event"
-      [vos]="vos"
-      data-cy="create-resource-select-vo">
-    </perun-web-apps-vo-search-select>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <div class="dialog-container" mat-dialog-content>
+      <perun-web-apps-vo-search-select
+        (voSelected)="selectedVo = $event"
+        [vos]="vos"
+        data-cy="create-resource-select-vo">
+      </perun-web-apps-vo-search-select>
 
-    <mat-form-field>
-      <input
-        matInput
-        [formControl]="nameCtrl"
-        placeholder="{{'DIALOGS.CREATE_RESOURCE.NAME' | translate}}"
-        data-cy="create-resource-name-input"
-        required />
-      <mat-error>
-        {{'DIALOGS.CREATE_RESOURCE.INCORRECT_NAME' | translate}}
-      </mat-error>
-    </mat-form-field>
-    <mat-form-field>
-      <input
-        matInput
-        [formControl]="descriptionCtrl"
-        placeholder="{{'DIALOGS.CREATE_RESOURCE.DESCRIPTION' | translate}}" />
-      <mat-error>
-        {{'DIALOGS.CREATE_RESOURCE.FILL_DESCRIPTION' | translate}}
-      </mat-error>
-    </mat-form-field>
-  </div>
+      <mat-form-field>
+        <input
+          matInput
+          [formControl]="nameCtrl"
+          placeholder="{{'DIALOGS.CREATE_RESOURCE.NAME' | translate}}"
+          data-cy="create-resource-name-input"
+          required />
+        <mat-error>
+          {{'DIALOGS.CREATE_RESOURCE.INCORRECT_NAME' | translate}}
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          [formControl]="descriptionCtrl"
+          placeholder="{{'DIALOGS.CREATE_RESOURCE.DESCRIPTION' | translate}}" />
+        <mat-error>
+          {{'DIALOGS.CREATE_RESOURCE.FILL_DESCRIPTION' | translate}}
+        </mat-error>
+      </mat-form-field>
+    </div>
 
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.CREATE_RESOURCE.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      class="ml-2"
-      data-cy="create-resource-dialog-button"
-      [disabled]="nameCtrl.invalid || descriptionCtrl.invalid || selectedVo === null || loading"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.CREATE_RESOURCE.CREATE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.CREATE_RESOURCE.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        class="ml-2"
+        data-cy="create-resource-dialog-button"
+        [disabled]="nameCtrl.invalid || descriptionCtrl.invalid || selectedVo === null || loading"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.CREATE_RESOURCE.CREATE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-resource-tag-dialog/create-resource-tag-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-resource-tag-dialog/create-resource-tag-dialog.component.html
@@ -1,22 +1,26 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.CREATE_RESOURCE_TAG.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-form-field>
-      <input
-        matInput
-        placeholder="{{'DIALOGS.CREATE_RESOURCE_TAG.NAME' | translate}}"
-        [(ngModel)]="name"
-        required />
-      <mat-error>{{'DIALOGS.CREATE_RESOURCE_TAG.EMPTY_NAME' | translate}}</mat-error>
-    </mat-form-field>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.CREATE_RESOURCE_TAG.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="accent" mat-flat-button>
-      {{'DIALOGS.CREATE_RESOURCE_TAG.CREATE' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.CREATE_RESOURCE_TAG.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-form-field>
+        <input
+          matInput
+          placeholder="{{'DIALOGS.CREATE_RESOURCE_TAG.NAME' | translate}}"
+          [(ngModel)]="name"
+          required />
+        <mat-error>{{'DIALOGS.CREATE_RESOURCE_TAG.EMPTY_NAME' | translate}}</mat-error>
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.CREATE_RESOURCE_TAG.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="accent" mat-flat-button>
+        {{'DIALOGS.CREATE_RESOURCE_TAG.CREATE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.html
@@ -1,240 +1,245 @@
-<div class="{{theme}}">
-  <h1 *ngIf="!this.successfullyCreated" mat-dialog-title>
-    {{'DIALOGS.CREATE_SPONSORED_MEMBER.TITLE' | translate}}
-  </h1>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 *ngIf="!this.successfullyCreated" mat-dialog-title>
+      {{'DIALOGS.CREATE_SPONSORED_MEMBER.TITLE' | translate}}
+    </h1>
 
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
+    <div *ngIf="!successfullyCreated" class="dialog-container" mat-dialog-content>
+      <mat-stepper #stepper [linear]="true">
+        <mat-step [stepControl]="userControl">
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.CREATE_SPONSORED_MEMBER.USER_LABEL' | translate}}</ng-template
+          >
+          <perun-web-apps-alert alert_type="error" *ngIf="this.functionalityNotSupported">
+            {{'DIALOGS.CREATE_SPONSORED_MEMBER.FUNCTIONALITY_NOT_SUPPORTED' | translate}}
+          </perun-web-apps-alert>
 
-  <div *ngIf="!loading && !successfullyCreated" class="dialog-container" mat-dialog-content>
-    <mat-stepper #stepper [linear]="true">
-      <mat-step [stepControl]="userControl">
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.CREATE_SPONSORED_MEMBER.USER_LABEL' | translate}}</ng-template
-        >
-        <perun-web-apps-alert alert_type="error" *ngIf="this.functionalityNotSupported">
-          {{'DIALOGS.CREATE_SPONSORED_MEMBER.FUNCTIONALITY_NOT_SUPPORTED' | translate}}
-        </perun-web-apps-alert>
+          <form [formGroup]="userControl" class="dialog-container">
+            <h5 class="mt-2">
+              {{'DIALOGS.CREATE_SPONSORED_MEMBER.USER_TITLE' | translate}}
+            </h5>
+            <mat-form-field class="mt-4">
+              <input
+                data-cy="first-name-input"
+                matInput
+                formControlName="firstName"
+                placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.FIRST_NAME' | translate}}"
+                required />
+              <mat-error *ngIf="userControl.hasError('required', 'firstName')">
+                {{'DIALOGS.CREATE_SPONSORED_MEMBER.LENGTH_ERROR' | translate}}
+              </mat-error>
+            </mat-form-field>
 
-        <form [formGroup]="userControl" class="dialog-container">
-          <h5 class="mt-2">
-            {{'DIALOGS.CREATE_SPONSORED_MEMBER.USER_TITLE' | translate}}
-          </h5>
-          <mat-form-field class="mt-4">
-            <input
-              data-cy="first-name-input"
-              matInput
-              formControlName="firstName"
-              placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.FIRST_NAME' | translate}}"
-              required />
-            <mat-error *ngIf="userControl.hasError('required', 'firstName')">
-              {{'DIALOGS.CREATE_SPONSORED_MEMBER.LENGTH_ERROR' | translate}}
-            </mat-error>
-          </mat-form-field>
+            <mat-form-field>
+              <input
+                data-cy="last-name-input"
+                matInput
+                formControlName="lastName"
+                placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.LAST_NAME' | translate}}"
+                required />
+              <mat-error *ngIf="userControl.hasError('required', 'lastName')">
+                {{'DIALOGS.CREATE_SPONSORED_MEMBER.LENGTH_ERROR' | translate}}
+              </mat-error>
+            </mat-form-field>
 
-          <mat-form-field>
-            <input
-              data-cy="last-name-input"
-              matInput
-              formControlName="lastName"
-              placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.LAST_NAME' | translate}}"
-              required />
-            <mat-error *ngIf="userControl.hasError('required', 'lastName')">
-              {{'DIALOGS.CREATE_SPONSORED_MEMBER.LENGTH_ERROR' | translate}}
-            </mat-error>
-          </mat-form-field>
+            <mat-form-field>
+              <input
+                matInput
+                formControlName="titleBefore"
+                placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.TITLE_BEFORE' | translate}}" />
+            </mat-form-field>
 
-          <mat-form-field>
-            <input
-              matInput
-              formControlName="titleBefore"
-              placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.TITLE_BEFORE' | translate}}" />
-          </mat-form-field>
+            <mat-form-field>
+              <input
+                matInput
+                formControlName="titleAfter"
+                placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.TITLE_AFTER' | translate}}" />
+            </mat-form-field>
+          </form>
+        </mat-step>
+        <mat-step [stepControl]="namespaceControl">
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.CREATE_SPONSORED_MEMBER.NAMESPACE_LABEL' | translate}}</ng-template
+          >
+          <h5 class="mt-2">{{'DIALOGS.CREATE_SPONSORED_MEMBER.NAMESPACE_TITLE' | translate}}</h5>
+          <form [formGroup]="namespaceControl" class="dialog-container mt-4">
+            <mat-form-field data-cy="namespace-filter">
+              <mat-select
+                formControlName="namespace"
+                placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.NAMESPACE' | translate}}"
+                (valueChange)="onNamespaceChanged($event)"
+                required>
+                <mat-option
+                  *ngFor="let namespc of namespaceOptions"
+                  [value]="namespc"
+                  attr.data-cy="{{namespc}}">
+                  {{namespc}}
+                </mat-option>
+              </mat-select>
+              <mat-error *ngIf="namespaceControl.hasError('required', 'namespace')">
+                {{'DIALOGS.CREATE_SPONSORED_MEMBER.NAMESPACE_ERROR' | translate}}
+              </mat-error>
+            </mat-form-field>
 
-          <mat-form-field>
-            <input
-              matInput
-              formControlName="titleAfter"
-              placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.TITLE_AFTER' | translate}}" />
-          </mat-form-field>
-        </form>
-      </mat-step>
-      <mat-step [stepControl]="namespaceControl">
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.CREATE_SPONSORED_MEMBER.NAMESPACE_LABEL' | translate}}</ng-template
-        >
-        <h5 class="mt-2">{{'DIALOGS.CREATE_SPONSORED_MEMBER.NAMESPACE_TITLE' | translate}}</h5>
-        <form [formGroup]="namespaceControl" class="dialog-container mt-4">
-          <mat-form-field data-cy="namespace-filter">
-            <mat-select
-              formControlName="namespace"
-              placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.NAMESPACE' | translate}}"
-              (valueChange)="onNamespaceChanged($event)"
-              required>
-              <mat-option
-                *ngFor="let namespc of namespaceOptions"
-                [value]="namespc"
-                attr.data-cy="{{namespc}}">
-                {{namespc}}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="namespaceControl.hasError('required', 'namespace')">
-              {{'DIALOGS.CREATE_SPONSORED_MEMBER.NAMESPACE_ERROR' | translate}}
-            </mat-error>
-          </mat-form-field>
+            <mat-form-field
+              matTooltip="{{'DIALOGS.CREATE_SPONSORED_MEMBER.LOGIN_DISABLED' | translate}}"
+              [matTooltipDisabled]="namespaceControl.get('login').enabled"
+              matTooltipPosition="left">
+              <input
+                data-cy="login-input"
+                matInput
+                formControlName="login"
+                placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.LOGIN' | translate}}"
+                required />
+              <mat-error *ngIf="namespaceControl.hasError('required', 'login')">
+                {{'DIALOGS.CREATE_SPONSORED_MEMBER.LENGTH_ERROR' | translate}}
+              </mat-error>
+            </mat-form-field>
 
-          <mat-form-field
-            matTooltip="{{'DIALOGS.CREATE_SPONSORED_MEMBER.LOGIN_DISABLED' | translate}}"
-            [matTooltipDisabled]="namespaceControl.get('login').enabled"
-            matTooltipPosition="left">
-            <input
-              data-cy="login-input"
-              matInput
-              formControlName="login"
-              placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.LOGIN' | translate}}"
-              required />
-            <mat-error *ngIf="namespaceControl.hasError('required', 'login')">
-              {{'DIALOGS.CREATE_SPONSORED_MEMBER.LENGTH_ERROR' | translate}}
-            </mat-error>
-          </mat-form-field>
-
-          <mat-form-field>
-            <input
-              data-cy="email-input"
-              matInput
-              placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.EMAIL' | translate}}"
-              formControlName="email"
-              required />
-            <mat-error
-              *ngIf="namespaceControl.hasError('required', 'email') ||
+            <mat-form-field>
+              <input
+                data-cy="email-input"
+                matInput
+                placeholder="{{'DIALOGS.CREATE_SPONSORED_MEMBER.EMAIL' | translate}}"
+                formControlName="email"
+                required />
+              <mat-error
+                *ngIf="namespaceControl.hasError('required', 'email') ||
             namespaceControl.hasError('pattern', 'email')">
-              {{'DIALOGS.CREATE_SPONSORED_MEMBER.EMAIL_ERROR' | translate}}
-            </mat-error>
-          </mat-form-field>
+                {{'DIALOGS.CREATE_SPONSORED_MEMBER.EMAIL_ERROR' | translate}}
+              </mat-error>
+            </mat-form-field>
 
-          <span
-            matTooltip="{{'DIALOGS.CREATE_SPONSORED_MEMBER.PASSWORD_RESET_DISABLED' | translate}}"
-            [matTooltipDisabled]="namespaceControl.get('passwordReset').enabled"
-            matTooltipPosition="left">
-            <mat-checkbox
-              labelPosition="before"
-              (change)="passwordResetChange()"
-              formControlName="passwordReset"
-              >{{'DIALOGS.CREATE_SPONSORED_MEMBER.PASSWORD_RESET' | translate}}
-            </mat-checkbox>
-          </span>
-          <mat-form-field *ngIf="namespaceControl.get('passwordReset').value">
-            <mat-label>{{'DIALOGS.INVITE_MEMBER.LANGUAGE' | translate}}</mat-label>
-            <mat-select [(value)]="currentLanguage">
-              <mat-option *ngFor="let lang of languages" value="{{lang}}">
-                {{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
+            <span
+              matTooltip="{{'DIALOGS.CREATE_SPONSORED_MEMBER.PASSWORD_RESET_DISABLED' | translate}}"
+              [matTooltipDisabled]="namespaceControl.get('passwordReset').enabled"
+              matTooltipPosition="left">
+              <mat-checkbox
+                labelPosition="before"
+                (change)="passwordResetChange()"
+                formControlName="passwordReset"
+                >{{'DIALOGS.CREATE_SPONSORED_MEMBER.PASSWORD_RESET' | translate}}
+              </mat-checkbox>
+            </span>
+            <mat-form-field *ngIf="namespaceControl.get('passwordReset').value">
+              <mat-label>{{'DIALOGS.INVITE_MEMBER.LANGUAGE' | translate}}</mat-label>
+              <mat-select [(value)]="currentLanguage">
+                <mat-option *ngFor="let lang of languages" value="{{lang}}">
+                  {{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
 
-          <perun-web-apps-password-form
-            [formGroup]="namespaceControl"
-            [namespace]="selectedNamespace"
-            [tooltipPwdViaEmail]="this.namespaceControl.get('passwordReset').value">
-          </perun-web-apps-password-form>
-        </form>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.CREATE_SPONSORED_MEMBER.SPONSORSHIP_LABEL' | translate}}</ng-template
-        >
-        <div class="dialog-container">
-          <h5 class="mt-2">{{'DIALOGS.CREATE_SPONSORED_MEMBER.SPONSORSHIP_TITLE' | translate}}</h5>
-          <app-choose-sponsor
+            <perun-web-apps-password-form
+              [formGroup]="namespaceControl"
+              [namespace]="selectedNamespace"
+              [tooltipPwdViaEmail]="this.namespaceControl.get('passwordReset').value">
+            </perun-web-apps-password-form>
+          </form>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.CREATE_SPONSORED_MEMBER.SPONSORSHIP_LABEL' | translate}}</ng-template
+          >
+          <div class="dialog-container">
+            <h5 class="mt-2">
+              {{'DIALOGS.CREATE_SPONSORED_MEMBER.SPONSORSHIP_TITLE' | translate}}
+            </h5>
+            <app-choose-sponsor
+              [voId]="data.voId"
+              [voSponsors]="data.sponsors"
+              (sponsorTypeSelected)="sponsorType = $event"
+              (sponsorSelected)="selectedSponsor = $event">
+            </app-choose-sponsor>
+
+            <h6 class="mt-4">{{'DIALOGS.CREATE_SPONSORED_MEMBER.EXPIRATION' | translate}}</h6>
+            <perun-web-apps-expiration-select (datePicker)="setExpiration($event)" class="mt-2">
+            </perun-web-apps-expiration-select>
+          </div>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GROUPS_LABEL' | translate}}</ng-template
+          >
+          <app-assign-groups-sponsored-members-component
+            (groupsToAdd)="createMember($event)"
+            (submitAllowed)="submitAllowed = $event"
             [voId]="data.voId"
-            [voSponsors]="data.sponsors"
-            (sponsorTypeSelected)="sponsorType = $event"
-            (sponsorSelected)="selectedSponsor = $event">
-          </app-choose-sponsor>
-
-          <h6 class="mt-4">{{'DIALOGS.CREATE_SPONSORED_MEMBER.EXPIRATION' | translate}}</h6>
-          <perun-web-apps-expiration-select (datePicker)="setExpiration($event)" class="mt-2">
-          </perun-web-apps-expiration-select>
-        </div>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GROUPS_LABEL' | translate}}</ng-template
-        >
-        <app-assign-groups-sponsored-members-component
-          (groupsToAdd)="createMember($event)"
-          (submitAllowed)="submitAllowed = $event"
-          [voId]="data.voId"
-          [submit]="groupsToAssign.asObservable()"></app-assign-groups-sponsored-members-component>
-      </mat-step>
-    </mat-stepper>
-  </div>
-
-  <div *ngIf="!loading && successfullyCreated" class="dialog-container" mat-dialog-content>
-    <div class="bigger-font mb-2">
-      <mat-icon class="mr-2 mb-2">done</mat-icon>
-      {{'DIALOGS.CREATE_SPONSORED_MEMBER.USER' | translate}}
-      <i>{{this.createdMember.user | userFullName}}</i>
-      {{'DIALOGS.CREATE_SPONSORED_MEMBER.WAS_CREATED' | translate}}
+            [submit]="groupsToAssign.asObservable()"></app-assign-groups-sponsored-members-component>
+        </mat-step>
+      </mat-stepper>
     </div>
-    <div>{{'DIALOGS.CREATE_SPONSORED_MEMBER.LOGIN' | translate}}: {{this.loginThatWasSet}}</div>
-    <div>
-      {{'DIALOGS.CREATE_SPONSORED_MEMBER.PASSWORD' | translate}} :
-      {{this.namespaceControl.get('passwordCtrl').value}}
+
+    <div *ngIf="successfullyCreated" class="dialog-container" mat-dialog-content>
+      <div class="bigger-font mb-2">
+        <mat-icon class="mr-2 mb-2">done</mat-icon>
+        {{'DIALOGS.CREATE_SPONSORED_MEMBER.USER' | translate}}
+        <i>{{this.createdMember.user | userFullName}}</i>
+        {{'DIALOGS.CREATE_SPONSORED_MEMBER.WAS_CREATED' | translate}}
+      </div>
+      <div>{{'DIALOGS.CREATE_SPONSORED_MEMBER.LOGIN' | translate}}: {{this.loginThatWasSet}}</div>
+      <div>
+        {{'DIALOGS.CREATE_SPONSORED_MEMBER.PASSWORD' | translate}} :
+        {{this.namespaceControl.get('passwordCtrl').value}}
+      </div>
+      <perun-web-apps-alert
+        alert_type="warn"
+        >{{'DIALOGS.CREATE_SPONSORED_MEMBER.COPY_INFORMATION' | translate}}</perun-web-apps-alert
+      >
+      <perun-web-apps-alert
+        *ngIf="finishedWithErrors"
+        alert_type="error"
+        >{{'DIALOGS.CREATE_SPONSORED_MEMBER.WITH_ERRORS' | translate}}</perun-web-apps-alert
+      >
     </div>
-    <perun-web-apps-alert
-      alert_type="warn"
-      >{{'DIALOGS.CREATE_SPONSORED_MEMBER.COPY_INFORMATION' | translate}}</perun-web-apps-alert
-    >
-    <perun-web-apps-alert
-      *ngIf="finishedWithErrors"
-      alert_type="error"
-      >{{'DIALOGS.CREATE_SPONSORED_MEMBER.WITH_ERRORS' | translate}}</perun-web-apps-alert
-    >
-  </div>
 
-  <div *ngIf="successfullyCreated" mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button data-cy="ok-button">
-      {{'DIALOGS.CREATE_SPONSORED_MEMBER.OK' | translate}}
-    </button>
-  </div>
+    <div *ngIf="successfullyCreated" mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button data-cy="ok-button">
+        {{'DIALOGS.CREATE_SPONSORED_MEMBER.OK' | translate}}
+      </button>
+    </div>
 
-  <div *ngIf="!loading && !successfullyCreated" mat-dialog-actions>
-    <button (click)="onCancel()" mat-flat-button>
-      {{'DIALOGS.CREATE_SPONSORED_MEMBER.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="stepperPrevious()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
-      class="ml-auto"
-      mat-flat-button>
-      {{'DIALOGS.CREATE_SPONSORED_MEMBER.BACK' | translate}}
-    </button>
-    <button
-      data-cy="next-button"
-      (click)="stepperNext()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
-      [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
-      [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
-      [disabled]="getStepperNextConditions()"
-      color="accent"
-      mat-flat-button
-      type="button">
-      {{'DIALOGS.CREATE_SPONSORED_MEMBER.NEXT' | translate}}
-    </button>
-    <button
-      data-cy="confirm-button"
-      (click)="onConfirm()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
-      [disabled]="!submitAllowed"
-      class="ml-2"
-      color="accent"
-      mat-flat-button
-      type="button">
-      {{'DIALOGS.CREATE_SPONSORED_MEMBER.SUBMIT' | translate}}
-    </button>
+    <div *ngIf="!successfullyCreated && stepper !== undefined" mat-dialog-actions>
+      <button (click)="onCancel()" mat-flat-button>
+        {{'DIALOGS.CREATE_SPONSORED_MEMBER.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="stepperPrevious()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
+        class="ml-auto"
+        mat-flat-button>
+        {{'DIALOGS.CREATE_SPONSORED_MEMBER.BACK' | translate}}
+      </button>
+      <button
+        data-cy="next-button"
+        (click)="stepperNext()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
+        [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
+        [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
+        [disabled]="getStepperNextConditions()"
+        color="accent"
+        mat-flat-button
+        type="button">
+        {{'DIALOGS.CREATE_SPONSORED_MEMBER.NEXT' | translate}}
+      </button>
+      <button
+        data-cy="confirm-button"
+        (click)="onConfirm()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
+        [disabled]="!submitAllowed"
+        class="ml-2"
+        color="accent"
+        mat-flat-button
+        type="button">
+        {{'DIALOGS.CREATE_SPONSORED_MEMBER.SUBMIT' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
@@ -103,6 +103,7 @@ export class CreateSponsoredMemberDialogComponent implements OnInit {
   }
 
   onConfirm(): void {
+    this.loading = true;
     this.groupsToAssign.next();
   }
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-vo-dialog/create-vo-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-vo-dialog/create-vo-dialog.component.html
@@ -1,7 +1,9 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{"DIALOGS.CREATE_VO.TITLE" | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{"DIALOGS.CREATE_VO.TITLE" | translate}}</h1>
     <div class="dialog-container" mat-dialog-content>
       <mat-form-field>
         <input

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-definition-dialog/delete-attribute-definition-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-definition-dialog/delete-attribute-definition-dialog.component.html
@@ -1,41 +1,45 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <div>
-      {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.TEXT_LINE1' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <div>
+        {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.TEXT_LINE1' | translate}}
+      </div>
+
+      <div class="font-weight-bold">
+        {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.TEXT_LINE2' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let attribute" mat-cell>{{attribute.friendlyName}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
+      </table>
+
+      <perun-web-apps-alert class="mt-3" alert_type="warn">
+        {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.WARNING' | translate}}
+      </perun-web-apps-alert>
     </div>
-
-    <div class="font-weight-bold">
-      {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.TEXT_LINE2' | translate}}
+    <div class="mt-3" mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        [disabled]="loading"
+        class="ml-2"
+        color="warn"
+        mat-flat-button
+        data-cy="confirm-delete-attr-definition-button">
+        {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.CONFIRM' | translate}}
+      </button>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let attribute" mat-cell>{{attribute.friendlyName}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
-    </table>
-
-    <perun-web-apps-alert class="mt-3" alert_type="warn">
-      {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.WARNING' | translate}}
-    </perun-web-apps-alert>
-  </div>
-  <div class="mt-3" mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      [disabled]="loading"
-      class="ml-2"
-      color="warn"
-      mat-flat-button
-      data-cy="confirm-delete-attr-definition-button">
-      {{'DIALOGS.DELETE_ATTRIBUTE_DEFINITION.CONFIRM' | translate}}
-    </button>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-dialog/delete-attribute-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-attribute-dialog/delete-attribute-dialog.component.html
@@ -1,37 +1,41 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.DELETE_ATTRIBUTES.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <div>
-      {{'DIALOGS.DELETE_ATTRIBUTES.DESCRIPTION' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.DELETE_ATTRIBUTES.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <div>
+        {{'DIALOGS.DELETE_ATTRIBUTES.DESCRIPTION' | translate}}
+      </div>
+
+      <div class="font-weight-bold">
+        {{'DIALOGS.DELETE_ATTRIBUTES.ASK' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let attribute" mat-cell>{{attribute.displayName}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-
-    <div class="font-weight-bold">
-      {{'DIALOGS.DELETE_ATTRIBUTES.ASK' | translate}}
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.DELETE_ATTRIBUTES.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        class="ml-2"
+        color="warn"
+        data-cy="delete-attributes"
+        [disabled]="loading"
+        mat-flat-button>
+        {{'DIALOGS.DELETE_ATTRIBUTES.DELETE' | translate}}
+      </button>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let attribute" mat-cell>{{attribute.displayName}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.DELETE_ATTRIBUTES.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      class="ml-2"
-      color="warn"
-      data-cy="delete-attributes"
-      [disabled]="loading"
-      mat-flat-button>
-      {{'DIALOGS.DELETE_ATTRIBUTES.DELETE' | translate}}
-    </button>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-notification-dialog/delete-notification-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-notification-dialog/delete-notification-dialog.component.html
@@ -1,31 +1,35 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.DESCRIPTION' | translate}}
-    </p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.DESCRIPTION' | translate}}
+      </p>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.CONFIRMATION' | translate}}
+      <div class="font-weight-bold">
+        {{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.CONFIRMATION' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let mail" mat-cell>{{getMailType(mail)}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let mail; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let mail" mat-cell>{{getMailType(mail)}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let mail; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.SUBMIT' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.APPLICATION_FORM_DELETE_MAIL.SUBMIT' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-resource-tag-dialog/delete-resource-tag-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-resource-tag-dialog/delete-resource-tag-dialog.component.html
@@ -1,31 +1,35 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.DELETE_RESOURCE_TAG.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.DELETE_RESOURCE_TAG.DESCRIPTION' | translate}}
-    </p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.DELETE_RESOURCE_TAG.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.DELETE_RESOURCE_TAG.DESCRIPTION' | translate}}
+      </p>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.DELETE_RESOURCE_TAG.ASK' | translate}}
+      <div class="font-weight-bold">
+        {{'DIALOGS.DELETE_RESOURCE_TAG.ASK' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let tag" mat-cell>{{tag.tagName}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let tag; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let tag" mat-cell>{{tag.tagName}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let tag; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.DELETE_RESOURCE_TAG.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.DELETE_RESOURCE_TAG.SUBMIT' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.DELETE_RESOURCE_TAG.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.DELETE_RESOURCE_TAG.SUBMIT' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-service-from-facility/delete-service-from-facility.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-service-from-facility/delete-service-from-facility.component.html
@@ -1,69 +1,72 @@
-<h1 mat-dialog-title>{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOXES_DESCRIPTION' | translate}}</p>
-    <div>
-      <mat-checkbox
-        *ngIf="taskId !== null"
-        (change)="change($event)"
-        class="right-space"
-        color="warn"
-        [checked]="taskChecked"
-        [disabled]="checkboxesDisabled"
-        [matTooltipDisabled]="!checkboxesDisabled"
-        id="task"
-        matTooltip="{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOXES_DISABLED' | translate}}">
-        {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOX_TASK_AND_TASK_RESULTS' | translate}}
-      </mat-checkbox>
-      <mat-checkbox
-        *ngIf="taskId !== null"
-        (change)="change($event)"
-        class="right-space"
-        color="warn"
-        [checked]="taskResultsChecked"
-        [disabled]="checkboxesDisabled"
-        [matTooltipDisabled]="!checkboxesDisabled"
-        id="taskResults"
-        matTooltip="{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOXES_DISABLED' | translate}}">
-        {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOX_TASK_RESULTS' | translate}}
-      </mat-checkbox>
-      <mat-checkbox
-        (change)="change($event)"
-        [disabled]="checkboxesDisabled"
-        [matTooltipDisabled]="!checkboxesDisabled"
-        color="warn"
-        id="destination"
-        [checked]="destinationChecked"
-        matTooltip="{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOXES_DISABLED' | translate}}">
-        {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOX_DESTINATION' | translate}}
-      </mat-checkbox>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOXES_DESCRIPTION' | translate}}</p>
+      <div>
+        <mat-checkbox
+          *ngIf="taskId !== null"
+          (change)="change($event)"
+          class="right-space"
+          color="warn"
+          [checked]="taskChecked"
+          [disabled]="checkboxesDisabled"
+          [matTooltipDisabled]="!checkboxesDisabled"
+          id="task"
+          matTooltip="{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOXES_DISABLED' | translate}}">
+          {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOX_TASK_AND_TASK_RESULTS' | translate}}
+        </mat-checkbox>
+        <mat-checkbox
+          *ngIf="taskId !== null"
+          (change)="change($event)"
+          class="right-space"
+          color="warn"
+          [checked]="taskResultsChecked"
+          [disabled]="checkboxesDisabled"
+          [matTooltipDisabled]="!checkboxesDisabled"
+          id="taskResults"
+          matTooltip="{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOXES_DISABLED' | translate}}">
+          {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOX_TASK_RESULTS' | translate}}
+        </mat-checkbox>
+        <mat-checkbox
+          (change)="change($event)"
+          [disabled]="checkboxesDisabled"
+          [matTooltipDisabled]="!checkboxesDisabled"
+          color="warn"
+          id="destination"
+          [checked]="destinationChecked"
+          matTooltip="{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOXES_DISABLED' | translate}}">
+          {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CHECKBOX_DESTINATION' | translate}}
+        </mat-checkbox>
+      </div>
+      <p>{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.DESCRIPTION' | translate}}</p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.ASK' | translate}}
+      </div>
+      <perun-web-apps-resources-list
+        (allSelected)="disableCheckboxes($event)"
+        [displayedColumns]="displayedColumns"
+        [disableRouting]="true"
+        [resources]="resources"
+        [selection]="selected"
+        [tableId]="tableId">
+      </perun-web-apps-resources-list>
     </div>
-    <p>{{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.DESCRIPTION' | translate}}</p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.ASK' | translate}}
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="remove()"
+        class="ml-2"
+        color="warn"
+        [disabled]="loading || selected.selected.length === 0"
+        mat-flat-button>
+        {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.REMOVE' | translate}}
+      </button>
     </div>
-    <perun-web-apps-resources-list
-      (allSelected)="disableCheckboxes($event)"
-      [displayedColumns]="displayedColumns"
-      *ngIf="!loading"
-      [disableRouting]="true"
-      [resources]="resources"
-      [selection]="selected"
-      [tableId]="tableId">
-    </perun-web-apps-resources-list>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="remove()"
-      class="ml-2"
-      color="warn"
-      [disabled]="loading || selected.selected.length === 0"
-      mat-flat-button>
-      {{'DIALOGS.REMOVE_SERVICE_FROM_FACILITY.REMOVE' | translate}}
-    </button>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-task-dialog/delete-task-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-task-dialog/delete-task-dialog.component.html
@@ -1,17 +1,21 @@
-<h1 mat-dialog-title>{{'DIALOGS.DELETE_TASK.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <div class="font-weight-bold">
-      {{'DIALOGS.DELETE_TASK.DESCRIPTION' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.DELETE_TASK.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <div class="font-weight-bold">
+        {{'DIALOGS.DELETE_TASK.DESCRIPTION' | translate}}
+      </div>
     </div>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.DELETE_TASK.CANCEL' | translate}}
-    </button>
-    <button (click)="remove()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.DELETE_TASK.DELETE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.DELETE_TASK.CANCEL' | translate}}
+      </button>
+      <button (click)="remove()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.DELETE_TASK.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-task-result-dialog/delete-task-result-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-task-result-dialog/delete-task-result-dialog.component.html
@@ -1,40 +1,46 @@
-<h1 mat-dialog-title>{{'DIALOGS.DELETE_TASK_RESULT.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>{{'DIALOGS.DELETE_TASK_RESULT.DESCRIPTION' | translate}}</p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.DELETE_TASK_RESULT.ASK' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.DELETE_TASK_RESULT.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>{{'DIALOGS.DELETE_TASK_RESULT.DESCRIPTION' | translate}}</p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.DELETE_TASK_RESULT.ASK' | translate}}
+      </div>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="id">
+          <th *matHeaderCellDef mat-header-cell>
+            {{'DIALOGS.DELETE_TASK_RESULT.RESULT_ID' | translate}}
+          </th>
+          <td *matCellDef="let taskResult" mat-cell>{{taskResult.id}}</td>
+        </ng-container>
+        <ng-container matColumnDef="destination">
+          <th *matHeaderCellDef mat-header-cell>
+            {{'DIALOGS.DELETE_TASK_RESULT.DESTINATION' | translate}}
+          </th>
+          <td *matCellDef="let taskResult" mat-cell>{{taskResult.destination.destination}}</td>
+        </ng-container>
+        <ng-container matColumnDef="time">
+          <th *matHeaderCellDef mat-header-cell>
+            {{'DIALOGS.DELETE_TASK_RESULT.TIME' | translate}}
+          </th>
+          <td *matCellDef="let taskResult" mat-cell>
+            {{taskResult.timestamp | date: 'd.M.y H:mm:ss'}}
+          </td>
+        </ng-container>
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let taskResult; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="id">
-        <th *matHeaderCellDef mat-header-cell>
-          {{'DIALOGS.DELETE_TASK_RESULT.RESULT_ID' | translate}}
-        </th>
-        <td *matCellDef="let taskResult" mat-cell>{{taskResult.id}}</td>
-      </ng-container>
-      <ng-container matColumnDef="destination">
-        <th *matHeaderCellDef mat-header-cell>
-          {{'DIALOGS.DELETE_TASK_RESULT.DESTINATION' | translate}}
-        </th>
-        <td *matCellDef="let taskResult" mat-cell>{{taskResult.destination.destination}}</td>
-      </ng-container>
-      <ng-container matColumnDef="time">
-        <th *matHeaderCellDef mat-header-cell>{{'DIALOGS.DELETE_TASK_RESULT.TIME' | translate}}</th>
-        <td *matCellDef="let taskResult" mat-cell>
-          {{taskResult.timestamp | date: 'd.M.y H:mm:ss'}}
-        </td>
-      </ng-container>
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let taskResult; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.DELETE_TASK_RESULT.CANCEL' | translate}}
-    </button>
-    <button (click)="onDelete()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.DELETE_TASK_RESULT.REMOVE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.DELETE_TASK_RESULT.CANCEL' | translate}}
+      </button>
+      <button (click)="onDelete()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.DELETE_TASK_RESULT.REMOVE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-data-dialog/edit-application-form-item-data-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-data-dialog/edit-application-form-item-data-dialog.component.html
@@ -1,39 +1,43 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>
-    {{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.TITLE' | translate}} {{itemName}}
-  </h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-form-field *ngIf="emailControl !== null">
-      <label>
-        <input [formControl]="emailControl" matInput required />
-      </label>
-      <mat-error
-        *ngIf="emailControl.invalid"
-        >{{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.INVALID_EMAIL' | translate}}</mat-error
-      >
-    </mat-form-field>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>
+      {{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.TITLE' | translate}} {{itemName}}
+    </h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-form-field *ngIf="emailControl !== null">
+        <label>
+          <input [formControl]="emailControl" matInput required />
+        </label>
+        <mat-error
+          *ngIf="emailControl.invalid"
+          >{{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.INVALID_EMAIL' | translate}}</mat-error
+        >
+      </mat-form-field>
 
-    <mat-form-field *ngIf="inputControl !== null">
-      <input [formControl]="inputControl" matInput required type="text" />
-      <mat-error
-        *ngIf="inputControl.invalid"
-        >{{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.EMPTY_INPUT' | translate}}</mat-error
-      >
-    </mat-form-field>
-  </div>
+      <mat-form-field *ngIf="inputControl !== null">
+        <input [formControl]="inputControl" matInput required type="text" />
+        <mat-error
+          *ngIf="inputControl.invalid"
+          >{{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.EMPTY_INPUT' | translate}}</mat-error
+        >
+      </mat-form-field>
+    </div>
 
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      [disabled]="loading || (inputControl !== null && inputControl.invalid) || (emailControl !== null && emailControl.invalid)"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.SUBMIT' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        [disabled]="loading || (inputControl !== null && inputControl.invalid) || (emailControl !== null && emailControl.invalid)"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.EDIT_APPLICATION_FORM_ITEM_DATA.SUBMIT' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.html
@@ -1,11 +1,13 @@
-<div class="{{theme}} h-100">
-  <div class="h-100 d-flex flex-column">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} h-100 position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner" class="h-100 d-flex flex-column">
     <h1 mat-dialog-title>
       {{'DIALOGS.APPLICATION_FORM_EDIT_ITEM.TITLE' | translate}} :
       {{this.applicationFormItem.shortname}}
     </h1>
-    <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-    <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
+    <div class="dialog-container" mat-dialog-content>
       <mat-tab-group color="primary">
         <mat-tab label="{{'DIALOGS.APPLICATION_FORM_EDIT_ITEM.BASIC_SETTINGS' | translate}}">
           <app-edit-application-form-item-line
@@ -58,6 +60,7 @@
               </app-edit-application-form-item-line>
             </div>
             <app-edit-application-form-item-line
+              *ngIf="destinationAttributes !== undefined"
               [description]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.SOURCE_ATTRIBUTE_DESCRIPTION' | translate"
               [label]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.SOURCE_ATTRIBUTE' | translate">
               <div class="w-100">
@@ -71,6 +74,7 @@
               </div>
             </app-edit-application-form-item-line>
             <app-edit-application-form-item-line
+              *ngIf="destinationAttributes !== undefined"
               [description]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.DESTINATION_ATTRIBUTE_DESCRIPTION' | translate"
               [label]="'DIALOGS.APPLICATION_FORM_EDIT_ITEM.DESTINATION_ATTRIBUTE' | translate">
               <div class="w-100">

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component.html
@@ -1,106 +1,110 @@
-<div class="admin-theme">
-  <div *ngIf="!showKeys">
-    <h1 mat-dialog-title>{{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.TITLE' | translate}}</h1>
-    <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-    <div *ngIf="!loading" mat-dialog-content>
-      <form [formGroup]="attributeControl" class="fields-container">
-        <mat-form-field>
-          <input
-            matInput
-            data-cy="display-name-input"
-            formControlName="name"
-            placeholder="{{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.DISPLAY_NAME' | translate}}"
-            required />
-          <mat-error *ngIf="attributeControl.hasError('required', 'name')">
-            {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
-          </mat-error>
-        </mat-form-field>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="admin-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <div *ngIf="!showKeys">
+      <h1 mat-dialog-title>{{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.TITLE' | translate}}</h1>
+      <div mat-dialog-content>
+        <form [formGroup]="attributeControl" class="fields-container">
+          <mat-form-field>
+            <input
+              matInput
+              data-cy="display-name-input"
+              formControlName="name"
+              placeholder="{{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.DISPLAY_NAME' | translate}}"
+              required />
+            <mat-error *ngIf="attributeControl.hasError('required', 'name')">
+              {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
+            </mat-error>
+          </mat-form-field>
 
-        <mat-form-field>
-          <textarea
-            matInput
-            formControlName="description"
-            cdkTextareaAutosize
-            placeholder="{{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.DESCRIPTION' | translate}}"
-            required>
-          </textarea>
-          <mat-error *ngIf="attributeControl.hasError('required', 'description')">
-            {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
-          </mat-error>
-        </mat-form-field>
-      </form>
+          <mat-form-field>
+            <textarea
+              matInput
+              formControlName="description"
+              cdkTextareaAutosize
+              placeholder="{{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.DESCRIPTION' | translate}}"
+              required>
+            </textarea>
+            <mat-error *ngIf="attributeControl.hasError('required', 'description')">
+              {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.ERROR_FIELD_EMPTY' | translate}}
+            </mat-error>
+          </mat-form-field>
+        </form>
 
-      <label class="urn-name">
-        {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.URN' | translate}}
-      </label>
-      <div class="urn-row">
-        {{urn}}
-        <mat-icon
-          class="copy-urn"
-          matSuffix
-          (click)="copyUrn()"
-          matTooltip="{{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.URN_TOOLTIP' | translate}}"
-          >content_copy</mat-icon
-        >
+        <label class="urn-name">
+          {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.URN' | translate}}
+        </label>
+        <div class="urn-row">
+          {{urn}}
+          <mat-icon
+            class="copy-urn"
+            matSuffix
+            (click)="copyUrn()"
+            matTooltip="{{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.URN_TOOLTIP' | translate}}"
+            >content_copy</mat-icon
+          >
+        </div>
+
+        <perun-web-apps-attribute-unique-toggle [attDef]="attDef">
+        </perun-web-apps-attribute-unique-toggle>
+
+        <perun-web-apps-attribute-critical-operations-toggles
+          [readOperation]="initReadOperations"
+          [writeOperation]="initWriteOperations"
+          (readOperationChanged)="finalReadOperations=$event"
+          (writeOperationChanged)="finalWriteOperations=$event">
+        </perun-web-apps-attribute-critical-operations-toggles>
+
+        <perun-web-apps-attribute-rights-tab-group
+          [attDef]="attDef"
+          [collections]="collections$ | async">
+        </perun-web-apps-attribute-rights-tab-group>
+
+        <mat-accordion>
+          <mat-expansion-panel class="mt-4 mb-4">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.SERVICES' | translate}}
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+            <app-services-list
+              [disableRouting]="true"
+              [displayedColumns]="['id', 'name', 'enabled', 'script']"
+              [services]="this.services$ | async">
+            </app-services-list>
+          </mat-expansion-panel>
+        </mat-accordion>
       </div>
 
-      <perun-web-apps-attribute-unique-toggle [attDef]="attDef">
-      </perun-web-apps-attribute-unique-toggle>
+      <div mat-dialog-actions>
+        <button *ngIf="attDef?.entity === 'entityless'" (click)="switchShowKeys()" mat-flat-button>
+          {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.SHOW_KEYS' | translate}}
+        </button>
+        <button (click)="onCopy()" class="ml-auto" mat-flat-button>
+          {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.COPY_FOR_IMPORT' | translate}}
+        </button>
+        <button (click)="onCancel()" class="ml-2" mat-flat-button>
+          {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.CANCEL' | translate}}
+        </button>
+        <button
+          class="ml-2"
+          color="accent"
+          mat-flat-button
+          (click)="onSubmit()"
+          [disabled]="loading || attributeControl.invalid">
+          {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.CONFIRM' | translate}}
+        </button>
+      </div>
+    </div>
 
-      <perun-web-apps-attribute-critical-operations-toggles
-        [readOperation]="initReadOperations"
-        [writeOperation]="initWriteOperations"
-        (readOperationChanged)="finalReadOperations=$event"
-        (writeOperationChanged)="finalWriteOperations=$event">
-      </perun-web-apps-attribute-critical-operations-toggles>
-
-      <perun-web-apps-attribute-rights-tab-group
+    <div *ngIf="showKeys">
+      <app-entityless-attribute-keys-list
+        (switchView)="switchShowKeys()"
         [attDef]="attDef"
-        [collections]="collections$ | async">
-      </perun-web-apps-attribute-rights-tab-group>
-
-      <mat-accordion>
-        <mat-expansion-panel class="mt-4 mb-4">
-          <mat-expansion-panel-header>
-            <mat-panel-title>
-              {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.SERVICES' | translate}}
-            </mat-panel-title>
-          </mat-expansion-panel-header>
-          <app-services-list
-            [disableRouting]="true"
-            [displayedColumns]="['id', 'name', 'enabled', 'script']"
-            [services]="this.services$ | async">
-          </app-services-list>
-        </mat-expansion-panel>
-      </mat-accordion>
+        [tableId]="tableId">
+      </app-entityless-attribute-keys-list>
     </div>
-
-    <div mat-dialog-actions>
-      <button *ngIf="attDef?.entity === 'entityless'" (click)="switchShowKeys()" mat-flat-button>
-        {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.SHOW_KEYS' | translate}}
-      </button>
-      <button (click)="onCopy()" class="ml-auto" mat-flat-button>
-        {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.COPY_FOR_IMPORT' | translate}}
-      </button>
-      <button (click)="onCancel()" class="ml-2" mat-flat-button>
-        {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.CANCEL' | translate}}
-      </button>
-      <button
-        class="ml-2"
-        color="accent"
-        mat-flat-button
-        (click)="onSubmit()"
-        [disabled]="loading || attributeControl.invalid">
-        {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.CONFIRM' | translate}}
-      </button>
-    </div>
-  </div>
-
-  <div *ngIf="showKeys">
-    <app-entityless-attribute-keys-list
-      (switchView)="switchShowKeys()"
-      [attDef]="attDef"
-      [tableId]="tableId">
-    </app-entityless-attribute-keys-list>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component.ts
@@ -60,11 +60,13 @@ export class EditAttributeDefinitionDialogComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.loading = true;
     this.dialogRef.addPanelClass('mat-dialog-height-transition');
     this.attributesManager.getAttributeRules(this.attDef.id).subscribe((attrRights) => {
       this.collections$ = new BehaviorSubject(attrRights.attributePolicyCollections);
       this.initReadOperations = attrRights.criticalActions.includes('READ');
       this.initWriteOperations = attrRights.criticalActions.includes('WRITE');
+      this.loading = false;
     });
   }
 
@@ -96,15 +98,15 @@ export class EditAttributeDefinitionDialogComponent implements OnInit {
           )
         )
       )
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.notificator.showSuccess(
             this.translate.instant('DIALOGS.EDIT_ATTRIBUTE_DEFINITION.SUCCESS') as string
           );
           this.dialogRef.close(true);
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
   }
 
   onCancel(): void {

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-email-footer-dialog/edit-email-footer-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-email-footer-dialog/edit-email-footer-dialog.component.html
@@ -1,47 +1,51 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <perun-web-apps-alert alert_type="info" *ngIf="plainEdithAuth && !htmlEditAuth">
-      {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.FORMAT_HTML_NOT_AUTHORIZED' | translate}}
-    </perun-web-apps-alert>
-    <mat-tab-group color="primary">
-      <mat-tab *ngFor="let format of formats" [disabled]="format === 'html' && !htmlEditAuth">
-        <ng-template mat-tab-label>
-          <span [ngClass]="{'disabled-label': format === 'html' && !htmlEditAuth}">
-            {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.FORMAT_' + format | uppercase | translate}}
-          </span>
-        </ng-template>
-        <mat-form-field class="w-100">
-          <textarea *ngIf="format === 'plain_text'" [(ngModel)]="mailFooter" matInput rows="5">
-          </textarea>
-          <textarea *ngIf="format === 'html'" [(ngModel)]="htmlMailFooter" matInput rows="5">
-          </textarea>
-        </mat-form-field>
-      </mat-tab>
-    </mat-tab-group>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <perun-web-apps-alert alert_type="info" *ngIf="plainEdithAuth && !htmlEditAuth">
+        {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.FORMAT_HTML_NOT_AUTHORIZED' | translate}}
+      </perun-web-apps-alert>
+      <mat-tab-group color="primary">
+        <mat-tab *ngFor="let format of formats" [disabled]="format === 'html' && !htmlEditAuth">
+          <ng-template mat-tab-label>
+            <span [ngClass]="{'disabled-label': format === 'html' && !htmlEditAuth}">
+              {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.FORMAT_' + format | uppercase | translate}}
+            </span>
+          </ng-template>
+          <mat-form-field class="w-100">
+            <textarea *ngIf="format === 'plain_text'" [(ngModel)]="mailFooter" matInput rows="5">
+            </textarea>
+            <textarea *ngIf="format === 'html'" [(ngModel)]="htmlMailFooter" matInput rows="5">
+            </textarea>
+          </mat-form-field>
+        </mat-tab>
+      </mat-tab-group>
 
-    <div class="mt-2 font-italic text-muted">
-      {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.DESCRIPTION' | translate}}
+      <div class="mt-2 font-italic text-muted">
+        {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.DESCRIPTION' | translate}}
+      </div>
     </div>
-  </div>
 
-  <div mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.CANCEL_BUTTON' | translate}}
-    </button>
-    <div
-      [matTooltipDisabled]="plainEdithAuth"
-      [matTooltipPosition]="'above'"
-      matTooltip="{{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.HINT' | translate}}">
-      <button
-        (click)="submit()"
-        [disabled]="loading || !plainEdithAuth"
-        class="ml-2"
-        color="accent"
-        mat-flat-button>
-        {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.SUBMIT_BUTTON' | translate}}
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.CANCEL_BUTTON' | translate}}
       </button>
+      <div
+        [matTooltipDisabled]="plainEdithAuth"
+        [matTooltipPosition]="'above'"
+        matTooltip="{{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.HINT' | translate}}">
+        <button
+          (click)="submit()"
+          [disabled]="loading || !plainEdithAuth"
+          class="ml-2"
+          color="accent"
+          mat-flat-button>
+          {{'DIALOGS.NOTIFICATIONS_EDIT_FOOTER.SUBMIT_BUTTON' | translate}}
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-email-footer-dialog/edit-email-footer-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-email-footer-dialog/edit-email-footer-dialog.component.ts
@@ -43,7 +43,6 @@ export class EditEmailFooterDialogComponent implements OnInit {
     } else {
       this.getFooterForVo();
     }
-    this.loading = false;
   }
 
   submit(): void {
@@ -96,9 +95,8 @@ export class EditEmailFooterDialogComponent implements OnInit {
   }
 
   private getFooterForVo(): void {
-    this.attributesManager
-      .getVoAttributeByName(this.data.voId, Urns.VO_DEF_MAIL_FOOTER)
-      .subscribe((footer) => {
+    this.attributesManager.getVoAttributeByName(this.data.voId, Urns.VO_DEF_MAIL_FOOTER).subscribe({
+      next: (footer) => {
         this.mailAttribute = footer;
         this.plainEdithAuth = this.mailAttribute.writable;
         if (footer.value) {
@@ -106,42 +104,57 @@ export class EditEmailFooterDialogComponent implements OnInit {
         } else {
           this.mailFooter = '';
         }
-      });
+        this.loading = false;
+      },
+      error: () => (this.loading = false),
+    });
     this.attributesManager
       .getVoAttributeByName(this.data.voId, Urns.VO_DEF_MAIL_HTML_FOOTER)
-      .subscribe((footer) => {
-        this.htmlMailAttribute = footer;
-        this.htmlEditAuth = this.htmlMailAttribute.writable;
-        if (footer.value) {
-          this.htmlMailFooter = footer.value as string;
-        } else {
-          this.htmlMailFooter = '';
-        }
+      .subscribe({
+        next: (footer) => {
+          this.htmlMailAttribute = footer;
+          this.htmlEditAuth = this.htmlMailAttribute.writable;
+          if (footer.value) {
+            this.htmlMailFooter = footer.value as string;
+          } else {
+            this.htmlMailFooter = '';
+          }
+          this.loading = false;
+        },
+        error: () => (this.loading = false),
       });
   }
 
   private getFooterForGroup(): void {
     this.attributesManager
       .getGroupAttributeByName(this.data.groupId, Urns.GROUP_DEF_MAIL_FOOTER)
-      .subscribe((footer) => {
-        this.mailAttribute = footer;
-        this.plainEdithAuth = this.mailAttribute.writable;
-        if (footer.value) {
-          this.mailFooter = footer.value as string;
-        } else {
-          this.mailFooter = '';
-        }
+      .subscribe({
+        next: (footer) => {
+          this.mailAttribute = footer;
+          this.plainEdithAuth = this.mailAttribute.writable;
+          if (footer.value) {
+            this.mailFooter = footer.value as string;
+          } else {
+            this.mailFooter = '';
+          }
+          this.loading = false;
+        },
+        error: () => (this.loading = false),
       });
     this.attributesManager
       .getGroupAttributeByName(this.data.groupId, Urns.GROUP_DEF_MAIL_HTML_FOOTER)
-      .subscribe((footer) => {
-        this.htmlMailAttribute = footer;
-        this.htmlEditAuth = this.htmlMailAttribute.writable;
-        if (footer.value) {
-          this.htmlMailFooter = footer.value as string;
-        } else {
-          this.htmlMailFooter = '';
-        }
+      .subscribe({
+        next: (footer) => {
+          this.htmlMailAttribute = footer;
+          this.htmlEditAuth = this.htmlMailAttribute.writable;
+          if (footer.value) {
+            this.htmlMailFooter = footer.value as string;
+          } else {
+            this.htmlMailFooter = '';
+          }
+          this.loading = false;
+        },
+        error: () => (this.loading = false),
       });
   }
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-member-sponsors-dialog/edit-member-sponsors-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-member-sponsors-dialog/edit-member-sponsors-dialog.component.html
@@ -1,79 +1,83 @@
-<h1 mat-dialog-title>{{'DIALOGS.EDIT_MEMBER_SPONSORS.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="id">
-        <th *matHeaderCellDef mat-header-cell>
-          {{'DIALOGS.EDIT_MEMBER_SPONSORS.TABLE_ID' | translate}}
-        </th>
-        <td *matCellDef="let sponsor" mat-cell>{{sponsor.user.id}}</td>
-      </ng-container>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell>
-          {{'DIALOGS.EDIT_MEMBER_SPONSORS.TABLE_NAME' | translate}}
-        </th>
-        <td *matCellDef="let sponsor" mat-cell>{{sponsor.user | userFullName}}</td>
-      </ng-container>
-      <ng-container matColumnDef="expiration">
-        <th *matHeaderCellDef mat-header-cell>
-          {{'DIALOGS.EDIT_MEMBER_SPONSORS.TABLE_EXPIRATION' | translate}}
-        </th>
-        <td *matCellDef="let sponsor" mat-cell>
-          <span>{{parseDate(sponsor.validityTo)}}</span>
-          <button
-            *ngIf="isExpirationAuthorized(sponsor)"
-            (click)="changeExpiration(sponsor)"
-            mat-icon-button>
-            <mat-icon> today </mat-icon>
-          </button>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="remove">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let sponsor" mat-cell>
-          <div
-            [matTooltipDisabled]="isRemoveAuthorized(sponsor)"
-            [matTooltipPosition]="'above'"
-            matTooltip="{{'DIALOGS.EDIT_MEMBER_SPONSORS.REMOVE_SPONSOR_DISABLED' | translate}}">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.EDIT_MEMBER_SPONSORS.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="id">
+          <th *matHeaderCellDef mat-header-cell>
+            {{'DIALOGS.EDIT_MEMBER_SPONSORS.TABLE_ID' | translate}}
+          </th>
+          <td *matCellDef="let sponsor" mat-cell>{{sponsor.user.id}}</td>
+        </ng-container>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell>
+            {{'DIALOGS.EDIT_MEMBER_SPONSORS.TABLE_NAME' | translate}}
+          </th>
+          <td *matCellDef="let sponsor" mat-cell>{{sponsor.user | userFullName}}</td>
+        </ng-container>
+        <ng-container matColumnDef="expiration">
+          <th *matHeaderCellDef mat-header-cell>
+            {{'DIALOGS.EDIT_MEMBER_SPONSORS.TABLE_EXPIRATION' | translate}}
+          </th>
+          <td *matCellDef="let sponsor" mat-cell>
+            <span>{{parseDate(sponsor.validityTo)}}</span>
             <button
-              attr.data-cy="{{sponsor.user.firstName}}-unsponsor-mark-button"
-              (click)="markSponsor(sponsor)"
-              class="btn-delete"
-              [disabled]="!isRemoveAuthorized(sponsor)"
+              *ngIf="isExpirationAuthorized(sponsor)"
+              (click)="changeExpiration(sponsor)"
               mat-icon-button>
-              <mat-icon
-                *ngIf="!sponsorsToRemove.has(sponsor.user.id)"
-                class="icn-delete"
-                color="warn"
-                >clear</mat-icon
-              >
-              <mat-icon *ngIf="sponsorsToRemove.has(sponsor.user.id)"
-                >settings_backup_restore</mat-icon
-              >
+              <mat-icon> today </mat-icon>
             </button>
-          </div>
-        </td>
-      </ng-container>
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr
-        [class.make-red]="sponsorsToRemove.has(sponsor.user.id)"
-        *matRowDef="let sponsor; columns: displayedColumns;"
-        mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.EDIT_MEMBER_SPONSORS.CANCEL' | translate}}
-    </button>
-    <button
-      data-cy="unsponsor-confirm-button"
-      (click)="onSubmit()"
-      class="ml-2"
-      color="warn"
-      [disabled]="loading || sponsorsToRemove.size === 0"
-      mat-flat-button>
-      {{'DIALOGS.EDIT_MEMBER_SPONSORS.SUBMIT' | translate}}
-    </button>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="remove">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let sponsor" mat-cell>
+            <div
+              [matTooltipDisabled]="isRemoveAuthorized(sponsor)"
+              [matTooltipPosition]="'above'"
+              matTooltip="{{'DIALOGS.EDIT_MEMBER_SPONSORS.REMOVE_SPONSOR_DISABLED' | translate}}">
+              <button
+                attr.data-cy="{{sponsor.user.firstName}}-unsponsor-mark-button"
+                (click)="markSponsor(sponsor)"
+                class="btn-delete"
+                [disabled]="!isRemoveAuthorized(sponsor)"
+                mat-icon-button>
+                <mat-icon
+                  *ngIf="!sponsorsToRemove.has(sponsor.user.id)"
+                  class="icn-delete"
+                  color="warn"
+                  >clear</mat-icon
+                >
+                <mat-icon *ngIf="sponsorsToRemove.has(sponsor.user.id)"
+                  >settings_backup_restore</mat-icon
+                >
+              </button>
+            </div>
+          </td>
+        </ng-container>
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr
+          [class.make-red]="sponsorsToRemove.has(sponsor.user.id)"
+          *matRowDef="let sponsor; columns: displayedColumns;"
+          mat-row></tr>
+      </table>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.EDIT_MEMBER_SPONSORS.CANCEL' | translate}}
+      </button>
+      <button
+        data-cy="unsponsor-confirm-button"
+        (click)="onSubmit()"
+        class="ml-2"
+        color="warn"
+        [disabled]="loading || sponsorsToRemove.size === 0"
+        mat-flat-button>
+        {{'DIALOGS.EDIT_MEMBER_SPONSORS.SUBMIT' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.html
@@ -1,188 +1,195 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-stepper #stepper *ngIf='state === "user-input"' [linear]="true">
-      <mat-step [stepControl]="usersInfoFormGroup">
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.USERS_LABEL' | translate}}</ng-template
-        >
-        <perun-web-apps-alert alert_type="error" *ngIf="this.functionalityNotSupported">
-          {{'DIALOGS.CREATE_SPONSORED_MEMBER.FUNCTIONALITY_NOT_SUPPORTED' | translate}}
-        </perun-web-apps-alert>
-        <h5 class="mt-2">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.USERS_INFO' | translate}}</h5>
-        <form [formGroup]="usersInfoFormGroup" class="flex-container mt-2">
-          <mat-form-field>
-            <mat-select
-              data-cy="namespace-filter"
-              placeholder="{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NAMESPACE' | translate}}"
-              formControlName="namespace"
-              required>
-              <mat-option
-                *ngFor="let namespc of namespaceOptions"
-                [value]="namespc"
-                attr.data-cy="{{namespc}}">
-                {{namespc}}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="usersInfoFormGroup.hasError('required', 'namespace')">
-              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NAMESPACE_ERROR' | translate}}
-            </mat-error>
-          </mat-form-field>
-          <div>{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.HINT'| translate}}</div>
-          <div class="font-weight-bold">
-            {{this.getSelectedNamespaceRules().csvGenHeaderDescription}}
-          </div>
-          <mat-form-field class="pt-2">
-            <mat-label>{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.INSERT_HERE'| translate}}</mat-label>
-            <textarea
-              data-cy="csv-input"
-              cols="50"
-              class="md-textarea form-control"
-              id="voGenerateSponsoredMembers"
-              name="voGenerateSponsoredMembers"
-              formControlName="sponsoredMembers"
-              matInput
-              placeholder="{{this.getSelectedNamespaceRules().csvGenPlaceholder}}"
-              rows="8">
-            </textarea>
-            <mat-error *ngIf="usersInfoFormGroup.hasError('required', 'sponsoredMembers')">
-              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NAMES_ERROR' | translate}}
-            </mat-error>
-            <mat-error *ngIf="usersInfoFormGroup.hasError('invalidFormat', 'sponsoredMembers')">
-              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ERROR_FORMAT'| translate}}:
-              {{usersInfoFormGroup.get('sponsoredMembers').getError('invalidFormat').value}}
-            </mat-error>
-            <mat-error *ngIf="usersInfoFormGroup.hasError('invalidEmail', 'sponsoredMembers')">
-              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ERROR_EMAIL'| translate}}:
-              {{usersInfoFormGroup.get('sponsoredMembers').getError('invalidEmail').value}}
-            </mat-error>
-            <mat-error *ngIf="usersInfoFormGroup.hasError('invalidLogin', 'sponsoredMembers')">
-              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ERROR_LOGIN'| translate}}:
-              {{usersInfoFormGroup.get('sponsoredMembers').getError('invalidLogin').value}}
-            </mat-error>
-          </mat-form-field>
-        </form>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.PASSWORD_LABEL' | translate}}</ng-template
-        >
-        <div class="mt-2">
-          <h5 class="mb-4">
-            {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.PASSWORD_MANAGEMENT' | translate}}
-          </h5>
-          <perun-web-apps-alert
-            alert_type="info"
-            *ngIf="getSelectedNamespaceRules().namespaceName === 'No namespace'">
-            {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NO_NAMESPACE_PASSWORD_INFO' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-stepper
+        #stepper
+        *ngIf='state === "user-input" && namespaceRules.length !== 0'
+        [linear]="true">
+        <mat-step [stepControl]="usersInfoFormGroup">
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.USERS_LABEL' | translate}}</ng-template
+          >
+          <perun-web-apps-alert alert_type="error" *ngIf="this.functionalityNotSupported">
+            {{'DIALOGS.CREATE_SPONSORED_MEMBER.FUNCTIONALITY_NOT_SUPPORTED' | translate}}
           </perun-web-apps-alert>
-          <mat-radio-group
-            *ngIf="getSelectedNamespaceRules().namespaceName !== 'No namespace'"
-            [(ngModel)]="passwordReset">
-            <mat-radio-button value="generate">
-              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GENERATE_PASSWORD' | translate}}
-            </mat-radio-button>
-            <mat-radio-button value="reset">
-              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.PASSWORD_RESET' | translate}}
-            </mat-radio-button>
-          </mat-radio-group>
-          <mat-form-field class="w-100" *ngIf="passwordReset === 'reset'">
-            <mat-label>{{'DIALOGS.INVITE_MEMBER.LANGUAGE' | translate}}</mat-label>
-            <mat-select [(value)]="currentLanguage">
-              <mat-option *ngFor="let lang of languages" value="{{lang}}">
-                {{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.EXPIRATION_LABEL' | translate}}</ng-template
-        >
-        <div class="mt-2">
-          <h5 class="mb-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.EXPIRATION' | translate}}</h5>
-          <perun-web-apps-expiration-select
-            (datePicker)="setExpiration($event)"
-            [expiration]="expiration">
-          </perun-web-apps-expiration-select>
-        </div>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GROUPS_LABEL' | translate}}</ng-template
-        >
-        <app-assign-groups-sponsored-members-component
-          (groupsToAdd)="onGenerate($event)"
-          (submitAllowed)="submitAllowed = $event"
-          [voId]="data.voId"
-          [submit]="groupsToAssign.asObservable()"></app-assign-groups-sponsored-members-component>
-      </mat-step>
-    </mat-stepper>
-    <div *ngIf='state === "results"'>
-      <perun-web-apps-alert *ngIf="this.finishedWithErrors === false" [alert_type]="'success'">
-        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.SUCCESS' | translate}}
-      </perun-web-apps-alert>
-      <perun-web-apps-alert *ngIf="this.finishedWithErrors" [alert_type]="'warn'">
-        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.FINISHED_WITH_ERRORS' | translate}}
-      </perun-web-apps-alert>
+          <h5 class="mt-2">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.USERS_INFO' | translate}}</h5>
+          <form [formGroup]="usersInfoFormGroup" class="flex-container mt-2">
+            <mat-form-field>
+              <mat-select
+                data-cy="namespace-filter"
+                placeholder="{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NAMESPACE' | translate}}"
+                formControlName="namespace"
+                required>
+                <mat-option
+                  *ngFor="let namespc of namespaceOptions"
+                  [value]="namespc"
+                  attr.data-cy="{{namespc}}">
+                  {{namespc}}
+                </mat-option>
+              </mat-select>
+              <mat-error *ngIf="usersInfoFormGroup.hasError('required', 'namespace')">
+                {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NAMESPACE_ERROR' | translate}}
+              </mat-error>
+            </mat-form-field>
+            <div>{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.HINT'| translate}}</div>
+            <div class="font-weight-bold">
+              {{this.getSelectedNamespaceRules().csvGenHeaderDescription}}
+            </div>
+            <mat-form-field class="pt-2">
+              <mat-label>{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.INSERT_HERE'| translate}}</mat-label>
+              <textarea
+                data-cy="csv-input"
+                cols="50"
+                class="md-textarea form-control"
+                id="voGenerateSponsoredMembers"
+                name="voGenerateSponsoredMembers"
+                formControlName="sponsoredMembers"
+                matInput
+                placeholder="{{this.getSelectedNamespaceRules().csvGenPlaceholder}}"
+                rows="8">
+              </textarea>
+              <mat-error *ngIf="usersInfoFormGroup.hasError('required', 'sponsoredMembers')">
+                {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NAMES_ERROR' | translate}}
+              </mat-error>
+              <mat-error *ngIf="usersInfoFormGroup.hasError('invalidFormat', 'sponsoredMembers')">
+                {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ERROR_FORMAT'| translate}}:
+                {{usersInfoFormGroup.get('sponsoredMembers').getError('invalidFormat').value}}
+              </mat-error>
+              <mat-error *ngIf="usersInfoFormGroup.hasError('invalidEmail', 'sponsoredMembers')">
+                {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ERROR_EMAIL'| translate}}:
+                {{usersInfoFormGroup.get('sponsoredMembers').getError('invalidEmail').value}}
+              </mat-error>
+              <mat-error *ngIf="usersInfoFormGroup.hasError('invalidLogin', 'sponsoredMembers')">
+                {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.ERROR_LOGIN'| translate}}:
+                {{usersInfoFormGroup.get('sponsoredMembers').getError('invalidLogin').value}}
+              </mat-error>
+            </mat-form-field>
+          </form>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.PASSWORD_LABEL' | translate}}</ng-template
+          >
+          <div class="mt-2">
+            <h5 class="mb-4">
+              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.PASSWORD_MANAGEMENT' | translate}}
+            </h5>
+            <perun-web-apps-alert
+              alert_type="info"
+              *ngIf="getSelectedNamespaceRules().namespaceName === 'No namespace'">
+              {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NO_NAMESPACE_PASSWORD_INFO' | translate}}
+            </perun-web-apps-alert>
+            <mat-radio-group
+              *ngIf="getSelectedNamespaceRules().namespaceName !== 'No namespace'"
+              [(ngModel)]="passwordReset">
+              <mat-radio-button value="generate">
+                {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GENERATE_PASSWORD' | translate}}
+              </mat-radio-button>
+              <mat-radio-button value="reset">
+                {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.PASSWORD_RESET' | translate}}
+              </mat-radio-button>
+            </mat-radio-group>
+            <mat-form-field class="w-100" *ngIf="passwordReset === 'reset'">
+              <mat-label>{{'DIALOGS.INVITE_MEMBER.LANGUAGE' | translate}}</mat-label>
+              <mat-select [(value)]="currentLanguage">
+                <mat-option *ngFor="let lang of languages" value="{{lang}}">
+                  {{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
+          </div>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.EXPIRATION_LABEL' | translate}}</ng-template
+          >
+          <div class="mt-2">
+            <h5 class="mb-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.EXPIRATION' | translate}}</h5>
+            <perun-web-apps-expiration-select
+              (datePicker)="setExpiration($event)"
+              [expiration]="expiration">
+            </perun-web-apps-expiration-select>
+          </div>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.GROUPS_LABEL' | translate}}</ng-template
+          >
+          <app-assign-groups-sponsored-members-component
+            (groupsToAdd)="onGenerate($event)"
+            (submitAllowed)="submitAllowed = $event"
+            [voId]="data.voId"
+            [submit]="groupsToAssign.asObservable()"></app-assign-groups-sponsored-members-component>
+        </mat-step>
+      </mat-stepper>
+      <div *ngIf='state === "results"'>
+        <perun-web-apps-alert *ngIf="this.finishedWithErrors === false" [alert_type]="'success'">
+          {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.SUCCESS' | translate}}
+        </perun-web-apps-alert>
+        <perun-web-apps-alert *ngIf="this.finishedWithErrors" [alert_type]="'warn'">
+          {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.FINISHED_WITH_ERRORS' | translate}}
+        </perun-web-apps-alert>
+      </div>
     </div>
-  </div>
-  <div *ngIf="!loading && stepper !== undefined && state !== 'results'" mat-dialog-actions>
-    <button (click)="onCancel()" mat-flat-button>
-      {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="stepperPrevious()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
-      class="ml-auto"
-      mat-flat-button>
-      {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.BACK' | translate}}
-    </button>
-    <button
-      data-cy="next-button"
-      (click)="stepperNext()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
-      [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
-      [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
-      [disabled]="getStepperNextConditions()"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NEXT' | translate}}
-    </button>
-    <button
-      data-cy="submit-button"
-      (click)="onSubmit()"
-      *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
-      [disabled]="!submitAllowed"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.SUBMIT' | translate}}
-    </button>
-  </div>
-  <div *ngIf='state === "results"' mat-dialog-actions>
-    <button (click)="onClose()" mat-flat-button data-cy="close-button">
-      {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.CLOSE' | translate}}
-    </button>
-    <button
-      [matMenuTriggerFor]="menu"
-      color="accent"
-      class="ml-auto dropdown-toggle"
-      mat-flat-button>
-      {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DOWNLOAD' | translate}}
-    </button>
-    <mat-menu #menu="matMenu">
-      <button (click)="generatePdf()" mat-menu-item>
-        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DOWNLOAD_PDF' | translate}}
+    <div *ngIf="stepper !== undefined && state !== 'results'" mat-dialog-actions>
+      <button (click)="onCancel()" mat-flat-button>
+        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.CANCEL' | translate}}
       </button>
-      <button (click)="downloadCsv()" mat-menu-item>
-        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DOWNLOAD_CSV' | translate}}
+      <button
+        (click)="stepperPrevious()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
+        class="ml-auto"
+        mat-flat-button>
+        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.BACK' | translate}}
       </button>
-    </mat-menu>
+      <button
+        data-cy="next-button"
+        (click)="stepperNext()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex !== stepper._steps.length - 1"
+        [class.ml-2]="stepper !== undefined && stepper.selectedIndex !== 0"
+        [class.ml-auto]="!(stepper !== undefined && stepper.selectedIndex !== 0)"
+        [disabled]="getStepperNextConditions()"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.NEXT' | translate}}
+      </button>
+      <button
+        data-cy="submit-button"
+        (click)="onSubmit()"
+        *ngIf="stepper !== undefined && stepper.selectedIndex === stepper._steps.length -1"
+        [disabled]="!submitAllowed"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.SUBMIT' | translate}}
+      </button>
+    </div>
+    <div *ngIf='state === "results"' mat-dialog-actions>
+      <button (click)="onClose()" mat-flat-button data-cy="close-button">
+        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.CLOSE' | translate}}
+      </button>
+      <button
+        [matMenuTriggerFor]="menu"
+        color="accent"
+        class="ml-auto dropdown-toggle"
+        mat-flat-button>
+        {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DOWNLOAD' | translate}}
+      </button>
+      <mat-menu #menu="matMenu">
+        <button (click)="generatePdf()" mat-menu-item>
+          {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DOWNLOAD_PDF' | translate}}
+        </button>
+        <button (click)="downloadCsv()" mat-menu-item>
+          {{'DIALOGS.GENERATE_SPONSORED_MEMBERS.DOWNLOAD_CSV' | translate}}
+        </button>
+      </mat-menu>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.ts
@@ -71,7 +71,7 @@ export class GenerateSponsoredMembersDialogComponent implements OnInit {
   languages = ['en'];
   currentLanguage = 'en';
 
-  private namespaceRules: NamespaceRules[] = [];
+  namespaceRules: NamespaceRules[] = [];
   private resultData: MemberData[] = [];
 
   constructor(
@@ -154,6 +154,7 @@ export class GenerateSponsoredMembersDialogComponent implements OnInit {
   }
 
   onSubmit(): void {
+    this.loading = true;
     this.groupsToAssign.next();
   }
 

--- a/apps/admin-gui/src/app/shared/components/dialogs/invite-member-dialog/invite-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/invite-member-dialog/invite-member-dialog.component.html
@@ -1,55 +1,61 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.INVITE_MEMBER.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <div *ngIf="!data.groupId" class="font-italic">
-      {{'DIALOGS.INVITE_MEMBER.DESCRIPTION_VO' | translate}}
-    </div>
-    <div *ngIf="data.groupId" class="font-italic">
-      {{'DIALOGS.INVITE_MEMBER.DESCRIPTION_GROUP' | translate}}
-    </div>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.INVITE_MEMBER.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <div *ngIf="!data.groupId" class="font-italic">
+        {{'DIALOGS.INVITE_MEMBER.DESCRIPTION_VO' | translate}}
+      </div>
+      <div *ngIf="data.groupId" class="font-italic">
+        {{'DIALOGS.INVITE_MEMBER.DESCRIPTION_GROUP' | translate}}
+      </div>
 
-    <mat-form-field class="w-100">
-      <input
-        matInput
-        placeholder="{{'DIALOGS.INVITE_MEMBER.NAME' | translate}}"
-        [formControl]="name"
-        required />
-      <mat-error *ngIf="name.invalid">{{'DIALOGS.INVITE_MEMBER.NAME_ERROR' | translate}}</mat-error>
-    </mat-form-field>
-    <mat-form-field class="w-100">
-      <textarea
-        matInput
-        placeholder="{{'DIALOGS.INVITE_MEMBER.EMAIL' | translate}}"
-        [formControl]="emailForm"
-        required></textarea>
-      <mat-error
-        *ngIf="emailForm.invalid"
-        >{{'DIALOGS.INVITE_MEMBER.EMAIL_ERROR' | translate}}</mat-error
-      >
-    </mat-form-field>
-    <mat-form-field class="w-100">
-      <mat-label>{{'DIALOGS.INVITE_MEMBER.LANGUAGE' | translate}}</mat-label>
-      <mat-select [(value)]="currentLanguage">
-        <mat-option
-          *ngFor="let lang of languages"
-          value="{{lang}}"
-          >{{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}</mat-option
+      <mat-form-field class="w-100">
+        <input
+          matInput
+          placeholder="{{'DIALOGS.INVITE_MEMBER.NAME' | translate}}"
+          [formControl]="name"
+          required />
+        <mat-error *ngIf="name.invalid">
+          {{'DIALOGS.INVITE_MEMBER.NAME_ERROR' | translate}}
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="w-100">
+        <textarea
+          matInput
+          placeholder="{{'DIALOGS.INVITE_MEMBER.EMAIL' | translate}}"
+          [formControl]="emailForm"
+          required></textarea>
+        <mat-error
+          *ngIf="emailForm.invalid"
+          >{{'DIALOGS.INVITE_MEMBER.EMAIL_ERROR' | translate}}</mat-error
         >
-      </mat-select>
-    </mat-form-field>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.INVITE_MEMBER.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      class="ml-2"
-      color="accent"
-      [disabled]="emailForm.invalid || name.invalid || loading"
-      mat-flat-button>
-      {{'DIALOGS.INVITE_MEMBER.INVITE' | translate}}
-    </button>
+      </mat-form-field>
+      <mat-form-field class="w-100">
+        <mat-label>{{'DIALOGS.INVITE_MEMBER.LANGUAGE' | translate}}</mat-label>
+        <mat-select [(value)]="currentLanguage">
+          <mat-option
+            *ngFor="let lang of languages"
+            value="{{lang}}"
+            >{{'SHARED_LIB.LANGUAGES.'+lang | uppercase | translate}}</mat-option
+          >
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.INVITE_MEMBER.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        class="ml-2"
+        color="accent"
+        [disabled]="emailForm.invalid || name.invalid || loading"
+        mat-flat-button>
+        {{'DIALOGS.INVITE_MEMBER.INVITE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/move-group-dialog/move-group-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/move-group-dialog/move-group-dialog.component.html
@@ -1,63 +1,67 @@
-<div class="{{data.theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.MOVE_GROUP.TITLE' | translate}}{{this.data.group.name}}</h1>
-  <div mat-dialog-content>
-    <p>
-      {{'DIALOGS.MOVE_GROUP.INFO' | translate}}
-    </p>
-    <mat-radio-group [(ngModel)]="moveOption">
-      <mat-radio-button
-        *ngIf="!toRootOptionDisabled"
-        color="primary"
-        class="move-options"
-        value="toRoot">
-        {{'DIALOGS.MOVE_GROUP.NO_GROUP' | translate}}
-      </mat-radio-button>
-      <mat-radio-button *ngIf="!toGroupOptionDisabled" color="primary" value="toGroup">
-        {{'DIALOGS.MOVE_GROUP.TO_GROUP' | translate}}
-      </mat-radio-button>
-    </mat-radio-group>
-    <perun-web-apps-alert *ngIf="toRootOptionDisabled && toGroupOptionDisabled" alert_type="warn">
-      {{'DIALOGS.MOVE_GROUP.CANNOT_MOVE' | translate}}
-    </perun-web-apps-alert>
-    <mat-form-field
-      *ngIf="!toGroupOptionDisabled"
-      [@openClose]="moveOption === 'toGroup' ? 'open' : 'closed'"
-      class="w-100 mt-2">
-      <input
-        matInput
-        placeholder="{{'DIALOGS.MOVE_GROUP.GROUP_SELECT' | translate}}"
-        (change)="selectedGroup = null"
-        [formControl]="otherGroupsCtrl"
-        [matAutocomplete]="groupSelectAutocomplete"
-        required />
-      <!--suppress AngularInvalidExpressionResultType -->
-      <mat-autocomplete #groupSelectAutocomplete="matAutocomplete" [displayWith]="displayFn">
-        <mat-option
-          *ngFor="let group of filteredGroups | async"
-          (click)="selectedGroup = group"
-          [value]="group">
-          <span>{{group.name}}</span>
-        </mat-option>
-      </mat-autocomplete>
-    </mat-form-field>
-  </div>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
-  <div mat-dialog-actions>
-    <button (click)="close()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.MOVE_GROUP.CANCEL' | translate}}
-    </button>
-    <span
-      [matTooltipDisabled]="selectedGroup !== null || moveOption === 'toRoot'"
-      [matTooltipPosition]="'above'"
-      matTooltip="{{'DIALOGS.MOVE_GROUP.DISABLED_HINT' | translate}}">
-      <button
-        (click)="confirm()"
-        [disabled]="((otherGroupsCtrl.invalid || selectedGroup === null) && moveOption !== 'toRoot') || loading"
-        class="ml-2"
-        color="accent"
-        mat-flat-button>
-        {{'DIALOGS.MOVE_GROUP.CONFIRM' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{data.theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.MOVE_GROUP.TITLE' | translate}}{{this.data.group.name}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.MOVE_GROUP.INFO' | translate}}
+      </p>
+      <mat-radio-group [(ngModel)]="moveOption">
+        <mat-radio-button
+          *ngIf="!toRootOptionDisabled"
+          color="primary"
+          class="move-options"
+          value="toRoot">
+          {{'DIALOGS.MOVE_GROUP.NO_GROUP' | translate}}
+        </mat-radio-button>
+        <mat-radio-button *ngIf="!toGroupOptionDisabled" color="primary" value="toGroup">
+          {{'DIALOGS.MOVE_GROUP.TO_GROUP' | translate}}
+        </mat-radio-button>
+      </mat-radio-group>
+      <perun-web-apps-alert *ngIf="toRootOptionDisabled && toGroupOptionDisabled" alert_type="warn">
+        {{'DIALOGS.MOVE_GROUP.CANNOT_MOVE' | translate}}
+      </perun-web-apps-alert>
+      <mat-form-field
+        *ngIf="!toGroupOptionDisabled"
+        [@openClose]="moveOption === 'toGroup' ? 'open' : 'closed'"
+        class="w-100 mt-2">
+        <input
+          matInput
+          placeholder="{{'DIALOGS.MOVE_GROUP.GROUP_SELECT' | translate}}"
+          (change)="selectedGroup = null"
+          [formControl]="otherGroupsCtrl"
+          [matAutocomplete]="groupSelectAutocomplete"
+          required />
+        <!--suppress AngularInvalidExpressionResultType -->
+        <mat-autocomplete #groupSelectAutocomplete="matAutocomplete" [displayWith]="displayFn">
+          <mat-option
+            *ngFor="let group of filteredGroups | async"
+            (click)="selectedGroup = group"
+            [value]="group">
+            <span>{{group.name}}</span>
+          </mat-option>
+        </mat-autocomplete>
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="close()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.MOVE_GROUP.CANCEL' | translate}}
       </button>
-    </span>
+      <span
+        [matTooltipDisabled]="selectedGroup !== null || moveOption === 'toRoot'"
+        [matTooltipPosition]="'above'"
+        matTooltip="{{'DIALOGS.MOVE_GROUP.DISABLED_HINT' | translate}}">
+        <button
+          (click)="confirm()"
+          [disabled]="((otherGroupsCtrl.invalid || selectedGroup === null) && moveOption !== 'toRoot') || loading"
+          class="ml-2"
+          color="accent"
+          mat-flat-button>
+          {{'DIALOGS.MOVE_GROUP.CONFIRM' | translate}}
+        </button>
+      </span>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/notifications-copy-mails-dialog/notifications-copy-mails-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/notifications-copy-mails-dialog/notifications-copy-mails-dialog.component.html
@@ -1,39 +1,43 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.NOTIFICATIONS_COPY_MAILS.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div [hidden]="loading" class="dialog-container" mat-dialog-content>
-    <div class="mb-2 font-italic">
-      {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.DESCRIPTION' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.NOTIFICATIONS_COPY_MAILS.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <div class="mb-2 font-italic">
+        {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.DESCRIPTION' | translate}}
+      </div>
+      {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.SOURCE_VO' | translate}}:
+
+      <perun-web-apps-vo-search-select
+        (voSelected)="voSelected($event)"
+        [vos]="vos"
+        class="long-input">
+      </perun-web-apps-vo-search-select>
+
+      {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.SOURCE_GROUP' | translate}}:
+
+      <perun-web-apps-group-search-select
+        (groupSelected)="selectedGroup = ($event)"
+        [groups]="groups"
+        [disableAutoSelect]="true"
+        class="long-input">
+      </perun-web-apps-group-search-select>
     </div>
-    {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.SOURCE_VO' | translate}}:
 
-    <perun-web-apps-vo-search-select
-      (voSelected)="voSelected($event)"
-      [vos]="vos"
-      class="long-input">
-    </perun-web-apps-vo-search-select>
-
-    {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.SOURCE_GROUP' | translate}}:
-
-    <perun-web-apps-group-search-select
-      (groupSelected)="selectedGroup = ($event)"
-      [groups]="groups"
-      [disableAutoSelect]="true"
-      class="long-input">
-    </perun-web-apps-group-search-select>
-  </div>
-
-  <div mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.CANCEL_BUTTON' | translate}}
-    </button>
-    <button
-      (click)="submit()"
-      class="ml-2"
-      color="accent"
-      [disabled]="selectedVo === null || selectedGroup === null || loading"
-      mat-flat-button>
-      {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.SUBMIT_BUTTON' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.CANCEL_BUTTON' | translate}}
+      </button>
+      <button
+        (click)="submit()"
+        class="ml-2"
+        color="accent"
+        [disabled]="selectedVo === null || selectedGroup === null || loading"
+        mat-flat-button>
+        {{'DIALOGS.NOTIFICATIONS_COPY_MAILS.SUBMIT_BUTTON' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/password-reset-request-dialog/password-reset-request-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/password-reset-request-dialog/password-reset-request-dialog.component.html
@@ -1,52 +1,55 @@
-<h1 mat-dialog-title>{{'DIALOGS.PASSWORD_RESET_REQUEST.TITLE'|translate}}</h1>
-<div class="member-theme">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-</div>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="member-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.PASSWORD_RESET_REQUEST.TITLE'|translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-form-field>
+        <mat-label>{{'DIALOGS.PASSWORD_RESET_REQUEST.NAMESPACE'|translate}}</mat-label>
+        <mat-select [(value)]="selectedLogin">
+          <mat-option *ngFor="let login of logins" [value]="login">
+            {{login.friendlyNameParameter}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
 
-<div *ngIf="!loading" class="dialog-container member-theme" mat-dialog-content>
-  <mat-form-field>
-    <mat-label>{{'DIALOGS.PASSWORD_RESET_REQUEST.NAMESPACE'|translate}}</mat-label>
-    <mat-select [(value)]="selectedLogin">
-      <mat-option *ngFor="let login of logins" [value]="login">
-        {{login.friendlyNameParameter}}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
+      <mat-form-field>
+        <mat-label>{{'DIALOGS.PASSWORD_RESET_REQUEST.LANGUAGE'|translate}}</mat-label>
+        <mat-select [(value)]="selectedLang">
+          <mat-option *ngFor="let lang of languages" [value]="lang">
+            {{'SHARED_LIB.LANGUAGES.' + lang | uppercase | translate}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>{{'DIALOGS.PASSWORD_RESET_REQUEST.LANGUAGE'|translate}}</mat-label>
-    <mat-select [(value)]="selectedLang">
-      <mat-option *ngFor="let lang of languages" [value]="lang">
-        {{'SHARED_LIB.LANGUAGES.' + lang | uppercase | translate}}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
+      <mat-form-field>
+        <mat-label>{{'DIALOGS.PASSWORD_RESET_REQUEST.EMAIL'|translate}}</mat-label>
+        <mat-select [(value)]="selectedMail">
+          <mat-option *ngFor="let mail of mails" [value]="mail">
+            {{mail}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>{{'DIALOGS.PASSWORD_RESET_REQUEST.EMAIL'|translate}}</mat-label>
-    <mat-select [(value)]="selectedMail">
-      <mat-option *ngFor="let mail of mails" [value]="mail">
-        {{mail}}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
-
-  <div class="row">
-    <p class="column-size ml-3">{{'DIALOGS.PASSWORD_RESET_REQUEST.LOGIN'|translate}}</p>
-    <p>{{selectedLogin.value}}</p>
+      <div class="row">
+        <p class="column-size ml-3">{{'DIALOGS.PASSWORD_RESET_REQUEST.LOGIN'|translate}}</p>
+        <p>{{selectedLogin.value}}</p>
+      </div>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.PASSWORD_RESET_REQUEST.CANCEL'|translate}}
+      </button>
+      <button
+        data-cy="reset-passwd-confirm-button"
+        (click)="onSubmit()"
+        [disabled]="loading"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.PASSWORD_RESET_REQUEST.SEND'|translate}}
+      </button>
+    </div>
   </div>
-</div>
-<div mat-dialog-actions>
-  <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-    {{'DIALOGS.PASSWORD_RESET_REQUEST.CANCEL'|translate}}
-  </button>
-  <button
-    data-cy="reset-passwd-confirm-button"
-    (click)="onSubmit()"
-    [disabled]="loading"
-    class="ml-2"
-    color="accent"
-    mat-flat-button>
-    {{'DIALOGS.PASSWORD_RESET_REQUEST.SEND'|translate}}
-  </button>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-destination-dialog/remove-destination-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-destination-dialog/remove-destination-dialog.component.html
@@ -1,27 +1,30 @@
-<h1 mat-dialog-title>{{'DIALOGS.REMOVE_DESTINATIONS.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <perun-web-apps-alert
-      alert_type="warn"
-      >{{'DIALOGS.REMOVE_DESTINATIONS.WARNING' | translate}}</perun-web-apps-alert
-    >
-    <p>{{'DIALOGS.REMOVE_DESTINATIONS.DESCRIPTION' | translate}}</p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_DESTINATIONS.ASK' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_DESTINATIONS.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <perun-web-apps-alert
+        alert_type="warn"
+        >{{'DIALOGS.REMOVE_DESTINATIONS.WARNING' | translate}}</perun-web-apps-alert
+      >
+      <p>{{'DIALOGS.REMOVE_DESTINATIONS.DESCRIPTION' | translate}}</p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_DESTINATIONS.ASK' | translate}}
+      </div>
+      <app-perun-web-apps-destination-list
+        [destinations]="destinations"
+        [displayedColumns]="displayedColumns">
+      </app-perun-web-apps-destination-list>
     </div>
-    <app-perun-web-apps-destination-list
-      *ngIf="!loading"
-      [destinations]="destinations"
-      [displayedColumns]="displayedColumns">
-    </app-perun-web-apps-destination-list>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_DESTINATIONS.CANCEL' | translate}}
-    </button>
-    <button (click)="onConfirm()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_DESTINATIONS.CONFIRM' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_DESTINATIONS.CANCEL' | translate}}
+      </button>
+      <button (click)="onConfirm()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_DESTINATIONS.CONFIRM' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-ext-source-dialog/remove-ext-source-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-ext-source-dialog/remove-ext-source-dialog.component.html
@@ -1,37 +1,41 @@
-<div class="{{theme}}">
-  <div mat-dialog-title>
-    <h1 class="page-subtitle">{{'DIALOGS.REMOVE_EXT_SOURCES.TITLE' | translate}}</h1>
-  </div>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.REMOVE_EXT_SOURCES.DESCRIPTION' | translate}}
-    </p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_EXT_SOURCES.ASK' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <div mat-dialog-title>
+      <h1 class="page-subtitle">{{'DIALOGS.REMOVE_EXT_SOURCES.TITLE' | translate}}</h1>
+    </div>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_EXT_SOURCES.DESCRIPTION' | translate}}
+      </p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_EXT_SOURCES.ASK' | translate}}
+      </div>
+
+      <table [dataSource]="extSources" class="w-100" mat-table>
+        <ng-container matColumnDef="id">
+          <th *matHeaderCellDef mat-header-cell>id</th>
+          <td *matCellDef="let extSource" mat-cell>{{extSource.id}}</td>
+        </ng-container>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell>name</th>
+          <td *matCellDef="let extSource" mat-cell>{{extSource.name}}</td>
+        </ng-container>
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let extSource; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
 
-    <table [dataSource]="extSources" class="w-100" mat-table>
-      <ng-container matColumnDef="id">
-        <th *matHeaderCellDef mat-header-cell>id</th>
-        <td *matCellDef="let extSource" mat-cell>{{extSource.id}}</td>
-      </ng-container>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell>name</th>
-        <td *matCellDef="let extSource" mat-cell>{{extSource.name}}</td>
-      </ng-container>
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let extSource; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_EXT_SOURCES.CANCEL' | translate}}
+      </button>
 
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_EXT_SOURCES.CANCEL' | translate}}
-    </button>
-
-    <button (click)="onRemove()" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_EXT_SOURCES.REMOVE' | translate}}
-    </button>
+      <button (click)="onRemove()" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_EXT_SOURCES.REMOVE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-facility-owner-dialog/remove-facility-owner-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-facility-owner-dialog/remove-facility-owner-dialog.component.html
@@ -1,32 +1,36 @@
-<h1 mat-dialog-title>{{'DIALOGS.REMOVE_OWNERS.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.REMOVE_OWNERS.DESCRIPTION' | translate}}
-    </p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_OWNERS.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_OWNERS.DESCRIPTION' | translate}}
+      </p>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_OWNERS.ASK' | translate}}
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_OWNERS.ASK' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let owner" mat-cell>{{owner.name}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let owner; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
 
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let owner" mat-cell>{{owner.name}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let owner; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_OWNERS.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_OWNERS.DELETE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_OWNERS.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_OWNERS.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-group-from-resource-dialog/remove-group-from-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-group-from-resource-dialog/remove-group-from-resource-dialog.component.html
@@ -1,37 +1,41 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.DESCRIPTION' | translate}}
-    </p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.DESCRIPTION' | translate}}
+      </p>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.ASK' | translate}}
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.ASK' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let group" mat-cell>{{group.name}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let group" mat-cell>{{group.name}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      [disabled]="loading"
-      class="ml-2"
-      color="warn"
-      mat-flat-button
-      data-cy="delete-button">
-      {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.DELETE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        [disabled]="loading"
+        class="ml-2"
+        color="warn"
+        mat-flat-button
+        data-cy="delete-button">
+        {{'DIALOGS.REMOVE_GROUP_FROM_RESOURCE.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-group-manager-dialog/remove-group-manager-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-group-manager-dialog/remove-group-manager-dialog.component.html
@@ -1,31 +1,35 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_GROUPS.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.REMOVE_GROUPS.DESCRIPTION' | translate}}
-    </p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_GROUPS.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_GROUPS.DESCRIPTION' | translate}}
+      </p>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_GROUPS.ASK' | translate}}
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_GROUPS.ASK' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let group" mat-cell>{{group.name}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let group" mat-cell>{{group.name}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_GROUPS.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_GROUPS.DELETE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_GROUPS.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_GROUPS.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-group-resource-dialog/remove-group-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-group-resource-dialog/remove-group-resource-dialog.component.html
@@ -1,33 +1,35 @@
-<div class="{{data.theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_RESOURCES.TITLE' | translate}}</h1>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{data.theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_RESOURCES.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_RESOURCES.DESCRIPTION' | translate}}
+      </p>
 
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_RESOURCES.ASK' | translate}}
+      </div>
 
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.REMOVE_RESOURCES.DESCRIPTION' | translate}}
-    </p>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let resource" mat-cell>{{resource.name}}</td>
+        </ng-container>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_RESOURCES.ASK' | translate}}
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let resource; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let resource" mat-cell>{{resource.name}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let resource; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div *ngIf="!loading" mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_RESOURCES.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_RESOURCES.DELETE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_RESOURCES.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_RESOURCES.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-host-dialog/remove-host-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-host-dialog/remove-host-dialog.component.html
@@ -1,26 +1,30 @@
-<h1 mat-dialog-title>{{'DIALOGS.REMOVE_HOST.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>{{'DIALOGS.REMOVE_HOST.DESCRIPTION' | translate}}</p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_HOST.ASK' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_HOST.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>{{'DIALOGS.REMOVE_HOST.DESCRIPTION' | translate}}</p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_HOST.ASK' | translate}}
+      </div>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let host" mat-cell>{{host.hostname}}</td>
+        </ng-container>
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let host; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let host" mat-cell>{{host.hostname}}</td>
-      </ng-container>
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let host; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_HOST.CANCEL' | translate}}
-    </button>
-    <button (click)="onConfirm()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_HOST.CONFIRM' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_HOST.CANCEL' | translate}}
+      </button>
+      <button (click)="onConfirm()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_HOST.CONFIRM' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-manager-dialog/remove-manager-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-manager-dialog/remove-manager-dialog.component.html
@@ -1,40 +1,44 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_MANAGERS.TITLE' | translate}}</h1>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.REMOVE_MANAGERS.DESCRIPTION' | translate}}
-    </p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_MANAGERS.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_MANAGERS.DESCRIPTION' | translate}}
+      </p>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_MANAGERS.ASK' | translate}}
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_MANAGERS.ASK' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let manager" mat-cell>{{manager.firstName}} {{manager.lastName}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let manager; columns: displayedColumns;" mat-row></tr>
+      </table>
+      <perun-web-apps-alert *ngIf="removeSelf" alert_type="warn">
+        {{'DIALOGS.REMOVE_MANAGERS.WARNING_REMOVE_YOURSELF' | translate: {role: 'ROLES.' + this.data.role | translate} }}
+      </perun-web-apps-alert>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let manager" mat-cell>{{manager.firstName}} {{manager.lastName}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let manager; columns: displayedColumns;" mat-row></tr>
-    </table>
-    <perun-web-apps-alert *ngIf="removeSelf" alert_type="warn">
-      {{'DIALOGS.REMOVE_MANAGERS.WARNING_REMOVE_YOURSELF' | translate: {role: 'ROLES.' + this.data.role | translate} }}
-    </perun-web-apps-alert>
-  </div>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_MANAGERS.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      class="ml-2"
-      color="warn"
-      data-cy="remove-manager-button-dialog"
-      [disabled]="loading"
-      mat-flat-button>
-      {{'DIALOGS.REMOVE_MANAGERS.DELETE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_MANAGERS.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        class="ml-2"
+        color="warn"
+        data-cy="remove-manager-button-dialog"
+        [disabled]="loading"
+        mat-flat-button>
+        {{'DIALOGS.REMOVE_MANAGERS.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-member-group-dialog/remove-member-group-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-member-group-dialog/remove-member-group-dialog.component.html
@@ -1,26 +1,30 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_MEMBER_GROUP.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <p>{{'DIALOGS.REMOVE_MEMBER_GROUP.DESCRIPTION' | translate}}</p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_MEMBER_GROUP.ASK' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_MEMBER_GROUP.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <p>{{'DIALOGS.REMOVE_MEMBER_GROUP.DESCRIPTION' | translate}}</p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_MEMBER_GROUP.ASK' | translate}}
+      </div>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let group" mat-cell>{{group.name}}</td>
+        </ng-container>
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let group" mat-cell>{{group.name}}</td>
-      </ng-container>
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let group; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_MEMBER_GROUP.CANCEL' | translate}}
-    </button>
-    <button (click)="onRemove()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_MEMBER_GROUP.REMOVE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_MEMBER_GROUP.CANCEL' | translate}}
+      </button>
+      <button (click)="onRemove()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_MEMBER_GROUP.REMOVE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-members-dialog/remove-members-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-members-dialog/remove-members-dialog.component.html
@@ -1,40 +1,44 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_MEMBERS.TITLE' | translate}}</h1>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{(!!data.groupId ? 'DIALOGS.REMOVE_MEMBERS.DESCRIPTION_GROUP' : 'DIALOGS.REMOVE_MEMBERS.DESCRIPTION') | translate}}
-    </p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_MEMBERS.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{(!!data.groupId ? 'DIALOGS.REMOVE_MEMBERS.DESCRIPTION_GROUP' : 'DIALOGS.REMOVE_MEMBERS.DESCRIPTION') | translate}}
+      </p>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_MEMBERS.ASK' | translate}}
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_MEMBERS.ASK' | translate}}
+      </div>
+
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="id">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let member" mat-cell>{{member.id}}</td>
+        </ng-container>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let member" mat-cell>{{member.user | userFullName}}</td>
+        </ng-container>
+
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let member; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="id">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let member" mat-cell>{{member.id}}</td>
-      </ng-container>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let member" mat-cell>{{member.user | userFullName}}</td>
-      </ng-container>
-
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let member; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_MEMBERS.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSubmit()"
-      class="ml-2"
-      color="warn"
-      data-cy="remove-members-dialog"
-      mat-flat-button>
-      {{(!!data.groupId ? 'DIALOGS.REMOVE_MEMBERS.REMOVE_GROUP' : 'DIALOGS.REMOVE_MEMBERS.REMOVE') | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_MEMBERS.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSubmit()"
+        class="ml-2"
+        color="warn"
+        data-cy="remove-members-dialog"
+        mat-flat-button>
+        {{(!!data.groupId ? 'DIALOGS.REMOVE_MEMBERS.REMOVE_GROUP' : 'DIALOGS.REMOVE_MEMBERS.REMOVE') | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-relation-dialog/remove-relation-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-relation-dialog/remove-relation-dialog.component.html
@@ -1,29 +1,33 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_RELATION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.REMOVE_RELATION.DESCRIPTION' | translate}}
-    </p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_RELATION.ASK' | translate}}
-    </div>
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let relation" mat-cell>{{relation.name}}</td>
-      </ng-container>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_RELATION.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_RELATION.DESCRIPTION' | translate}}
+      </p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_RELATION.ASK' | translate}}
+      </div>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let relation" mat-cell>{{relation.name}}</td>
+        </ng-container>
 
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let relation; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_RELATION.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_RELATION.DELETE' | translate}}
-    </button>
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let relation; columns: displayedColumns;" mat-row></tr>
+      </table>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_RELATION.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_RELATION.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-required-attributes-dialog/remove-required-attributes-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-required-attributes-dialog/remove-required-attributes-dialog.component.html
@@ -1,26 +1,30 @@
-<h1 mat-dialog-title>{{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.TITLE' | translate}}</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>{{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.DESCRIPTION' | translate}}</p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.ASK' | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>{{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.DESCRIPTION' | translate}}</p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.ASK' | translate}}
+      </div>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let attrDefinition" mat-cell>{{attrDefinition.friendlyName}}</td>
+        </ng-container>
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let attrDefinition; columns: displayedColumns;" mat-row></tr>
+      </table>
     </div>
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let attrDefinition" mat-cell>{{attrDefinition.friendlyName}}</td>
-      </ng-container>
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let attrDefinition; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.CANCEL' | translate}}
-    </button>
-    <button (click)="onConfirm()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.REMOVE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.CANCEL' | translate}}
+      </button>
+      <button (click)="onConfirm()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_REQUIRED_ATTRIBUTES.REMOVE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-service-from-resource-dialog/remove-service-from-resource-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-service-from-resource-dialog/remove-service-from-resource-dialog.component.html
@@ -1,29 +1,33 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <p>
-      {{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.DESCRIPTION' | translate}}
-    </p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.ASK' | translate}}
-    </div>
-    <table [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let service" mat-cell>{{service.name}}</td>
-      </ng-container>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.DESCRIPTION' | translate}}
+      </p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.ASK' | translate}}
+      </div>
+      <table [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th *matHeaderCellDef mat-header-cell></th>
+          <td *matCellDef="let service" mat-cell>{{service.name}}</td>
+        </ng-container>
 
-      <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let service; columns: displayedColumns;" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.CANCEL' | translate}}
-    </button>
-    <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
-      {{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.DELETE' | translate}}
-    </button>
+        <tr *matHeaderRowDef="displayedColumns" class="font-weight-bolder" mat-header-row></tr>
+        <tr *matRowDef="let service; columns: displayedColumns;" mat-row></tr>
+      </table>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.CANCEL' | translate}}
+      </button>
+      <button (click)="onSubmit()" [disabled]="loading" class="ml-2" color="warn" mat-flat-button>
+        {{'DIALOGS.REMOVE_SERVICE_FROM_RESOURCE.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.html
@@ -27,18 +27,21 @@
       {{'DIALOGS.SPONSOR_EXISTING_MEMBER.SEARCH' | translate}}
     </button>
 
-    <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-
-    <perun-web-apps-members-list
-      [disableRouting]="true"
-      *ngIf="firstSearchDone"
-      [hidden]="loading"
-      [disableStatusChange]="true"
-      [members]="members"
-      [selection]="selection"
-      [displayedColumns]="displayedColumns"
-      [tableId]="tableId">
-    </perun-web-apps-members-list>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
+    <div class="position-relative" *ngIf="firstSearchDone">
+      <perun-web-apps-members-list
+        *perunWebAppsLoader="loading; indicator: spinner"
+        [disableRouting]="true"
+        [hidden]="loading"
+        [disableStatusChange]="true"
+        [members]="members"
+        [selection]="selection"
+        [displayedColumns]="displayedColumns"
+        [tableId]="tableId">
+      </perun-web-apps-members-list>
+    </div>
 
     <perun-web-apps-alert *ngIf="!firstSearchDone" alert_type="info">
       {{'DIALOGS.SPONSOR_EXISTING_MEMBER.BEGIN_SEARCH' | translate}}

--- a/apps/admin-gui/src/app/shared/components/dialogs/update-application-form-dialog/update-application-form-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/update-application-form-dialog/update-application-form-dialog.component.html
@@ -1,52 +1,22 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.UPDATE_APPLICATION_FORM.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-form-field>
-      <input
-        matInput
-        [(ngModel)]="moduleName"
-        placeholder="{{'DIALOGS.UPDATE_APPLICATION_FORM.MODULE_NAME' | translate}}" />
-    </mat-form-field>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.UPDATE_APPLICATION_FORM.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-form-field>
+        <input
+          matInput
+          [(ngModel)]="moduleName"
+          placeholder="{{'DIALOGS.UPDATE_APPLICATION_FORM.MODULE_NAME' | translate}}" />
+      </mat-form-field>
 
-    <mat-form-field class="w-100">
-      <mat-select
-        [(value)]="initialState"
-        disableOptionCentering
-        placeholder="{{'DIALOGS.UPDATE_APPLICATION_FORM.INITIAL' | translate}}:">
-        <mat-option
-          value="auto"
-          >{{'DIALOGS.UPDATE_APPLICATION_FORM.AUTOMATIC' | translate}}</mat-option
-        >
-        <mat-option
-          value="manual"
-          >{{'DIALOGS.UPDATE_APPLICATION_FORM.MANUAL' | translate}}</mat-option
-        >
-      </mat-select>
-    </mat-form-field>
-
-    <mat-form-field class="w-100">
-      <mat-select
-        [(value)]="extensionState"
-        disableOptionCentering
-        placeholder="{{'DIALOGS.UPDATE_APPLICATION_FORM.EXTENSION' | translate}}:">
-        <mat-option
-          value="auto"
-          >{{'DIALOGS.UPDATE_APPLICATION_FORM.AUTOMATIC' | translate}}</mat-option
-        >
-        <mat-option
-          value="manual"
-          >{{'DIALOGS.UPDATE_APPLICATION_FORM.MANUAL' | translate}}</mat-option
-        >
-      </mat-select>
-    </mat-form-field>
-
-    <div *ngIf="entity === 'group' && autoRegistrationEnabled">
       <mat-form-field class="w-100">
         <mat-select
-          [(value)]="embeddedState"
+          [(value)]="initialState"
           disableOptionCentering
-          placeholder="{{'DIALOGS.UPDATE_APPLICATION_FORM.EMBEDDED' | translate}}:">
+          placeholder="{{'DIALOGS.UPDATE_APPLICATION_FORM.INITIAL' | translate}}:">
           <mat-option
             value="auto"
             >{{'DIALOGS.UPDATE_APPLICATION_FORM.AUTOMATIC' | translate}}</mat-option
@@ -57,14 +27,48 @@
           >
         </mat-select>
       </mat-form-field>
+
+      <mat-form-field class="w-100">
+        <mat-select
+          [(value)]="extensionState"
+          disableOptionCentering
+          placeholder="{{'DIALOGS.UPDATE_APPLICATION_FORM.EXTENSION' | translate}}:">
+          <mat-option
+            value="auto"
+            >{{'DIALOGS.UPDATE_APPLICATION_FORM.AUTOMATIC' | translate}}</mat-option
+          >
+          <mat-option
+            value="manual"
+            >{{'DIALOGS.UPDATE_APPLICATION_FORM.MANUAL' | translate}}</mat-option
+          >
+        </mat-select>
+      </mat-form-field>
+
+      <div *ngIf="entity === 'group' && autoRegistrationEnabled">
+        <mat-form-field class="w-100">
+          <mat-select
+            [(value)]="embeddedState"
+            disableOptionCentering
+            placeholder="{{'DIALOGS.UPDATE_APPLICATION_FORM.EMBEDDED' | translate}}:">
+            <mat-option
+              value="auto"
+              >{{'DIALOGS.UPDATE_APPLICATION_FORM.AUTOMATIC' | translate}}</mat-option
+            >
+            <mat-option
+              value="manual"
+              >{{'DIALOGS.UPDATE_APPLICATION_FORM.MANUAL' | translate}}</mat-option
+            >
+          </mat-select>
+        </mat-form-field>
+      </div>
     </div>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.UPDATE_APPLICATION_FORM.CANCEL_BUTTON' | translate}}
-    </button>
-    <button (click)="submit()" [disabled]="loading" class="ml-2" color="accent" mat-flat-button>
-      {{'DIALOGS.UPDATE_APPLICATION_FORM.SUBMIT_BUTTON' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.UPDATE_APPLICATION_FORM.CANCEL_BUTTON' | translate}}
+      </button>
+      <button (click)="submit()" [disabled]="loading" class="ml-2" color="accent" mat-flat-button>
+        {{'DIALOGS.UPDATE_APPLICATION_FORM.SUBMIT_BUTTON' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/update-ban-dialog/update-ban-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/update-ban-dialog/update-ban-dialog.component.html
@@ -1,19 +1,20 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.UPDATE_BAN.TITLE' | translate}}</h1>
-  <div mat-dialog-content>
-    <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-    <perun-web-apps-ban-specification
-      *ngIf="!loading"
-      [description]="ban.description"
-      [validity]="ban.validityTo">
-    </perun-web-apps-ban-specification>
-  </div>
-  <div mat-dialog-actions>
-    <button mat-flat-button class="ml-auto mr-2" (click)="cancel.emit()">
-      {{'DIALOGS.UPDATE_BAN.CANCEL' | translate}}
-    </button>
-    <button mat-flat-button color="accent" (click)="updateBan()">
-      {{'DIALOGS.UPDATE_BAN.UPDATE' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.UPDATE_BAN.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <perun-web-apps-ban-specification [description]="ban.description" [validity]="ban.validityTo">
+      </perun-web-apps-ban-specification>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-flat-button class="ml-auto mr-2" (click)="cancel.emit()">
+        {{'DIALOGS.UPDATE_BAN.CANCEL' | translate}}
+      </button>
+      <button mat-flat-button color="accent" (click)="updateBan()">
+        {{'DIALOGS.UPDATE_BAN.UPDATE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/update-facility-ban-dialog/update-facility-ban-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/update-facility-ban-dialog/update-facility-ban-dialog.component.html
@@ -1,6 +1,7 @@
 <app-update-ban-dialog
   [ban]="data.ban"
   [theme]="'facility-theme'"
+  [loading]="loading"
   (cancel)="cancel()"
   (update)="update($event)">
 </app-update-ban-dialog>

--- a/apps/admin-gui/src/app/shared/components/dialogs/update-resource-ban-dialog/update-resource-ban-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/update-resource-ban-dialog/update-resource-ban-dialog.component.html
@@ -1,6 +1,7 @@
 <app-update-ban-dialog
   [ban]="data.ban"
   [theme]="'facility-theme'"
+  [loading]="loading"
   (cancel)="cancel()"
   (update)="update($event)">
 </app-update-ban-dialog>

--- a/apps/admin-gui/src/app/shared/components/dialogs/update-vo-ban-dialog/update-vo-ban-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/update-vo-ban-dialog/update-vo-ban-dialog.component.html
@@ -1,6 +1,7 @@
 <app-update-ban-dialog
   [ban]="data.ban"
   [theme]="'vo-theme'"
+  [loading]="loading"
   (cancel)="cancel()"
   (update)="update($event)">
 </app-update-ban-dialog>

--- a/apps/admin-gui/src/app/shared/components/identity-detail/identity-detail.component.html
+++ b/apps/admin-gui/src/app/shared/components/identity-detail/identity-detail.component.html
@@ -35,12 +35,16 @@
     mat-flat-button>
     {{ 'SHARED.IDENTITY_DETAIL.REMOVE' | translate}}
   </button>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-attributes-list
-    #list
-    [selection]="selection"
-    *ngIf="!loading"
-    [attributes]="attributes"
-    [tableId]="tableId">
-  </perun-web-apps-attributes-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-attributes-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      #list
+      [selection]="selection"
+      [attributes]="attributes"
+      [tableId]="tableId">
+    </perun-web-apps-attributes-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/managers-page/managers-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/managers-page/managers-page.component.html
@@ -46,15 +46,20 @@
 
       <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
 
-      <app-users-list
-        *ngIf="!loading && managers"
-        [disableSelf]="disableSelf"
-        [tableId]="tableId"
-        [disableRouting]="!routeAuth || disableRouting"
-        [displayedColumns]="displayedUserColumns"
-        [selection]="selectionUsers"
-        [users]="managers">
-      </app-users-list>
+      <ng-template #spinner>
+        <perun-web-apps-loading-table></perun-web-apps-loading-table>
+      </ng-template>
+      <div class="position-relative" *ngIf="managers">
+        <app-users-list
+          *perunWebAppsLoader="loading; indicator: spinner"
+          [disableSelf]="disableSelf"
+          [tableId]="tableId"
+          [disableRouting]="!routeAuth || disableRouting"
+          [displayedColumns]="displayedUserColumns"
+          [selection]="selectionUsers"
+          [users]="managers">
+        </app-users-list>
+      </div>
     </ng-template>
   </mat-tab>
 
@@ -98,15 +103,20 @@
 
       <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
 
-      <perun-web-apps-groups-list
-        *ngIf="!loading && groups"
-        [disableMembers]="false"
-        [disableRouting]="disableRouting"
-        [displayedColumns]="displayedGroupColumns"
-        [groups]="groups"
-        [selection]="selectionGroups"
-        [tableId]="tableId">
-      </perun-web-apps-groups-list>
+      <ng-template #spinner>
+        <perun-web-apps-loading-table></perun-web-apps-loading-table>
+      </ng-template>
+      <div class="position-relative" *ngIf="groups">
+        <perun-web-apps-groups-list
+          *perunWebAppsLoader="loading; indicator: spinner"
+          [disableMembers]="false"
+          [disableRouting]="disableRouting"
+          [displayedColumns]="displayedGroupColumns"
+          [groups]="groups"
+          [selection]="selectionGroups"
+          [tableId]="tableId">
+        </perun-web-apps-groups-list>
+      </div>
     </ng-template>
   </mat-tab>
 </mat-tab-group>

--- a/apps/admin-gui/src/app/shared/components/members-candidates-list/members-candidates-list.component.html
+++ b/apps/admin-gui/src/app/shared/components/members-candidates-list/members-candidates-list.component.html
@@ -1,4 +1,4 @@
-<div [hidden]="members.length === 0" class="card mt-2">
+<div [hidden]="dataSource.data.length === 0" class="card mt-2">
   <perun-web-apps-table-wrapper
     (exportDisplayedData)="exportDisplayedData($event)"
     (exportAllData)="exportAllData($event)"
@@ -111,6 +111,8 @@
   </perun-web-apps-table-wrapper>
 </div>
 
-<perun-web-apps-alert *ngIf="members.length === 0" alert_type="warn">
+<perun-web-apps-alert
+  *ngIf="dataSource.data.length === 0 && members !== undefined"
+  alert_type="warn">
   {{'DIALOGS.ADD_MEMBERS.NO_USERS_FOUND' | translate}}
 </perun-web-apps-alert>

--- a/apps/admin-gui/src/app/shared/components/members-candidates-list/members-candidates-list.component.ts
+++ b/apps/admin-gui/src/app/shared/components/members-candidates-list/members-candidates-list.component.ts
@@ -42,8 +42,9 @@ export class MembersCandidatesListComponent implements OnChanges, AfterViewInit 
     'alreadyMember',
     'local',
   ];
-  dataSource: MatTableDataSource<MemberCandidate>;
+  dataSource: MatTableDataSource<MemberCandidate> = new MatTableDataSource<MemberCandidate>([]);
   pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
+  firstSearchDone = false;
   private sort: MatSort;
 
   constructor(
@@ -62,8 +63,11 @@ export class MembersCandidatesListComponent implements OnChanges, AfterViewInit 
   }
 
   ngOnChanges(): void {
-    this.dataSource = new MatTableDataSource<MemberCandidate>(this.members);
-    this.setDataSource();
+    if (this.members !== undefined && this.members !== null) {
+      this.firstSearchDone = true;
+      this.dataSource = new MatTableDataSource<MemberCandidate>(this.members);
+      this.setDataSource();
+    }
   }
 
   canBeSelected = (row: MemberCandidate): boolean =>

--- a/apps/admin-gui/src/app/shared/components/one-entity-attribute-page/one-entity-attribute-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/one-entity-attribute-page/one-entity-attribute-page.component.html
@@ -32,13 +32,16 @@
   (filter)="applyFilter($event)"
   [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTES_LIST.FILTER'"></perun-web-apps-immediate-filter>
 
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-
-<perun-web-apps-attributes-list
-  [attributes]="attributes"
-  #list
-  *ngIf="!loading"
-  [filterValue]="filterValue"
-  [selection]="selection"
-  [tableId]="tableId">
-</perun-web-apps-attributes-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-attributes-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [attributes]="attributes"
+    #list
+    [filterValue]="filterValue"
+    [selection]="selection"
+    [tableId]="tableId">
+  </perun-web-apps-attributes-list>
+</div>

--- a/apps/admin-gui/src/app/shared/components/set-login-dialog/set-login-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/set-login-dialog/set-login-dialog.component.html
@@ -1,23 +1,27 @@
-<div class="vo-theme">
-  <h1 class="mat-dialog-title">{{'DIALOGS.SET_LOGIN.TITLE' | translate}}</h1>
-  <div *ngIf="!processing" class="dialog-container" mat-dialog-content>
-    <app-login-password-form-with-generate-option
-      [formGroup]="formGroup"
-      [filteredNamespace]="this.data.filteredNamespaces">
-    </app-login-password-form-with-generate-option>
-  </div>
-  <mat-spinner *ngIf="processing" class="ml-auto mr-auto"></mat-spinner>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" mat-flat-button class="ml-auto">
-      {{'DIALOGS.SET_LOGIN.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onSetLogin()"
-      [disabled]="(formGroup.get('namespaceCtrl').value === 'Not selected' || formGroup.invalid || formGroup.pending) || processing"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{"DIALOGS.SET_LOGIN.SET_LOGIN" | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="vo-theme position-relative">
+  <div *perunWebAppsLoader="processing; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.SET_LOGIN.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <app-login-password-form-with-generate-option
+        [formGroup]="formGroup"
+        [filteredNamespace]="this.data.filteredNamespaces">
+      </app-login-password-form-with-generate-option>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" mat-flat-button class="ml-auto">
+        {{'DIALOGS.SET_LOGIN.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onSetLogin()"
+        [disabled]="(formGroup.get('namespaceCtrl').value === 'Not selected' || formGroup.invalid || formGroup.pending) || processing"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{"DIALOGS.SET_LOGIN.SET_LOGIN" | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.html
@@ -72,13 +72,17 @@
     <perun-web-apps-immediate-filter
       (filter)="applyFilter($event)"
       [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTES_LIST.FILTER'"></perun-web-apps-immediate-filter>
-    <mat-spinner *ngIf="innerLoading" class="ml-auto mr-auto"></mat-spinner>
-    <perun-web-apps-attributes-list
-      #list
-      *ngIf="!innerLoading"
-      [attributes]="attributes"
-      [filterValue]="filterValue"
-      [selection]="selection">
-    </perun-web-apps-attributes-list>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
+    <div class="position-relative">
+      <perun-web-apps-attributes-list
+        #list
+        *perunWebAppsLoader="innerLoading; indicator: spinner"
+        [attributes]="attributes"
+        [filterValue]="filterValue"
+        [selection]="selection">
+      </perun-web-apps-attributes-list>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/shared/shared.module.ts
+++ b/apps/admin-gui/src/app/shared/shared.module.ts
@@ -80,6 +80,7 @@ import { DeleteAttributeDefinitionDialogComponent } from './components/dialogs/d
 // eslint-disable-next-line max-len
 import { CreateAttributeDefinitionDialogComponent } from './components/dialogs/create-attribute-definition-dialog/create-attribute-definition-dialog.component';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { EditAttributeDefinitionDialogComponent } from './components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component';
 import { EntitylessAttributeKeysListComponent } from './components/entityless-attribute-keys-list/entityless-attribute-keys-list.component';
 import { ServicesListComponent } from './components/services-list/services-list.component';
@@ -229,6 +230,7 @@ import { ApplicationsListColumnsChangeDialogComponent } from './components/dialo
     MatMenuModule,
     ScrollingModule,
     UiAlertsModule,
+    UiLoadersModule,
     MatBadgeModule,
     PerunSharedComponentsModule,
     ConfigTableConfigModule,

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-accounts/user-accounts.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-accounts/user-accounts.component.html
@@ -34,7 +34,7 @@
         <perun-web-apps-groups-list
           *ngIf="!loading"
           [groups]="groups"
-          [memberId]="member.id"
+          [memberId]="member?.id"
           [memberGroupStatus]="member.groupStatus"
           (refreshTable)="loadMember(selectedVo)"
           [displayedColumns]="['id', 'recent', 'name', 'description', 'expiration', 'groupStatus']">

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-bans/user-bans.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-bans/user-bans.component.html
@@ -72,7 +72,5 @@
 </mat-tab-group>
 
 <ng-template #spinner>
-  <div class="spinner-container">
-    <mat-spinner></mat-spinner>
-  </div>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
 </ng-template>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-card/dashboard-card.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-card/dashboard-card.component.html
@@ -6,40 +6,44 @@
       <mat-icon class="dashboard-icon">info_outline</mat-icon>
     </span>
   </div>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading">
-    <span *ngIf="primaryObject === 'Vo'">
-      <perun-web-apps-vos-list
-        [pageSizeOptions]="null"
-        [displayedColumns]="['id', 'recent', 'shortName', 'name']"
-        [recentIds]="this.recentIds"
-        [vos]="this.objects">
-      </perun-web-apps-vos-list>
-    </span>
-    <span *ngIf="primaryObject === 'Group'">
-      <perun-web-apps-groups-list
-        [pageSizeOptions]="null"
-        [displayedColumns]="['id', 'recent', 'vo', 'name', 'description']"
-        [groups]="this.objects"
-        [recentIds]="recentIds">
-      </perun-web-apps-groups-list>
-    </span>
-    <span *ngIf="primaryObject === 'Resource'">
-      <perun-web-apps-resources-list
-        [pageSizeOptions]="null"
-        [displayedColumns]="['id', 'recent', 'name', 'vo', 'facility']"
-        [resources]="this.objects"
-        [recentIds]="recentIds"
-        [routingVo]="true">
-      </perun-web-apps-resources-list>
-    </span>
-    <span *ngIf="primaryObject === 'Facility'">
-      <perun-web-apps-facilities-list
-        [displayedColumns]="['id', 'recent', 'name', 'description']"
-        [facilities]="this.objects"
-        [pageSizeOptions]="null"
-        [recentIds]="recentIds">
-      </perun-web-apps-facilities-list>
-    </span>
-  </div>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <span *ngIf="primaryObject === 'Vo'" class="position-relative">
+    <perun-web-apps-vos-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [pageSizeOptions]="null"
+      [displayedColumns]="['id', 'recent', 'shortName', 'name']"
+      [recentIds]="this.recentIds"
+      [vos]="this.objects">
+    </perun-web-apps-vos-list>
+  </span>
+  <span *ngIf="primaryObject === 'Group'" class="position-relative">
+    <perun-web-apps-groups-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [pageSizeOptions]="null"
+      [displayedColumns]="['id', 'recent', 'vo', 'name', 'description']"
+      [groups]="this.objects"
+      [recentIds]="recentIds">
+    </perun-web-apps-groups-list>
+  </span>
+  <span *ngIf="primaryObject === 'Resource'" class="position-relative">
+    <perun-web-apps-resources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [pageSizeOptions]="null"
+      [displayedColumns]="['id', 'recent', 'name', 'vo', 'facility']"
+      [resources]="this.objects"
+      [recentIds]="recentIds"
+      [routingVo]="true">
+    </perun-web-apps-resources-list>
+  </span>
+  <span *ngIf="primaryObject === 'Facility'" class="position-relative">
+    <perun-web-apps-facilities-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [displayedColumns]="['id', 'recent', 'name', 'description']"
+      [facilities]="this.objects"
+      [pageSizeOptions]="null"
+      [recentIds]="recentIds">
+    </perun-web-apps-facilities-list>
+  </span>
 </div>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-card/dashboard-card.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-card/dashboard-card.component.ts
@@ -24,7 +24,7 @@ export class DashboardCardComponent implements OnInit {
   svgIcon: string;
   title: string;
   roleTooltipInfo: string;
-  objects: Vo[] | Group[] | RichResource[] | EnrichedFacility[];
+  objects: Vo[] | Group[] | RichResource[] | EnrichedFacility[] = [];
   loading = false;
   recentIds: number[] = [];
 

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-facilities/user-facilities.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-facilities/user-facilities.component.html
@@ -5,12 +5,16 @@
     (filter)="applyFilter($event)"
     [placeholder]="'USER_DETAIL.FACILITIES.FILTER_PLACEHOLDER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-facilities-list
-    [displayedColumns]="displayedColumns"
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [facilities]="facilities"
-    [tableId]="tableId">
-  </perun-web-apps-facilities-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-facilities-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [displayedColumns]="displayedColumns"
+      [filterValue]="filterValue"
+      [facilities]="facilities"
+      [tableId]="tableId">
+    </perun-web-apps-facilities-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-groups/user-groups.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-groups/user-groups.component.html
@@ -9,15 +9,16 @@
   (filter)="memberFilter($event)"
   [placeholder]="'SHARED_LIB.PERUN.ORGANIZATIONS.FILTER'">
 </perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="memberRefresh" class="ml-auto mr-auto"></mat-spinner>
-<perun-web-apps-groups-list
-  *ngIf="!memberRefresh"
-  [disableMembers]="false"
-  [groups]="membersGroups"
-  [displayedColumns]="['id', 'vo', 'name', 'description']"
-  [filter]="memberFilterValue"
-  [tableId]="tableId">
-</perun-web-apps-groups-list>
+<div class="position-relative">
+  <perun-web-apps-groups-list
+    *perunWebAppsLoader="memberRefresh; indicator: spinner"
+    [disableMembers]="false"
+    [groups]="membersGroups"
+    [displayedColumns]="['id', 'vo', 'name', 'description']"
+    [filter]="memberFilterValue"
+    [tableId]="tableId">
+  </perun-web-apps-groups-list>
+</div>
 
 <div *ngIf="!this.showPrincipal" class="mt-5">
   <h1 class="page-subtitle">
@@ -28,13 +29,18 @@
     (filter)="adminFilter($event)"
     [placeholder]="'SHARED_LIB.PERUN.ORGANIZATIONS.FILTER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="adminRefresh" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-groups-list
-    *ngIf="!adminRefresh"
-    [disableMembers]="false"
-    [groups]="adminsGroups"
-    [displayedColumns]="['id', 'vo', 'name', 'description']"
-    [filter]="adminFilterValue"
-    [tableId]="adminTableId">
-  </perun-web-apps-groups-list>
+  <div class="position-relative">
+    <perun-web-apps-groups-list
+      *perunWebAppsLoader="adminRefresh; indicator: spinner"
+      [disableMembers]="false"
+      [groups]="adminsGroups"
+      [displayedColumns]="['id', 'vo', 'name', 'description']"
+      [filter]="adminFilterValue"
+      [tableId]="adminTableId">
+    </perun-web-apps-groups-list>
+  </div>
 </div>
+
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-identities/user-identities.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-identities/user-identities.component.html
@@ -21,12 +21,13 @@
   (filter)="applyFilter($event)"
   [placeholder]="'USER_DETAIL.IDENTITIES.FILTER_PLACEHOLDER'">
 </perun-web-apps-immediate-filter>
-<div class="admin-theme">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-</div>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
 
-<div *ngIf="!loading">
+<div class="position-relative">
   <perun-web-apps-user-ext-sources-list
+    *perunWebAppsLoader="loading; indicator: spinner"
     [displayedColumns]="displayedColumns"
     [filterValue]="filterValue"
     [selection]="selection"

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-organizations/user-organizations.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-organizations/user-organizations.component.html
@@ -9,14 +9,15 @@
   (filter)="applyMemberFilter($event)"
   [placeholder]="'SHARED_LIB.PERUN.ORGANIZATIONS.FILTER'">
 </perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="memberRefresh" class="mr-auto ml-auto"></mat-spinner>
-<perun-web-apps-vos-list
-  *ngIf="!memberRefresh"
-  [displayedColumns]="displayedColumns"
-  [tableId]="memberTableId"
-  [filterValue]="memberFilterValue"
-  [vos]="vosWhereIsMember">
-</perun-web-apps-vos-list>
+<div class="position-relative">
+  <perun-web-apps-vos-list
+    *perunWebAppsLoader="memberRefresh; indicator: spinner"
+    [displayedColumns]="displayedColumns"
+    [tableId]="memberTableId"
+    [filterValue]="memberFilterValue"
+    [vos]="vosWhereIsMember">
+  </perun-web-apps-vos-list>
+</div>
 
 <div *ngIf="!this.isMyProfile" class="mt-5">
   <h1 class="page-subtitle">{{'SHARED_LIB.PERUN.ORGANIZATIONS.USER_IS_ADMIN' | translate}}</h1>
@@ -25,12 +26,17 @@
     (filter)="applyAdminFilter($event)"
     [placeholder]="'SHARED_LIB.PERUN.ORGANIZATIONS.FILTER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="adminRefresh" class="mr-auto ml-auto"></mat-spinner>
-  <perun-web-apps-vos-list
-    *ngIf="!adminRefresh"
-    [displayedColumns]="displayedColumns"
-    [tableId]="adminTableId"
-    [filterValue]="adminFilterValue"
-    [vos]="vosWhereIsAdmin">
-  </perun-web-apps-vos-list>
+  <div class="position-relative">
+    <perun-web-apps-vos-list
+      *perunWebAppsLoader="adminRefresh; indicator: spinner"
+      [displayedColumns]="displayedColumns"
+      [tableId]="adminTableId"
+      [filterValue]="adminFilterValue"
+      [vos]="vosWhereIsAdmin">
+    </perun-web-apps-vos-list>
+  </div>
 </div>
+
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-organizations/user-organizations.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-organizations/user-organizations.component.ts
@@ -14,8 +14,8 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class UserOrganizationsComponent implements OnInit {
   @HostBinding('class.router-component') true;
-  vosWhereIsAdmin: Vo[];
-  vosWhereIsMember: Vo[];
+  vosWhereIsAdmin: Vo[] = [];
+  vosWhereIsMember: Vo[] = [];
   memberRefresh: boolean;
   adminRefresh: boolean;
   userId: number;

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-resources/user-resources.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-resources/user-resources.component.html
@@ -5,12 +5,16 @@
     (filter)="resourceFilter($event)"
     [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_SEARCH'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-resources-list
-    [displayedColumns]="['id', 'name', 'vo', 'facility', 'description']"
-    *ngIf="!loading"
-    [resources]="resources"
-    [filterValue]="filterValue"
-    [tableId]="tableId">
-  </perun-web-apps-resources-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-resources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [displayedColumns]="['id', 'name', 'vo', 'facility', 'description']"
+      [resources]="resources"
+      [filterValue]="filterValue"
+      [tableId]="tableId">
+    </perun-web-apps-resources-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-associated-users/user-settings-associated-users.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-associated-users/user-settings-associated-users.component.html
@@ -12,15 +12,18 @@
     mat-flat-button>
     {{'USER_DETAIL.SETTINGS.ASSOCIATED_USERS.REMOVE' | translate}}
   </button>
-  <app-users-list
-    *ngIf="!loading"
-    [noUsersFoundLabel]="'USER_DETAIL.SETTINGS.ASSOCIATED_USERS.NO_ASSOCIATED_USERS' | translate"
-    [disableRouting]="disableRouting"
-    [displayedColumns]="displayedColumns"
-    [selection]="selection"
-    [tableId]="tableId"
-    [users]="associatedUsers">
-  </app-users-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-users-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [noUsersFoundLabel]="'USER_DETAIL.SETTINGS.ASSOCIATED_USERS.NO_ASSOCIATED_USERS' | translate"
+      [disableRouting]="disableRouting"
+      [displayedColumns]="displayedColumns"
+      [selection]="selection"
+      [tableId]="tableId"
+      [users]="associatedUsers">
+    </app-users-list>
+  </div>
 </div>
-
-<mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-service-identities/service-identity-authentication/service-identity-certificates/service-identity-certificates.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-service-identities/service-identity-authentication/service-identity-certificates/service-identity-certificates.component.html
@@ -8,10 +8,14 @@
   mat-flat-button>
   {{'USER_DETAIL.SETTINGS.CERTIFICATES.SAVE' | translate}}
 </button>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<perun-web-apps-attributes-list
-  *ngIf="!loading"
-  #list
-  [attributes]="[certificates]"
-  [selection]="selection">
-</perun-web-apps-attributes-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-attributes-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    #list
+    [attributes]="[certificates]"
+    [selection]="selection">
+  </perun-web-apps-attributes-list>
+</div>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-service-identities/user-settings-service-identities.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-settings/user-settings-service-identities/user-settings-service-identities.component.html
@@ -18,14 +18,17 @@
   {{'USER_DETAIL.SETTINGS.SERVICE_IDENTITIES.DELETE' | translate}}
 </button>
 
-<mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-
-<app-users-list
-  *ngIf="!loading"
-  [noUsersFoundLabel]="'USER_DETAIL.SETTINGS.SERVICE_IDENTITIES.NO_IDENTITIES' | translate"
-  [displayedColumns]="displayedColumns"
-  [selection]="selection"
-  [tableId]="tableId"
-  [routeToAdmin]="routeToAdminSection"
-  [users]="identities">
-</app-users-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <app-users-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [noUsersFoundLabel]="'USER_DETAIL.SETTINGS.SERVICE_IDENTITIES.NO_IDENTITIES' | translate"
+    [displayedColumns]="displayedColumns"
+    [selection]="selection"
+    [tableId]="tableId"
+    [routeToAdmin]="routeToAdminSection"
+    [users]="identities">
+  </app-users-list>
+</div>

--- a/apps/admin-gui/src/app/users/users.module.ts
+++ b/apps/admin-gui/src/app/users/users.module.ts
@@ -35,6 +35,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatMenuModule } from '@angular/material/menu';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { MatBadgeModule } from '@angular/material/badge';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { ConfigTableConfigModule } from '@perun-web-apps/config/table-config';
@@ -140,6 +141,7 @@ import { UserBansComponent } from './pages/user-detail-page/user-bans/user-bans.
     MatMenuModule,
     ScrollingModule,
     UiAlertsModule,
+    UiLoadersModule,
     MatBadgeModule,
     PerunSharedComponentsModule,
     ConfigTableConfigModule,

--- a/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.html
+++ b/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.html
@@ -1,6 +1,4 @@
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-
-<div *ngIf="this.applicationFormItems.length !== 0 && !loading" class="card mt-2">
+<div *ngIf="this.applicationFormItems.length !== 0" class="card mt-2">
   <div class="card-body table-theme">
     <div class="overflow-auto">
       <table
@@ -287,6 +285,6 @@
   </div>
 </div>
 
-<perun-web-apps-alert *ngIf="this.applicationFormItems.length === 0 && !loading" alert_type="warn">
+<perun-web-apps-alert *ngIf="this.applicationFormItems.length === 0" alert_type="warn">
   {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.NO_APPLICATION_FORM' | translate}}
 </perun-web-apps-alert>

--- a/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.ts
@@ -25,8 +25,6 @@ import { Router } from '@angular/router';
 })
 export class ApplicationFormListComponent implements OnInit, OnChanges {
   @Input()
-  loading: boolean;
-  @Input()
   applicationForm: ApplicationForm;
   @Input()
   applicationFormItems: ApplicationFormItem[] = [];

--- a/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.html
+++ b/apps/admin-gui/src/app/vos/components/application-form-manage-groups/application-form-manage-groups.component.html
@@ -27,14 +27,18 @@
   (filter)="this.filterValue = $event"
   [placeholder]="'VO_DETAIL.SETTINGS.APPLICATION_FORM.MANAGE_GROUPS_PAGE.FILTER'">
 </perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
-<perun-web-apps-groups-list
-  *ngIf="!loading"
-  [displayedColumns]="['select', 'id', 'name', 'description']"
-  [disableRouting]="true"
-  [groups]="this.groups"
-  [filter]="filterValue"
-  [selection]="selected"
-  [tableId]="tableId"
-  theme="vo-theme">
-</perun-web-apps-groups-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-groups-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [displayedColumns]="['select', 'id', 'name', 'description']"
+    [disableRouting]="true"
+    [groups]="this.groups"
+    [filter]="filterValue"
+    [selection]="selected"
+    [tableId]="tableId"
+    theme="vo-theme">
+  </perun-web-apps-groups-list>
+</div>

--- a/apps/admin-gui/src/app/vos/components/application-list-details/application-list-details.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-list-details/application-list-details.component.ts
@@ -25,6 +25,9 @@ interface ApplicationData extends Application {
   prefilledValue?: string;
 }
 
+/**
+ * @deprecated it seems that this component is no longer used anywhere
+ */
 @Component({
   selector: 'app-perun-web-apps-application-list-details',
   templateUrl: './application-list-details.component.html',

--- a/apps/admin-gui/src/app/vos/components/applications-dynamic-list/applications-dynamic-list.component.html
+++ b/apps/admin-gui/src/app/vos/components/applications-dynamic-list/applications-dynamic-list.component.html
@@ -5,9 +5,6 @@
     [dataLength]="dataSource.allObjectCount"
     [pageSizeOptions]="pageSizeOptions"
     [tableId]="tableId">
-    <div class="spinner-container" *ngIf="dataSource.loading$ | async">
-      <mat-spinner class="ml-auto mr-auto"></mat-spinner>
-    </div>
     <table
       [dataSource]="dataSource"
       class="w-100"
@@ -138,8 +135,6 @@
   </perun-web-apps-table-wrapper>
 </div>
 
-<perun-web-apps-alert
-  *ngIf="this.dataSource.allObjectCount === 0 && (dataSource.loading$ | async) === false"
-  [alert_type]="'warn'">
+<perun-web-apps-alert *ngIf="this.dataSource.allObjectCount === 0" [alert_type]="'warn'">
   {{'VO_DETAIL.APPLICATION.NO_APPLICATION_FOUND' | translate}}
 </perun-web-apps-alert>

--- a/apps/admin-gui/src/app/vos/components/applications-dynamic-list/applications-dynamic-list.component.ts
+++ b/apps/admin-gui/src/app/vos/components/applications-dynamic-list/applications-dynamic-list.component.ts
@@ -1,4 +1,13 @@
-import { AfterViewInit, Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import {
   Application,
   ApplicationFormItemData,
@@ -24,7 +33,7 @@ import {
   DynamicPaginatingService,
   GuiAuthResolver,
 } from '@perun-web-apps/perun/services';
-import { merge } from 'rxjs';
+import { merge, Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { TableConfigService } from '@perun-web-apps/config/table-config';
 import { formatDate } from '@angular/common';
@@ -40,46 +49,21 @@ export class ApplicationsDynamicListComponent implements OnInit, OnChanges, Afte
   @ViewChild(TableWrapperComponent, { static: true }) child: TableWrapperComponent;
 
   @ViewChild(MatSort) sort: MatSort;
-
-  @Input()
-  displayedColumns: string[] = [];
-  @Input()
-  fedColumns: string[] = [];
-
-  @Input()
-  tableId: string;
-
-  @Input()
-  disableRouting = false;
-
-  @Input()
-  searchString = '';
-
-  @Input()
-  group: Group;
-
-  @Input()
-  member: Member;
-
-  @Input()
-  vo: Vo;
-
-  @Input()
-  includeGroupApps: boolean;
-
-  @Input()
-  states: AppState[];
-
-  @Input()
-  dateTo: Date = new Date();
-
-  @Input()
-  dateFrom: Date = this.yearAgo();
-  @Input()
-  fedAttrNames: string[] = [];
-
-  @Input()
-  refreshTable = false;
+  @Input() displayedColumns: string[] = [];
+  @Input() fedColumns: string[] = [];
+  @Input() tableId: string;
+  @Input() disableRouting = false;
+  @Input() searchString = '';
+  @Input() group: Group;
+  @Input() member: Member;
+  @Input() vo: Vo;
+  @Input() includeGroupApps: boolean;
+  @Input() states: AppState[];
+  @Input() dateTo: Date = new Date();
+  @Input() dateFrom: Date = this.yearAgo();
+  @Input() fedAttrNames: string[] = [];
+  @Input() refreshTable = false;
+  @Output() loading$: EventEmitter<Observable<boolean>> = new EventEmitter<Observable<boolean>>();
   parsedColumns: string[] = [];
   dataSource: DynamicDataSource<Application>;
   pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
@@ -126,6 +110,7 @@ export class ApplicationsDynamicListComponent implements OnInit, OnChanges, Afte
       this.group?.id ?? null,
       this.getVoId()
     );
+    this.loading$.emit(this.dataSource.loading$);
 
     this.dataSource.loading$.subscribe((val) => {
       if (val || !this.displayedColumns.includes('fedInfo')) return;

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-applications/group-applications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-applications/group-applications.component.html
@@ -1,7 +1,6 @@
 <h1 class="page-subtitle">{{'VO_DETAIL.APPLICATION.TITLE' | translate}}</h1>
 <div>
-  <perun-web-apps-refresh-button
-    (refresh)="this.refresh=!this.refresh"></perun-web-apps-refresh-button>
+  <perun-web-apps-refresh-button (refresh)="refreshTable()"></perun-web-apps-refresh-button>
   <button (click)="this.showDetails(true)" *ngIf="!showAllDetails" class="mr-2" mat-stroked-button>
     {{'VO_DETAIL.APPLICATION.SHOW_ALL_DETAILS' | translate}}
   </button>
@@ -28,9 +27,13 @@
     </button>
   </span>
 </div>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
   <app-applications-dynamic-list
+    *perunWebAppsLoader="loading$ | async; indicator: spinner"
+    (loading$)="loading$ = $event"
     [tableId]="showAllDetails ? detailTableId : tableId"
     [searchString]="filterValue"
     [displayedColumns]="currentColumns"

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.html
@@ -115,18 +115,23 @@
     class="mt-2 search-field">
   </perun-web-apps-debounce-filter>
 </div>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
-<perun-web-apps-members-dynamic-list
-  *ngIf="!loading"
-  [attrNames]="memberAttrNames"
-  [groupId]="group.id"
-  [tableId]="tableId"
-  [displayedColumns]="displayedColumns"
-  [searchString]="searchString"
-  [updateTable]="updateTable"
-  [selectedGroupStatuses]="selectedGroupStatuses"
-  [selectedStatuses]="selectedStatuses"
-  [selection]="selection"
-  [voId]="group.voId"
-  [isMembersGroup]="group.name === 'members'">
-</perun-web-apps-members-dynamic-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-members-dynamic-list
+    *perunWebAppsLoader="loading$ | async; indicator: spinner"
+    (loading$)="loading$ = $event"
+    [attrNames]="memberAttrNames"
+    [groupId]="group.id"
+    [tableId]="tableId"
+    [displayedColumns]="displayedColumns"
+    [searchString]="searchString"
+    [updateTable]="updateTable"
+    [selectedGroupStatuses]="selectedGroupStatuses"
+    [selectedStatuses]="selectedStatuses"
+    [selection]="selection"
+    [voId]="group.voId"
+    [isMembersGroup]="group.name === 'members'">
+  </perun-web-apps-members-dynamic-list>
+</div>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-members/group-members.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, HostBinding, OnInit } from '@angular/core';
 import { SelectionModel } from '@angular/cdk/collections';
 import {
   ApiRequestConfigurationService,
@@ -26,6 +26,7 @@ import { RPCError } from '@perun-web-apps/perun/models';
 import { GroupAddMemberDialogComponent } from '../../../components/group-add-member-dialog/group-add-member-dialog.component';
 import { BulkInviteMembersDialogComponent } from '../../../../shared/components/dialogs/bulk-invite-members-dialog/bulk-invite-members-dialog.component';
 import { CopyMembersDialogComponent } from '../../../../shared/components/dialogs/copy-members-dialog/copy-members-dialog-component';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'app-group-members',
@@ -42,7 +43,7 @@ export class GroupMembersComponent implements OnInit {
   synchEnabled = false;
   searchString: string;
   updateTable = false;
-  loading = false;
+  loading$: Observable<boolean>;
   tableId = TABLE_GROUP_MEMBERS;
   memberAttrNames = [
     Urns.MEMBER_DEF_ORGANIZATION,
@@ -94,11 +95,12 @@ export class GroupMembersComponent implements OnInit {
     private attributesManager: AttributesManagerService,
     private apiRequest: ApiRequestConfigurationService,
     private notificator: NotificatorService,
-    private entityStorageService: EntityStorageService
+    private entityStorageService: EntityStorageService,
+    private cd: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
-    this.loading = true;
+    this.loading$ = of(true);
     this.selection = new SelectionModel<RichMember>(true, []);
     this.statuses.setValue(this.selectedStatuses);
     this.groupStatuses.setValue(this.selectedGroupStatuses);
@@ -115,7 +117,6 @@ export class GroupMembersComponent implements OnInit {
       .subscribe((group) => {
         this.group = group;
         this.synchEnabled = isGroupSynchronized(this.group);
-        this.loading = false;
       });
   }
 
@@ -269,7 +270,7 @@ export class GroupMembersComponent implements OnInit {
   }
 
   isCopyMembersDisabled(): void {
-    this.copyDisabled = false;
+    this.copyDisabled = true;
     this.groupService.getGroupDirectMembersCount(this.group.id).subscribe({
       next: (count) => {
         this.copyDisabled = count === 0;
@@ -283,16 +284,19 @@ export class GroupMembersComponent implements OnInit {
   changeVoStatuses(): void {
     this.selection.clear();
     this.selectedStatuses = this.statuses.value as VoMemberStatuses[];
+    this.cd.detectChanges();
   }
 
   changeGroupStatuses(): void {
     this.selection.clear();
     this.selectedGroupStatuses = this.groupStatuses.value as MemberGroupStatus[];
+    this.cd.detectChanges();
   }
 
   refreshTable(): void {
     this.selection.clear();
     this.updateTable = !this.updateTable;
+    this.cd.detectChanges();
     this.isCopyMembersDisabled();
   }
 }

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.html
@@ -24,20 +24,24 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_SEARCH'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-resources-list
-    #list
-    *ngIf="resources && !loading"
-    (refreshTable)="refreshTable()"
-    [disableRouting]="!routingAuth"
-    [filterValue]="filterValue"
-    [resources]="resources"
-    [routingVo]="true"
-    [displayedColumns]="['select', 'id', 'indirectResourceAssigment', 'name', 'status', 'facility', 'tags', 'description']"
-    [selection]="selected"
-    [groupId]="group.id"
-    [groupToResource]="group"
-    [resourcesToDisableCheckbox]="resourcesToDisable"
-    [tableId]="tableId">
-  </perun-web-apps-resources-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative" *ngIf="resources">
+    <perun-web-apps-resources-list
+      #list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      (refreshTable)="refreshTable()"
+      [disableRouting]="!routingAuth"
+      [filterValue]="filterValue"
+      [resources]="resources"
+      [routingVo]="true"
+      [displayedColumns]="['select', 'id', 'indirectResourceAssigment', 'name', 'status', 'facility', 'tags', 'description']"
+      [selection]="selected"
+      [groupId]="group.id"
+      [groupToResource]="group"
+      [resourcesToDisableCheckbox]="resourcesToDisable"
+      [tableId]="tableId">
+    </perun-web-apps-resources-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-resources/group-resources.component.ts
@@ -28,7 +28,7 @@ export class GroupResourcesComponent implements OnInit {
   list: ResourcesListComponent;
 
   group: Group;
-  resources: ResourceWithStatus[] = null;
+  resources: ResourceWithStatus[] = [];
   selected = new SelectionModel<ResourceWithStatus>(true, []);
   resourcesToDisable: Set<number>;
   loading: boolean;

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
@@ -106,15 +106,20 @@
     {{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.DRAG_AND_DROP_INFO' | translate}}
   </perun-web-apps-alert>
 
-  <app-application-form-list
-    (applicationFormItemsChange)="changeItems()"
-    [applicationForm]="applicationForm"
-    [applicationFormItems]="applicationFormItems"
-    [loading]="loading"
-    [displayedColumns]="editAuth ? ['drag', 'shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups', 'edit', 'delete'] : ['shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups']"
-    [refreshApplicationForm]="refreshApplicationForm"
-    [theme]="'group-theme'">
-  </app-application-form-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-application-form-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      (applicationFormItemsChange)="changeItems()"
+      [applicationForm]="applicationForm"
+      [applicationFormItems]="applicationFormItems"
+      [displayedColumns]="editAuth ? ['drag', 'shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups', 'edit', 'delete'] : ['shortname', 'type', 'disabled', 'hidden', 'preview', 'managegroups']"
+      [refreshApplicationForm]="refreshApplicationForm"
+      [theme]="'group-theme'">
+    </app-application-form-list>
+  </div>
 </div>
 <div *ngIf="!loading && noApplicationForm">
   <perun-web-apps-alert

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-extsources/group-settings-extsources.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-extsources/group-settings-extsources.component.html
@@ -21,13 +21,17 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'GROUP_DETAIL.SETTINGS.EXT_SOURCES.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-ext-sources-list
-    [extSources]="extSources"
-    *ngIf="!loading"
-    [selection]="selection"
-    [displayedColumns]="displayedColumns"
-    [filterValue]="filterValue"
-    [tableId]="tableId">
-  </app-ext-sources-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-ext-sources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [extSources]="extSources"
+      [selection]="selection"
+      [displayedColumns]="displayedColumns"
+      [filterValue]="filterValue"
+      [tableId]="tableId">
+    </app-ext-sources-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-notifications/group-settings-notifications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-notifications/group-settings-notifications.component.html
@@ -33,19 +33,23 @@
       {{'GROUP_DETAIL.SETTINGS.NOTIFICATIONS.COPY_FROM_VO' | translate}}
     </button>
   </div>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
 
-  <app-notification-list
-    *ngIf="!loading"
-    [disableSend]="!addAuth"
-    [displayedColumns]="displayedColumns"
-    (selectionChange)="changeSelection($event)"
-    [applicationMails]="applicationMails"
-    [groupId]="group.id"
-    [selection]="selection"
-    [tableId]="tableId"
-    [theme]="'group-theme'">
-  </app-notification-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-notification-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [disableSend]="!addAuth"
+      [displayedColumns]="displayedColumns"
+      (selectionChange)="changeSelection($event)"
+      [applicationMails]="applicationMails"
+      [groupId]="group.id"
+      [selection]="selection"
+      [tableId]="tableId"
+      [theme]="'group-theme'">
+    </app-notification-list>
+  </div>
 </div>
 <div *ngIf="noApplicationForm && !loading">
   <perun-web-apps-alert

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-overview/group-settings-overview.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-overview/group-settings-overview.component.ts
@@ -43,7 +43,6 @@ export class GroupSettingsOverviewComponent implements OnInit {
     this.loading = true;
     this.group = this.entityStorageService.getEntity();
     this.initItems();
-    this.loading = false;
   }
 
   private initItems(): void {
@@ -54,21 +53,23 @@ export class GroupSettingsOverviewComponent implements OnInit {
     this.apiRequest.dontHandleErrorForNext();
     this.attributesManager
       .getGroupAttributeByName(this.group.id, Urns.GROUP_DEF_EXPIRATION_RULES)
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.items.push({
             cssIcon: 'perun-group',
             url: `/organizations/${this.group.voId}/groups/${this.group.id}/settings/expiration`,
             label: 'MENU_ITEMS.GROUP.EXPIRATION',
             style: 'group-btn',
           });
+          this.loading = false;
         },
-        (error: RPCError) => {
+        error: (error: RPCError) => {
           if (error.name !== 'PrivilegeException') {
             this.notificator.showRPCError(error);
           }
-        }
-      );
+          this.loading = false;
+        },
+      });
 
     if (this.routePolicyService.canNavigate('groups-settings-managers', this.group)) {
       this.items.push({

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-relations/group-settings-relations.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-relations/group-settings-relations.component.html
@@ -29,15 +29,19 @@
     (change)="showReverseUnions()"
     >{{'GROUP_DETAIL.SETTINGS.RELATIONS.REVERSE_UNIONS' | translate}}</mat-checkbox
   >
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
 
-  <perun-web-apps-groups-list
-    *ngIf="!loading"
-    [groups]="groups"
-    [parentGroup]="group"
-    [disableHeadCheckbox]="true"
-    [selection]="selection"
-    [displayedColumns]="['select', 'id', 'vo', 'name', 'description']"
-    [filter]="filterValue"
-    [tableId]="tableId"></perun-web-apps-groups-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-groups-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [groups]="groups"
+      [parentGroup]="group"
+      [disableHeadCheckbox]="true"
+      [selection]="selection"
+      [displayedColumns]="['select', 'id', 'vo', 'name', 'description']"
+      [filter]="filterValue"
+      [tableId]="tableId"></perun-web-apps-groups-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-subgroups/group-subgroups.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-subgroups/group-subgroups.component.html
@@ -39,30 +39,34 @@
     >{{'GROUP_DETAIL.SUBGROUPS.TREE_VIEW' | translate}}</mat-slide-toggle
   >
   <label [attr.for]="toggle.inputId">{{'GROUP_DETAIL.SUBGROUPS.LIST_VIEW' | translate}}</label>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="mt-3">
-    <perun-web-apps-groups-tree
-      *ngIf="!showGroupList"
-      [disableRouting]="!routeAuth"
-      [expandAll]="filtering"
-      [groups]="groups"
-      (moveGroup)="onMoveGroup($event)"
-      (refreshTable)="refreshTable()"
-      [hideCheckbox]="!deleteAuth"
-      [filterValue]="filterValue"
-      [selection]="selected">
-    </perun-web-apps-groups-tree>
-    <perun-web-apps-groups-list
-      (groupMoved)="onMoveGroup($event)"
-      (refreshTable)="refreshTable()"
-      *ngIf="showGroupList"
-      [disableMembers]="true"
-      [disableRouting]="!routeAuth"
-      [displayedColumns]="deleteAuth ? ['select', 'id', 'name', 'description', 'menu'] : ['id', 'name', 'description', 'menu']"
-      [groups]="groups"
-      [selection]="selected"
-      [filter]="filterValue"
-      [tableId]="tableId">
-    </perun-web-apps-groups-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative mt-3">
+    <div *perunWebAppsLoader="loading; indicator: spinner">
+      <perun-web-apps-groups-tree
+        *ngIf="!showGroupList"
+        [disableRouting]="!routeAuth"
+        [expandAll]="filtering"
+        [groups]="groups"
+        (moveGroup)="onMoveGroup($event)"
+        (refreshTable)="refreshTable()"
+        [hideCheckbox]="!deleteAuth"
+        [filterValue]="filterValue"
+        [selection]="selected">
+      </perun-web-apps-groups-tree>
+      <perun-web-apps-groups-list
+        (groupMoved)="onMoveGroup($event)"
+        (refreshTable)="refreshTable()"
+        *ngIf="showGroupList"
+        [disableMembers]="true"
+        [disableRouting]="!routeAuth"
+        [displayedColumns]="deleteAuth ? ['select', 'id', 'name', 'description', 'menu'] : ['id', 'name', 'description', 'menu']"
+        [groups]="groups"
+        [selection]="selected"
+        [filter]="filterValue"
+        [tableId]="tableId">
+      </perun-web-apps-groups-list>
+    </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-applications/member-applications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-applications/member-applications.component.html
@@ -1,19 +1,10 @@
 <h1 class="page-subtitle">{{'MEMBER_DETAIL.APPLICATIONS.TITLE' | translate}}</h1>
 <div>
-  <perun-web-apps-refresh-button
-    (refresh)="this.refresh=!this.refresh"></perun-web-apps-refresh-button>
-  <button
-    (click)="this.showAllDetails = true"
-    *ngIf="!showAllDetails"
-    class="mr-2"
-    mat-stroked-button>
+  <perun-web-apps-refresh-button (refresh)="refreshTable()"></perun-web-apps-refresh-button>
+  <button (click)="showDetails()" *ngIf="!showAllDetails" class="mr-2" mat-stroked-button>
     {{'MEMBER_DETAIL.APPLICATIONS.SHOW_ALL_DETAILS' | translate}}
   </button>
-  <button
-    (click)="this.showAllDetails = false"
-    *ngIf="showAllDetails"
-    class="mr-2"
-    mat-stroked-button>
+  <button (click)="showDetails()" *ngIf="showAllDetails" class="mr-2" mat-stroked-button>
     {{'MEMBER_DETAIL.APPLICATIONS.SHOW_LESS_DETAILS' | translate}}
   </button>
   <perun-web-apps-debounce-filter
@@ -21,9 +12,13 @@
     (filter)="applyFilter($event)">
   </perun-web-apps-debounce-filter>
 </div>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
   <app-applications-dynamic-list
+    *perunWebAppsLoader="loading$ | async; indicator: spinner"
+    (loading$)="loading$ = $event"
     [tableId]="showAllDetails ? detailTableId : tableId"
     [searchString]="filterValue"
     [member]="member"

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-applications/member-applications.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-applications/member-applications.component.ts
@@ -1,14 +1,11 @@
-import { Component, OnInit } from '@angular/core';
-import {
-  Member,
-  MembersManagerService,
-  RegistrarManagerService,
-} from '@perun-web-apps/perun/openapi';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { Member } from '@perun-web-apps/perun/openapi';
 import {
   TABLE_MEMBER_APPLICATIONS_DETAILED,
   TABLE_MEMBER_APPLICATIONS_NORMAL,
 } from '@perun-web-apps/config/table-config';
-import { ActivatedRoute } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { EntityStorageService } from '@perun-web-apps/perun/services';
 
 @Component({
   selector: 'app-member-applications',
@@ -16,7 +13,7 @@ import { ActivatedRoute } from '@angular/router';
   styleUrls: ['./member-applications.component.scss'],
 })
 export class MemberApplicationsComponent implements OnInit {
-  loading = false;
+  loading$: Observable<boolean>;
   memberId: number;
   member: Member;
   displayedColumns: string[] = [
@@ -52,25 +49,24 @@ export class MemberApplicationsComponent implements OnInit {
   dateFrom: Date = new Date('1970-01-01');
   refresh: boolean;
 
-  constructor(
-    private registrarManager: RegistrarManagerService,
-    private memberManager: MembersManagerService,
-    protected route: ActivatedRoute
-  ) {}
+  constructor(private entityStorageService: EntityStorageService, private cd: ChangeDetectorRef) {}
 
   ngOnInit(): void {
-    this.loading = true;
-    this.route.parent.params.subscribe((parentParams) => {
-      this.memberId = Number(parentParams['memberId']);
-
-      this.memberManager.getMemberById(this.memberId).subscribe((member) => {
-        this.member = member;
-        this.loading = false;
-      });
-    });
+    this.loading$ = of(true);
+    this.member = this.entityStorageService.getEntity();
   }
 
   applyFilter(filterValue: string): void {
     this.filterValue = filterValue;
+  }
+
+  showDetails(): void {
+    this.showAllDetails = !this.showAllDetails;
+    this.cd.detectChanges();
+  }
+
+  refreshTable(): void {
+    this.refresh = !this.refresh;
+    this.cd.detectChanges();
   }
 }

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-bans/member-bans.component.html
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-bans/member-bans.component.html
@@ -13,7 +13,5 @@
   </perun-web-apps-ban-on-entity-list>
 </div>
 <ng-template #spinner>
-  <div class="spinner-container">
-    <mat-spinner></mat-spinner>
-  </div>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
 </ng-template>

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-groups/member-groups.component.html
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-groups/member-groups.component.html
@@ -25,16 +25,20 @@
   (filter)="applyFilter($event)"
   [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_SEARCH'">
 </perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-<perun-web-apps-groups-list
-  *ngIf="!loading"
-  (refreshTable)="refreshTable()"
-  [displayedColumns]="['select', 'id', 'name', 'description', 'expiration', 'groupStatus']"
-  [memberId]="memberId"
-  [disableRouting]="!routeAuth"
-  [groups]="groups"
-  [filter]="filterValue"
-  [memberGroupStatus]="member.groupStatus"
-  [selection]="selection"
-  [tableId]="tableId">
-</perun-web-apps-groups-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-groups-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    (refreshTable)="refreshTable()"
+    [displayedColumns]="['select', 'id', 'name', 'description', 'expiration', 'groupStatus']"
+    [memberId]="memberId"
+    [disableRouting]="!routeAuth"
+    [groups]="groups"
+    [filter]="filterValue"
+    [memberGroupStatus]="member?.groupStatus"
+    [selection]="selection"
+    [tableId]="tableId">
+  </perun-web-apps-groups-list>
+</div>

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-groups/member-groups.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-groups/member-groups.component.ts
@@ -29,7 +29,7 @@ export class MemberGroupsComponent implements OnInit {
   // used for router animation
   @HostBinding('class.router-component') true;
 
-  groups: Group[];
+  groups: Group[] = [];
   memberId: number;
   member: Member;
   allGroups: Group[];

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-resources/member-resources.component.html
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-resources/member-resources.component.html
@@ -14,15 +14,18 @@
     (filter)="applyFilter($event)"
     [placeholder]="'MEMBER_DETAIL.RESOURCES.FILTER'">
   </perun-web-apps-immediate-filter>
-  <perun-web-apps-resources-list
-    [disableRouting]="!routeAuth"
-    *ngIf="!loading"
-    [filterValue]="filterValue"
-    [displayedColumns]="displayedColumns"
-    [routingVo]="true"
-    [resources]="resources"
-    [tableId]="tableId">
-  </perun-web-apps-resources-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-resources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [disableRouting]="!routeAuth"
+      [filterValue]="filterValue"
+      [displayedColumns]="displayedColumns"
+      [routingVo]="true"
+      [resources]="resources"
+      [tableId]="tableId">
+    </perun-web-apps-resources-list>
+  </div>
 </div>
-
-<mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-resources/member-resources.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-resources/member-resources.component.ts
@@ -37,6 +37,7 @@ export class MemberResourcesComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.loading = true;
     this.route.parent.params.subscribe((parentParams) => {
       const memberId = Number(parentParams['memberId']);
 

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-applications/vo-applications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-applications/vo-applications.component.html
@@ -1,7 +1,6 @@
 <h1 class="page-subtitle">{{'VO_DETAIL.APPLICATION.TITLE' | translate}}</h1>
 <div>
-  <perun-web-apps-refresh-button
-    (refresh)="this.refresh = !this.refresh"></perun-web-apps-refresh-button>
+  <perun-web-apps-refresh-button (refresh)="refreshTable()"></perun-web-apps-refresh-button>
   <button mat-stroked-button *ngIf="!showAllDetails" class="mr-2" (click)="this.showDetails(true)">
     {{'VO_DETAIL.APPLICATION.SHOW_ALL_DETAILS' | translate}}
   </button>
@@ -38,9 +37,13 @@
     </span>
   </div>
 </div>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
   <app-applications-dynamic-list
+    *perunWebAppsLoader="loading$ | async; indicator: spinner"
+    (loading$)="loading$ = $event"
     [tableId]="showAllDetails ? detailTableId : tableId"
     [searchString]="filterValue"
     [displayedColumns]="currentColumns"

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-groups/vo-groups.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-groups/vo-groups.component.html
@@ -73,7 +73,5 @@
   </div>
 </div>
 <ng-template #spinner>
-  <div class="spinner-container">
-    <mat-spinner></mat-spinner>
-  </div>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
 </ng-template>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.html
@@ -65,16 +65,21 @@
       class="mt-2 search-field">
     </perun-web-apps-debounce-filter>
   </div>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
-  <perun-web-apps-members-dynamic-list
-    *ngIf="!loading"
-    [attrNames]="attrNames"
-    [selection]="selection"
-    [tableId]="tableId"
-    [displayedColumns]="displayedColumns"
-    [updateTable]="updateTable"
-    [searchString]="searchString"
-    [selectedStatuses]="selectedStatuses"
-    [voId]="vo.id"
-    [isMembersGroup]="false"></perun-web-apps-members-dynamic-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-members-dynamic-list
+      *perunWebAppsLoader="loading$ | async; indicator: spinner"
+      (loading$)="loading$ = $event"
+      [attrNames]="attrNames"
+      [selection]="selection"
+      [tableId]="tableId"
+      [displayedColumns]="displayedColumns"
+      [updateTable]="updateTable"
+      [searchString]="searchString"
+      [selectedStatuses]="selectedStatuses"
+      [voId]="vo.id"
+      [isMembersGroup]="false"></perun-web-apps-members-dynamic-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-members/vo-members.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, HostBinding, OnInit } from '@angular/core';
 import { SelectionModel } from '@angular/cdk/collections';
 import {
   ApiRequestConfigurationService,
@@ -23,6 +23,7 @@ import { InviteMemberDialogComponent } from '../../../../shared/components/dialo
 import { RPCError } from '@perun-web-apps/perun/models';
 import { VoAddMemberDialogComponent } from '../../../components/vo-add-member-dialog/vo-add-member-dialog.component';
 import { BulkInviteMembersDialogComponent } from '../../../../shared/components/dialogs/bulk-invite-members-dialog/bulk-invite-members-dialog.component';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'app-vo-members',
@@ -36,7 +37,7 @@ export class VoMembersComponent implements OnInit {
   vo: Vo;
   members: RichMember[] = null;
   selection = new SelectionModel<RichMember>(true, []);
-  loading = false;
+  loading$: Observable<boolean>;
   attrNames = [
     Urns.MEMBER_DEF_ORGANIZATION,
     Urns.MEMBER_DEF_MAIL,
@@ -65,18 +66,19 @@ export class VoMembersComponent implements OnInit {
     private storeService: StoreService,
     private attributesManager: AttributesManagerService,
     private apiRequest: ApiRequestConfigurationService,
-    private entityStorageService: EntityStorageService
+    private entityStorageService: EntityStorageService,
+    private cd: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
-    this.loading = true;
+    this.loading$ = of(true);
     this.statuses.setValue(this.selectedStatuses);
     this.attrNames = this.attrNames.concat(this.storeService.getLoginAttributeNames());
 
     this.vo = this.entityStorageService.getEntity();
     this.setAuthRights();
 
-    void this.isManualAddingBlocked(this.vo.id).then(() => (this.loading = false));
+    void this.isManualAddingBlocked(this.vo.id);
   }
 
   setAuthRights(): void {
@@ -202,10 +204,12 @@ export class VoMembersComponent implements OnInit {
   changeStatuses(): void {
     this.selection.clear();
     this.selectedStatuses = this.statuses.value as VoMemberStatuses[];
+    this.cd.detectChanges();
   }
 
   refreshTable(): void {
     this.selection.clear();
     this.updateTable = !this.updateTable;
+    this.cd.detectChanges();
   }
 }

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-resources/vo-resources-preview/vo-resources-preview.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-resources/vo-resources-preview/vo-resources-preview.component.html
@@ -14,15 +14,19 @@
     (filter)="applyFilter($event)"
     [placeholder]="'SHARED_LIB.PERUN.COMPONENTS.RESOURCES_LIST.TABLE_SEARCH'"></perun-web-apps-immediate-filter>
 
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-resources-list
-    *ngIf="!loading"
-    [disableRouting]="!routeAuth"
-    [filterValue]="filterValue"
-    [resources]="resources"
-    [routingVo]="true"
-    [displayedColumns]="displayedColumns"
-    [selection]="selected"
-    [tableId]="tableId">
-  </perun-web-apps-resources-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-resources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [disableRouting]="!routeAuth"
+      [filterValue]="filterValue"
+      [resources]="resources"
+      [routingVo]="true"
+      [displayedColumns]="displayedColumns"
+      [selection]="selected"
+      [tableId]="tableId">
+    </perun-web-apps-resources-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-resources/vo-resources-tags/vo-resources-tags.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-resources/vo-resources-tags/vo-resources-tags.component.html
@@ -23,13 +23,16 @@
   [placeholder]="'VO_DETAIL.RESOURCES.TAGS.SEARCH'">
 </perun-web-apps-immediate-filter>
 
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-
-<app-resources-tags-list
-  *ngIf="!loading"
-  [displayedColumns]="displayedColumns"
-  [entity]="'vo'"
-  [resourceTags]="resourceTag"
-  [filterValue]="filterValue"
-  [selection]="selection"
-  [tableId]="tableId"></app-resources-tags-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <app-resources-tags-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [displayedColumns]="displayedColumns"
+    [entity]="'vo'"
+    [resourceTags]="resourceTag"
+    [filterValue]="filterValue"
+    [selection]="selection"
+    [tableId]="tableId"></app-resources-tags-list>
+</div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.html
@@ -90,13 +90,18 @@
     {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.DRAG_AND_DROP_INFO' | translate}}
   </perun-web-apps-alert>
 
-  <app-application-form-list
-    (applicationFormItemsChange)="changeItems()"
-    [applicationForm]="applicationForm"
-    [applicationFormItems]="applicationFormItems"
-    [loading]="loading"
-    [displayedColumns]="displayedColumns"
-    [refreshApplicationForm]="refreshApplicationForm"
-    [theme]="'vo-theme'">
-  </app-application-form-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-application-form-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      (applicationFormItemsChange)="changeItems()"
+      [applicationForm]="applicationForm"
+      [applicationFormItems]="applicationFormItems"
+      [displayedColumns]="displayedColumns"
+      [refreshApplicationForm]="refreshApplicationForm"
+      [theme]="'vo-theme'">
+    </app-application-form-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.ts
@@ -158,6 +158,7 @@ export class VoSettingsApplicationFormComponent implements OnInit {
   }
 
   save(): void {
+    this.loading = true;
     let i = 0;
     for (const item of this.applicationFormItems) {
       item.ordnum = i;
@@ -168,13 +169,16 @@ export class VoSettingsApplicationFormComponent implements OnInit {
 
     this.registrarManager
       .updateFormItemsForVo({ vo: this.vo.id, items: this.applicationFormItems })
-      .subscribe(() => {
-        this.translate
-          .get('VO_DETAIL.SETTINGS.APPLICATION_FORM.CHANGE_APPLICATION_FORM_ITEMS_SUCCESS')
-          .subscribe((successMessage: string) => {
-            this.notificator.showSuccess(successMessage);
-          });
-        this.updateFormItems();
+      .subscribe({
+        next: () => {
+          this.translate
+            .get('VO_DETAIL.SETTINGS.APPLICATION_FORM.CHANGE_APPLICATION_FORM_ITEMS_SUCCESS')
+            .subscribe((successMessage: string) => {
+              this.notificator.showSuccess(successMessage);
+            });
+          this.updateFormItems();
+        },
+        error: () => (this.loading = false),
       });
   }
 

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-bans/vo-settings-bans.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-bans/vo-settings-bans.component.html
@@ -32,7 +32,5 @@
   </perun-web-apps-ban-on-entity-list>
 </div>
 <ng-template #spinner>
-  <div class="spinner-container">
-    <mat-spinner></mat-spinner>
-  </div>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
 </ng-template>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-extsources/vo-settings-extsources.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-extsources/vo-settings-extsources.component.html
@@ -21,13 +21,17 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'VO_DETAIL.SETTINGS.EXT_SOURCES.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-ext-sources-list
-    [extSources]="extSources"
-    *ngIf="!loading"
-    [selection]="selection"
-    [displayedColumns]="displayedColumns"
-    [filterValue]="filterValue"
-    [tableId]="tableId">
-  </app-ext-sources-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-ext-sources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [extSources]="extSources"
+      [selection]="selection"
+      [displayedColumns]="displayedColumns"
+      [filterValue]="filterValue"
+      [tableId]="tableId">
+    </app-ext-sources-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-hierarchical-inclusion/vo-settings-hierarchical-inclusion.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-hierarchical-inclusion/vo-settings-hierarchical-inclusion.component.html
@@ -20,13 +20,17 @@
     </perun-web-apps-vo-search-select>
   </div>
 </div>
-<perun-web-apps-groups-list
-  *ngIf="!loading"
-  [tableId]="tableId"
-  [groups]="allowedGroups"
-  [selection]="selected"
-  [displayedColumns]="['select', 'id', 'name', 'description']"
-  [noGroupsAlert]="'VO_DETAIL.SETTINGS.HIERARCHICAL_INCLUSION.NO_GROUPS_ALLOWED_ALERT'"
-  theme="vo-theme">
-</perun-web-apps-groups-list>
-<mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-groups-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [tableId]="tableId"
+    [groups]="allowedGroups"
+    [selection]="selected"
+    [displayedColumns]="['select', 'id', 'name', 'description']"
+    [noGroupsAlert]="'VO_DETAIL.SETTINGS.HIERARCHICAL_INCLUSION.NO_GROUPS_ALLOWED_ALERT'"
+    theme="vo-theme">
+  </perun-web-apps-groups-list>
+</div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-member-organizations/add-member-organization-dialog/add-member-organization-dialog.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-member-organizations/add-member-organization-dialog/add-member-organization-dialog.component.html
@@ -1,76 +1,82 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>
-    {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.TITLE' | translate}}
-  </h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content class="dialog-container">
-    <mat-stepper #stepper [linear]="true">
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.SELECTION_STEP' | translate}}</ng-template
-        >
-        <perun-web-apps-immediate-filter
-          (filter)="voFilter = $event"
-          [placeholder]="'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.FILTER_VOS'"></perun-web-apps-immediate-filter>
-        <perun-web-apps-vos-list
-          [vos]="vos"
-          [selection]="voSelection"
-          [displayedColumns]="displayedColumns"
-          [filterValue]="voFilter"
-          [disableRouting]="true"></perun-web-apps-vos-list>
-      </mat-step>
-      <mat-step>
-        <ng-template
-          matStepLabel
-          >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.CONFIRMATION_STEP' | translate}}</ng-template
-        >
-        <ng-template matStepContent>
-          <span
-            >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.CONFIRM' | translate}}</span
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>
+      {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.TITLE' | translate}}
+    </h1>
+    <div mat-dialog-content class="dialog-container">
+      <mat-stepper #stepper [linear]="true">
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.SELECTION_STEP' | translate}}</ng-template
           >
-          <table mat-table [dataSource]="voSelection.selected" class="w-100">
-            <ng-container matColumnDef="name">
-              <th mat-header-cell *matHeaderCellDef></th>
-              <td mat-cell *matCellDef="let vo">{{vo.name}}</td>
-            </ng-container>
-            <tr mat-header-row *matHeaderRowDef="columns"></tr>
-            <tr mat-row *matRowDef="let vo; columns: columns;"></tr>
-          </table>
-          <perun-web-apps-alert
-            [alert_type]="'warn'"
-            >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.WARNING' | translate}}</perun-web-apps-alert
+          <perun-web-apps-immediate-filter
+            (filter)="voFilter = $event"
+            [placeholder]="'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.FILTER_VOS'"></perun-web-apps-immediate-filter>
+          <perun-web-apps-vos-list
+            [vos]="vos"
+            [selection]="voSelection"
+            [displayedColumns]="displayedColumns"
+            [filterValue]="voFilter"
+            [disableRouting]="true"></perun-web-apps-vos-list>
+        </mat-step>
+        <mat-step>
+          <ng-template
+            matStepLabel
+            >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.CONFIRMATION_STEP' | translate}}</ng-template
           >
-        </ng-template>
-      </mat-step>
-    </mat-stepper>
-  </div>
-  <div *ngIf="!loading" mat-dialog-actions>
-    <button (click)="close()" mat-flat-button>
-      {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.CANCEL' | translate}}
-    </button>
-    <div class="ml-auto">
-      <button
-        *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
-        (click)="stepperPrevious()"
-        mat-flat-button>
-        {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.BACK' | translate}}
+          <ng-template matStepContent>
+            <span
+              >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.CONFIRM' | translate}}</span
+            >
+            <table mat-table [dataSource]="voSelection.selected" class="w-100">
+              <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef></th>
+                <td mat-cell *matCellDef="let vo">{{vo.name}}</td>
+              </ng-container>
+              <tr mat-header-row *matHeaderRowDef="columns"></tr>
+              <tr mat-row *matRowDef="let vo; columns: columns;"></tr>
+            </table>
+            <perun-web-apps-alert
+              [alert_type]="'warn'"
+              >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.WARNING' | translate}}</perun-web-apps-alert
+            >
+          </ng-template>
+        </mat-step>
+      </mat-stepper>
+    </div>
+    <div mat-dialog-actions>
+      <button (click)="close()" mat-flat-button>
+        {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.CANCEL' | translate}}
       </button>
-      <button
-        *ngIf="stepper?.selectedIndex !== 1"
-        (click)="stepperNext()"
-        [disabled]="voSelection.selected.length === 0"
-        color="accent"
-        mat-flat-button>
-        {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.NEXT' | translate}}
-      </button>
-      <button
-        *ngIf="stepper?.selectedIndex === 1"
-        (click)="addMemberOrganization()"
-        color="accent"
-        mat-flat-button>
-        {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.ADD' | translate}}
-      </button>
+      <div class="ml-auto">
+        <button
+          *ngIf="stepper !== undefined && stepper.selectedIndex !== 0"
+          (click)="stepperPrevious()"
+          [disabled]="loading"
+          mat-flat-button>
+          {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.BACK' | translate}}
+        </button>
+        <button
+          *ngIf="stepper?.selectedIndex !== 1"
+          (click)="stepperNext()"
+          [disabled]="voSelection.selected.length === 0 || loading"
+          color="accent"
+          mat-flat-button>
+          {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.NEXT' | translate}}
+        </button>
+        <button
+          *ngIf="stepper?.selectedIndex === 1"
+          (click)="addMemberOrganization()"
+          [disabled]="loading"
+          color="accent"
+          mat-flat-button>
+          {{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.ADD' | translate}}
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-member-organizations/vo-settings-member-organizations.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-member-organizations/vo-settings-member-organizations.component.html
@@ -20,12 +20,16 @@
 <perun-web-apps-immediate-filter
   (filter)="filterValue = $event"
   [placeholder]="'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.FILTER'"></perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<perun-web-apps-vos-list
-  *ngIf="!loading"
-  [vos]="memberVos"
-  [selection]="voSelection"
-  [filterValue]="filterValue"
-  [disableRouting]="!auth"
-  [displayedColumns]="displayedColumns">
-</perun-web-apps-vos-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-vos-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [vos]="memberVos"
+    [selection]="voSelection"
+    [filterValue]="filterValue"
+    [disableRouting]="!auth"
+    [displayedColumns]="displayedColumns">
+  </perun-web-apps-vos-list>
+</div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-notifications/vo-settings-notifications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-notifications/vo-settings-notifications.component.html
@@ -29,16 +29,19 @@
   </button>
 </div>
 
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"> </mat-spinner>
-
-<app-notification-list
-  *ngIf="!loading"
-  [applicationMails]="applicationMails"
-  (selectionChange)="changeSelection($event)"
-  [disableSend]="!addAuth"
-  [displayedColumns]="displayedColumns"
-  [tableId]="tableId"
-  [selection]="selection"
-  [theme]="'vo-theme'"
-  [voId]="vo.id">
-</app-notification-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <app-notification-list
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [applicationMails]="applicationMails"
+    (selectionChange)="changeSelection($event)"
+    [disableSend]="!addAuth"
+    [displayedColumns]="displayedColumns"
+    [tableId]="tableId"
+    [selection]="selection"
+    [theme]="'vo-theme'"
+    [voId]="vo.id">
+  </app-notification-list>
+</div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-service-members/vo-settings-service-members.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-service-members/vo-settings-service-members.component.html
@@ -16,12 +16,16 @@
   (filter)="applyFilter($event)"
   [placeholder]="'VO_DETAIL.SETTINGS.SERVICE_MEMBERS.FILTER'">
 </perun-web-apps-immediate-filter>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<perun-web-apps-members-list
-  [tableId]="tableId"
-  *ngIf="!loading"
-  [displayedColumns]="['checkbox','id', 'type', 'fullName', 'status']"
-  [selection]="selection"
-  [disableStatusChange]="true"
-  [filter]="searchString"
-  [members]="members"></perun-web-apps-members-list>
+<ng-template #spinner>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div class="position-relative">
+  <perun-web-apps-members-list
+    [tableId]="tableId"
+    *perunWebAppsLoader="loading; indicator: spinner"
+    [displayedColumns]="['checkbox','id', 'type', 'fullName', 'status']"
+    [selection]="selection"
+    [disableStatusChange]="true"
+    [filter]="searchString"
+    [members]="members"></perun-web-apps-members-list>
+</div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-sponsored-members/vo-settings-sponsored-members.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-sponsored-members/vo-settings-sponsored-members.component.html
@@ -47,13 +47,17 @@
     (filter)="applyFilter($event)"
     [placeholder]="'VO_DETAIL.SETTINGS.SPONSORED_MEMBERS.FILTER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <app-sponsored-members-list
-    *ngIf="!loading"
-    (refreshTable)="refresh()"
-    [disableRouting]="!routeAuth"
-    [selection]="selection"
-    [filterValue]="searchString"
-    [sponsoredMembers]="members"
-    [tableId]="tableId"></app-sponsored-members-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <app-sponsored-members-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      (refreshTable)="refresh()"
+      [disableRouting]="!routeAuth"
+      [selection]="selection"
+      [filterValue]="searchString"
+      [sponsoredMembers]="members"
+      [tableId]="tableId"></app-sponsored-members-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-select-page/vo-select-page.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-select-page/vo-select-page.component.html
@@ -31,14 +31,18 @@
     (filter)="applyFilter($event)"
     [placeholder]="'VO_MANAGEMENT.FILTER_PLACEHOLDER'">
   </perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-vos-list
-    *ngIf="!loading"
-    [tableId]="tableId"
-    [displayedColumns]="displayedColumns"
-    [filterValue]="filterValue"
-    [recentIds]="recentIds"
-    [selection]="selection"
-    [vos]="vos">
-  </perun-web-apps-vos-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-vos-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [tableId]="tableId"
+      [displayedColumns]="displayedColumns"
+      [filterValue]="filterValue"
+      [recentIds]="recentIds"
+      [selection]="selection"
+      [vos]="vos">
+    </perun-web-apps-vos-list>
+  </div>
 </div>

--- a/apps/admin-gui/src/app/vos/vos.module.ts
+++ b/apps/admin-gui/src/app/vos/vos.module.ts
@@ -47,6 +47,7 @@ import { GroupSettingsManagersComponent } from './pages/group-detail-page/group-
 import { GroupSettingsNotificationsComponent } from './pages/group-detail-page/group-settings/group-settings-notifications/group-settings-notifications.component';
 import { NotificationListComponent } from './components/notification-list/notification-list.component';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { VoSettingsExtsourcesComponent } from './pages/vo-detail-page/vo-settings/vo-settings-extsources/vo-settings-extsources.component';
 import { GroupSettingsRelationsComponent } from './pages/group-detail-page/group-settings/group-settings-relations/group-settings-relations.component';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
@@ -77,6 +78,7 @@ import { MemberBansComponent } from './pages/member-detail-page/member-bans/memb
     VosRoutingModule,
     SharedModule,
     UiAlertsModule,
+    UiLoadersModule,
     PerunSharedComponentsModule,
     PerunPipesModule,
     PerunUtilsModule,

--- a/apps/admin-gui/src/styles.scss
+++ b/apps/admin-gui/src/styles.scss
@@ -1414,6 +1414,22 @@ td.mat-cell {
   justify-content: center;
 }
 
+// TODO: check this style after the migration to Angular 15
+// make the whole dialog grey (including padding space) while the spinner is active
+mat-dialog-container:has(#loading-dialog-spinner) {
+  box-shadow: 0 0 0 24px rgba(0, 0, 0, 0.15) inset;
+  padding-bottom: 0;
+  .position-relative {
+    padding-bottom: 24px;
+  }
+  .spinner-container {
+    margin-bottom: 24px;
+  }
+  .mat-dialog-actions {
+    padding-bottom: 16px;
+  }
+}
+
 #preloader {
   position: fixed;
   top: 0;

--- a/apps/consolidator/src/app/app.module.ts
+++ b/apps/consolidator/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { MainWindowComponent } from './components/main-window/main-window.compon
 import { MatIconModule } from '@angular/material/icon';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
 import { GeneralModule } from '@perun-web-apps/general';
 import { LibLinkerModule } from '@perun-web-apps/lib-linker';
@@ -68,6 +69,7 @@ const loadConfigs = (appConfig: ConsolidatorConfigService) => (): Promise<void> 
     MatIconModule,
     PerunSharedComponentsModule,
     UiAlertsModule,
+    UiLoadersModule,
     PerunUtilsModule,
     GeneralModule,
     OAuthModule.forRoot(),

--- a/apps/consolidator/src/styles.scss
+++ b/apps/consolidator/src/styles.scss
@@ -117,6 +117,35 @@ button:focus {
   width: 100%;
 }
 
+.spinner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// TODO: check this style after the migration to Angular 15
+// make the whole dialog grey (including padding space) while the spinner is active
+mat-dialog-container:has(#loading-dialog-spinner) {
+  box-shadow: 0 0 0 24px rgba(0, 0, 0, 0.15) inset;
+  padding-bottom: 0;
+  .position-relative {
+    padding-bottom: 24px;
+  }
+  .spinner-container {
+    margin-bottom: 24px;
+  }
+  .mat-dialog-actions {
+    padding-bottom: 16px;
+  }
+}
+
 #preloader {
   position: fixed;
   top: 0;

--- a/apps/linker/src/app/app.module.ts
+++ b/apps/linker/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { PerunLoginModule } from '@perun-web-apps/perun/login';
 import { MatIconModule } from '@angular/material/icon';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
 import { GeneralModule } from '@perun-web-apps/general';
 import { OAuthModule } from 'angular-oauth2-oidc';
@@ -62,6 +63,7 @@ const loadConfigs = (appConfig: LinkerConfigService) => (): Promise<void> =>
     MatIconModule,
     PerunSharedComponentsModule,
     UiAlertsModule,
+    UiLoadersModule,
     PerunUtilsModule,
     GeneralModule,
     OAuthModule.forRoot(),

--- a/apps/linker/src/app/components/send-message-dialog/send-message-dialog.component.html
+++ b/apps/linker/src/app/components/send-message-dialog/send-message-dialog.component.html
@@ -1,30 +1,34 @@
-<div>
-  <div mat-dialog-title>
-    <h1 class="page-subtitle">
-      {{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.TITLE' | translate}}
-    </h1>
-  </div>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
-    <perun-web-apps-alert alert_type="info">
-      {{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.SUBTITLE' | translate}}
-    </perun-web-apps-alert>
-    <mat-form-field class="w-100">
-      <textarea
-        [(ngModel)]="message"
-        matInput
-        cdkTextareaAutosize
-        placeholder="{{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.PLACEHOLDER' | translate}}"></textarea>
-    </mat-form-field>
-  </div>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <div mat-dialog-title>
+      <h1 class="page-subtitle">
+        {{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.TITLE' | translate}}
+      </h1>
+    </div>
+    <div mat-dialog-content>
+      <perun-web-apps-alert alert_type="info">
+        {{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.SUBTITLE' | translate}}
+      </perun-web-apps-alert>
+      <mat-form-field class="w-100">
+        <textarea
+          [(ngModel)]="message"
+          matInput
+          cdkTextareaAutosize
+          placeholder="{{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.PLACEHOLDER' | translate}}"></textarea>
+      </mat-form-field>
+    </div>
 
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.CANCEL' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.CANCEL' | translate}}
+      </button>
 
-    <button (click)="onSend()" class="ml-2" color="accent" mat-flat-button>
-      {{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.SUBMIT' | translate}}
-    </button>
+      <button (click)="onSend()" class="ml-2" color="accent" mat-flat-button>
+        {{'SHARED_LIB.CONSOLIDATOR.SEND_MESSAGE_TO_SUPPORT_DIALOG.SUBMIT' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/linker/src/app/components/show-result/show-result.component.html
+++ b/apps/linker/src/app/components/show-result/show-result.component.html
@@ -24,7 +24,4 @@
       </button>
     </div>
   </perun-web-apps-consolidation-result>
-  <div class="spinner-container" *ngIf="loading">
-    <mat-spinner class="ml-auto mr-auto"></mat-spinner>
-  </div>
 </div>

--- a/apps/linker/src/app/components/show-result/show-result.component.ts
+++ b/apps/linker/src/app/components/show-result/show-result.component.ts
@@ -13,7 +13,6 @@ import { SendMessageDialogComponent } from '../send-message-dialog/send-message-
 })
 export class ShowResultComponent implements OnInit {
   linkerResult: LinkerResult = 'UNKNOWN_ERROR';
-  loading = false;
   openerWindow = window.opener as Window;
 
   constructor(

--- a/apps/linker/src/styles.scss
+++ b/apps/linker/src/styles.scss
@@ -89,6 +89,35 @@ $perun-theme: mat.define-light-theme($perun-primary, $perun-accent, $perun-warn)
   @include mat.all-component-themes($user-theme);
 }
 
+.spinner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// TODO: check this style after the migration to Angular 15
+// make the whole dialog grey (including padding space) while the spinner is active
+mat-dialog-container:has(#loading-dialog-spinner) {
+  box-shadow: 0 0 0 24px rgba(0, 0, 0, 0.15) inset;
+  padding-bottom: 0;
+  .position-relative {
+    padding-bottom: 24px;
+  }
+  .spinner-container {
+    margin-bottom: 24px;
+  }
+  .mat-dialog-actions {
+    padding-bottom: 16px;
+  }
+}
+
 #preloader {
   position: fixed;
   top: 0;

--- a/apps/password-reset/src/app/app.module.ts
+++ b/apps/password-reset/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { PasswordResetPageComponent } from './pages/password-reset-page/password-reset-page.component';
 import { PasswordResetFormComponent } from './components/password-reset-form/password-reset-form.component';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { InvalidRequestAlertComponent } from './components/invalid-request-alert/invalid-request-alert.component';
 import { PerunNamespacePasswordFormModule } from '@perun-web-apps/perun/namespace-password-form';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
@@ -72,6 +73,7 @@ const loadConfigs = (appConfig: PasswordResetConfigService) => (): Promise<void>
     AppRoutingModule,
     UiMaterialModule,
     UiAlertsModule,
+    UiLoadersModule,
     PerunNamespacePasswordFormModule,
     OAuthModule.forRoot(),
     PerunSharedComponentsModule,

--- a/apps/password-reset/src/styles.scss
+++ b/apps/password-reset/src/styles.scss
@@ -94,3 +94,32 @@ $password-reset-theme: mat.define-light-theme(
 mat-icon {
   overflow: inherit !important;
 }
+
+.spinner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// TODO: check this style after the migration to Angular 15
+// make the whole dialog grey (including padding space) while the spinner is active
+mat-dialog-container:has(#loading-dialog-spinner) {
+  box-shadow: 0 0 0 24px rgba(0, 0, 0, 0.15) inset;
+  padding-bottom: 0;
+  .position-relative {
+    padding-bottom: 24px;
+  }
+  .spinner-container {
+    margin-bottom: 24px;
+  }
+  .mat-dialog-actions {
+    padding-bottom: 16px;
+  }
+}

--- a/apps/publications/src/app/app.module.ts
+++ b/apps/publications/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { CategoriesListComponent } from './components/categories-list/categories
 import { AddCategoryDialogComponent } from './dialogs/add-category-dialog/add-category-dialog.component';
 import { RemoveCategoryDialogComponent } from './dialogs/remove-category-dialog/remove-category-dialog.component';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { PublicationSystemsListComponent } from './components/publication-systems-list/publication-systems-list.component';
 import { UpdateRankDialogComponent } from './dialogs/update-rank-dialog/update-rank-dialog.component';
 import { AuthorsListComponent } from './components/authors-list/authors-list.component';
@@ -122,6 +123,7 @@ const loadConfigs: (appConfig: PublicationsConfigService) => () => Promise<void>
     HttpClientModule,
     AppRoutingModule,
     UiAlertsModule,
+    UiLoadersModule,
     PerunPipesModule,
     PerunLoginModule,
     MatTabsModule,

--- a/apps/publications/src/app/components/add-authors/add-authors.component.html
+++ b/apps/publications/src/app/components/add-authors/add-authors.component.html
@@ -19,14 +19,18 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'PUBLICATION_DETAIL.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <perun-web-apps-authors-list
-    *ngIf="!loading"
-    [authors]="publication.authors"
-    [selection]="selection"
-    [filterValue]="filterValue"
-    [tableId]="tableId"
-    [disableRouting]="disableRouting"
-    [displayedColumns]="publication.locked ? ['id', 'name', 'organization', 'email'] : ['select', 'id', 'name', 'organization', 'email']">
-  </perun-web-apps-authors-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-authors-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [authors]="publication.authors"
+      [selection]="selection"
+      [filterValue]="filterValue"
+      [tableId]="tableId"
+      [disableRouting]="disableRouting"
+      [displayedColumns]="publication.locked ? ['id', 'name', 'organization', 'email'] : ['select', 'id', 'name', 'organization', 'email']">
+    </perun-web-apps-authors-list>
+  </div>
 </div>

--- a/apps/publications/src/app/components/add-thanks/add-thanks.component.html
+++ b/apps/publications/src/app/components/add-thanks/add-thanks.component.html
@@ -19,13 +19,17 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'PUBLICATION_DETAIL.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <perun-web-apps-thanks-list
-    *ngIf="!loading"
-    [thanks]="publication.thanks"
-    [filterValue]="filterValue"
-    [tableId]="tableId"
-    [displayedColumns]="publication.locked ? ['id', 'name', 'createdBy'] : ['select', 'id', 'name', 'createdBy']"
-    [selection]="selection">
-  </perun-web-apps-thanks-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-thanks-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [thanks]="publication.thanks"
+      [filterValue]="filterValue"
+      [tableId]="tableId"
+      [displayedColumns]="publication.locked ? ['id', 'name', 'createdBy'] : ['select', 'id', 'name', 'createdBy']"
+      [selection]="selection">
+    </perun-web-apps-thanks-list>
+  </div>
 </div>

--- a/apps/publications/src/app/components/categories-list/categories-list.component.html
+++ b/apps/publications/src/app/components/categories-list/categories-list.component.html
@@ -59,8 +59,6 @@
   </perun-web-apps-table-wrapper>
 </div>
 
-<perun-web-apps-alert
-  *ngIf="dataSource.filteredData.length === 0 && categories.length !== 0"
-  alert_type="warn">
+<perun-web-apps-alert *ngIf="dataSource.filteredData.length === 0" alert_type="warn">
   {{'CATEGORIES_PAGE.NO_FILTER_RESULTS' | translate}}
 </perun-web-apps-alert>

--- a/apps/publications/src/app/components/publication-systems-list/publication-systems-list.component.html
+++ b/apps/publications/src/app/components/publication-systems-list/publication-systems-list.component.html
@@ -57,8 +57,6 @@
   </perun-web-apps-table-wrapper>
 </div>
 
-<perun-web-apps-alert
-  *ngIf="dataSource.filteredData.length === 0 && publicationSystems.length !== 0"
-  alert_type="warn">
+<perun-web-apps-alert *ngIf="dataSource.filteredData.length === 0" alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_FILTER_RESULTS_ALERT' | translate}}
 </perun-web-apps-alert>

--- a/apps/publications/src/app/dialogs/add-authors-dialog/add-authors-dialog.component.html
+++ b/apps/publications/src/app/dialogs/add-authors-dialog/add-authors-dialog.component.html
@@ -1,57 +1,61 @@
-<div class="user-theme">
-  <h1 mat-dialog-title>{{'DIALOGS.ADD_AUTHORS.TITLE' | translate}}</h1>
-  <div mat-dialog-content>
-    <mat-form-field class="mr-2 adjust-width">
-      <label>
-        <input
-          matInput
-          autocomplete="false"
-          placeholder="{{'DIALOGS.ADD_AUTHORS.SEARCH_PLACEHOLDER' | translate}}"
-          (keyup.enter)="onSearchByString()"
-          [formControl]="searchControl" />
-      </label>
-      <mat-error>
-        {{'DIALOGS.ADD_AUTHORS.EMPTY_SEARCH_MESSAGE' | translate }}
-      </mat-error>
-    </mat-form-field>
-    <button
-      mat-flat-button
-      color="accent"
-      class="mr-2"
-      [disabled]="searchLoading || searchControl.value.trim() === ''"
-      (click)="onSearchByString()">
-      <mat-icon>search</mat-icon>
-    </button>
-    <div *ngIf="!loading">
-      <div *ngIf="!searchLoading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_AUTHORS.TITLE' | translate}}</h1>
+    <div mat-dialog-content>
+      <mat-form-field class="mr-2 adjust-width">
+        <label>
+          <input
+            matInput
+            autocomplete="false"
+            placeholder="{{'DIALOGS.ADD_AUTHORS.SEARCH_PLACEHOLDER' | translate}}"
+            (keyup.enter)="onSearchByString()"
+            [formControl]="searchControl" />
+        </label>
+        <mat-error>
+          {{'DIALOGS.ADD_AUTHORS.EMPTY_SEARCH_MESSAGE' | translate }}
+        </mat-error>
+      </mat-form-field>
+      <button
+        mat-flat-button
+        color="accent"
+        class="mr-2"
+        [disabled]="searchLoading || searchControl.value.trim() === ''"
+        (click)="onSearchByString()">
+        <mat-icon>search</mat-icon>
+      </button>
+      <ng-template #searchSpinner>
+        <perun-web-apps-loading-table></perun-web-apps-loading-table>
+      </ng-template>
+      <div class="position-relative" *ngIf="firstSearchDone">
         <perun-web-apps-authors-list
-          *ngIf="firstSearchDone"
+          *perunWebAppsLoader="searchLoading; indicator: searchSpinner"
           [authors]="authors"
           [selection]="selection"
           [disableRouting]="true"
           [tableId]="tableIdAuthors"
           [displayedColumns]="['select', 'id', 'name', 'organization', 'email']">
         </perun-web-apps-authors-list>
-        <perun-web-apps-alert *ngIf="!firstSearchDone" alert_type="info">
-          {{'DIALOGS.ADD_AUTHORS.SEARCH_INFO' | translate}}
-        </perun-web-apps-alert>
       </div>
-      <mat-spinner *ngIf="searchLoading" class="ml-auto mr-auto"></mat-spinner>
+      <perun-web-apps-alert *ngIf="!firstSearchDone" alert_type="info">
+        {{'DIALOGS.ADD_AUTHORS.SEARCH_INFO' | translate}}
+      </perun-web-apps-alert>
     </div>
-  </div>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
 
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.ADD_AUTHORS.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onAdd()"
-      [disabled]="selection.selected.length === 0 || loading"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.ADD_AUTHORS.ADD' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.ADD_AUTHORS.CANCEL' | translate}}
+      </button>
+      <button
+        (click)="onAdd()"
+        [disabled]="selection.selected.length === 0 || loading"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.ADD_AUTHORS.ADD' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/publications/src/app/dialogs/add-authors-dialog/add-authors-dialog.component.ts
+++ b/apps/publications/src/app/dialogs/add-authors-dialog/add-authors-dialog.component.ts
@@ -51,6 +51,7 @@ export class AddAuthorsDialogComponent implements OnInit {
   }
 
   onSearchByString(): void {
+    this.firstSearchDone = true;
     if (!this.searchLoading && this.searchControl.value.trim() !== '') {
       this.searchLoading = true;
       this.cabinetService.findNewAuthors(this.searchControl.value).subscribe({
@@ -59,7 +60,6 @@ export class AddAuthorsDialogComponent implements OnInit {
             (item) => !this.alreadyAddedAuthors.map((author) => author.id).includes(item.id)
           );
           this.authors = authors;
-          this.firstSearchDone = true;
           this.searchLoading = false;
         },
         error: () => {

--- a/apps/publications/src/app/dialogs/add-category-dialog/add-category-dialog.component.html
+++ b/apps/publications/src/app/dialogs/add-category-dialog/add-category-dialog.component.html
@@ -1,7 +1,9 @@
-<div class="user-theme">
-  <h1 mat-dialog-title>{{"DIALOGS.ADD_CATEGORY.TITLE" | translate}}</h1>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{"DIALOGS.ADD_CATEGORY.TITLE" | translate}}</h1>
     <div mat-dialog-content class="dialog-container">
       <mat-form-field>
         <input

--- a/apps/publications/src/app/dialogs/add-thanks-dialog/add-thanks-dialog.component.html
+++ b/apps/publications/src/app/dialogs/add-thanks-dialog/add-thanks-dialog.component.html
@@ -1,7 +1,9 @@
-<div class="user-theme">
-  <h1 mat-dialog-title>{{"DIALOGS.ADD_THANKS.TITLE" | translate}}</h1>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{"DIALOGS.ADD_THANKS.TITLE" | translate}}</h1>
     <div mat-dialog-content class="dialog-container">
       <perun-web-apps-immediate-filter
         (filter)="filterValue = $event"

--- a/apps/publications/src/app/dialogs/add-thanks-dialog/add-thanks-dialog.component.ts
+++ b/apps/publications/src/app/dialogs/add-thanks-dialog/add-thanks-dialog.component.ts
@@ -18,7 +18,7 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class AddThanksDialogComponent implements OnInit {
   loading: boolean;
-  owners: Owner[];
+  owners: Owner[] = [];
   selected = new SelectionModel<Owner>(true, []);
   filterValue: string;
   tableId = TABLE_ADD_THANKS_DIALOG;

--- a/apps/publications/src/app/dialogs/remove-category-dialog/remove-category-dialog.component.html
+++ b/apps/publications/src/app/dialogs/remove-category-dialog/remove-category-dialog.component.html
@@ -1,33 +1,36 @@
-<div class="user-theme">
-  <h1 mat-dialog-title>{{'DIALOGS.REMOVE_CATEGORY.TITLE' | translate}}</h1>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_CATEGORY.TITLE' | translate}}</h1>
 
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_CATEGORY.DESCRIPTION' | translate}}
+      </p>
 
-  <div mat-dialog-content *ngIf="!loading">
-    <p>
-      {{'DIALOGS.REMOVE_CATEGORY.DESCRIPTION' | translate}}
-    </p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_CATEGORY.ASK' | translate}}
+      </div>
 
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_CATEGORY.ASK' | translate}}
+      <table mat-table [dataSource]="dataSource" class="w-100">
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let category">{{category.name}}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns" class="font-weight-bolder"></tr>
+        <tr mat-row *matRowDef="let category; columns: displayedColumns;"></tr>
+      </table>
     </div>
-
-    <table mat-table [dataSource]="dataSource" class="w-100">
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let category">{{category.name}}</td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="displayedColumns" class="font-weight-bolder"></tr>
-      <tr mat-row *matRowDef="let category; columns: displayedColumns;"></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions *ngIf="!loading">
-    <button mat-flat-button class="ml-auto" (click)="onCancel()">
-      {{'DIALOGS.REMOVE_CATEGORY.CANCEL' | translate}}
-    </button>
-    <button mat-flat-button class="ml-2" color="warn" [disabled]="loading" (click)="onSubmit()">
-      {{'DIALOGS.REMOVE_CATEGORY.DELETE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button mat-flat-button class="ml-auto" (click)="onCancel()">
+        {{'DIALOGS.REMOVE_CATEGORY.CANCEL' | translate}}
+      </button>
+      <button mat-flat-button class="ml-2" color="warn" [disabled]="loading" (click)="onSubmit()">
+        {{'DIALOGS.REMOVE_CATEGORY.DELETE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/publications/src/app/dialogs/remove-publication-dialog/remove-publication-dialog.component.html
+++ b/apps/publications/src/app/dialogs/remove-publication-dialog/remove-publication-dialog.component.html
@@ -1,20 +1,24 @@
-<div class="user-theme">
-  <h1 mat-dialog-title>{{"DIALOGS.REMOVE_PUBLICATION.TITLE" | translate}}</h1>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <div mat-dialog-content class="dialog-container" *ngIf="!loading">
-    {{'DIALOGS.REMOVE_PUBLICATION.WARNING' | translate}}
-    <perun-web-apps-publications-list
-      [publications]="publications"
-      [routerPath]="null"
-      [displayedColumns]="['id', 'title', 'year']">
-    </perun-web-apps-publications-list>
-  </div>
-  <div mat-dialog-actions>
-    <button mat-flat-button class="ml-auto" (click)="cancel()">
-      {{'DIALOGS.REMOVE_PUBLICATION.CANCEL' | translate}}
-    </button>
-    <button mat-flat-button color="warn" class="ml-2" [disabled]="loading" (click)="remove()">
-      {{'DIALOGS.REMOVE_PUBLICATION.REMOVE' | translate}}
-    </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{"DIALOGS.REMOVE_PUBLICATION.TITLE" | translate}}</h1>
+    <div mat-dialog-content class="dialog-container">
+      {{'DIALOGS.REMOVE_PUBLICATION.WARNING' | translate}}
+      <perun-web-apps-publications-list
+        [publications]="publications"
+        [routerPath]="null"
+        [displayedColumns]="['id', 'title', 'year']">
+      </perun-web-apps-publications-list>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-flat-button class="ml-auto" (click)="cancel()">
+        {{'DIALOGS.REMOVE_PUBLICATION.CANCEL' | translate}}
+      </button>
+      <button mat-flat-button color="warn" class="ml-2" [disabled]="loading" (click)="remove()">
+        {{'DIALOGS.REMOVE_PUBLICATION.REMOVE' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/publications/src/app/dialogs/update-rank-dialog/update-rank-dialog.component.html
+++ b/apps/publications/src/app/dialogs/update-rank-dialog/update-rank-dialog.component.html
@@ -1,7 +1,9 @@
-<div class="user-theme">
-  <h1 mat-dialog-title>{{"DIALOGS.UPDATE_RANK.TITLE" | translate}}{{categoryName}}</h1>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{"DIALOGS.UPDATE_RANK.TITLE" | translate}}{{categoryName}}</h1>
     <div mat-dialog-content class="dialog-container">
       <mat-form-field>
         <input
@@ -27,7 +29,7 @@
           mat-flat-button
           class="ml-2"
           color="accent"
-          [disabled]="rankCtrl.invalid"
+          [disabled]="rankCtrl.invalid || loading"
           (click)="onSubmit()">
           {{'DIALOGS.UPDATE_RANK.UPDATE' | translate}}
         </button>

--- a/apps/publications/src/app/pages/all-publications-page/all-publications-page.component.html
+++ b/apps/publications/src/app/pages/all-publications-page/all-publications-page.component.html
@@ -17,12 +17,16 @@
       (filteredPublication)="filterPublication($event)"></perun-web-apps-publication-filter>
   </div>
 
-  <perun-web-apps-publications-list
-    *ngIf="!loading"
-    [publications]="publications"
-    [selection]="selected"
-    [routerPath]="'/all-publications'"
-    [tableId]="tableId">
-  </perun-web-apps-publications-list>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-publications-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [publications]="publications"
+      [selection]="selected"
+      [routerPath]="'/all-publications'"
+      [tableId]="tableId">
+    </perun-web-apps-publications-list>
+  </div>
 </div>

--- a/apps/publications/src/app/pages/all-publications-page/all-publications-page.component.ts
+++ b/apps/publications/src/app/pages/all-publications-page/all-publications-page.component.ts
@@ -18,7 +18,7 @@ import { Filter } from '../Filter';
 })
 export class AllPublicationsPageComponent implements OnInit {
   loading: boolean;
-  publications: PublicationForGUI[];
+  publications: PublicationForGUI[] = [];
   selected = new SelectionModel<PublicationForGUI>(true, []);
   tableId = TABLE_PUBLICATION_AUTHOR_DETAIL_PUBLICATIONS;
   filter: Filter = {

--- a/apps/publications/src/app/pages/author-detail/author-detail.component.html
+++ b/apps/publications/src/app/pages/author-detail/author-detail.component.html
@@ -19,12 +19,17 @@
         (filteredPublication)="filterPublication($event)"></perun-web-apps-publication-filter>
     </div>
 
-    <perun-web-apps-publications-list
-      *ngIf="!loading"
-      [publications]="publications"
-      [selection]="selected"
-      [tableId]="tableId"
-      [routerPath]="'/authors/'+author.id+'/publication'"></perun-web-apps-publications-list>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
+    <div class="position-relative">
+      <perun-web-apps-publications-list
+        *perunWebAppsLoader="loading; indicator: spinner"
+        [publications]="publications"
+        [selection]="selected"
+        [tableId]="tableId"
+        [routerPath]="'/authors/'+author.id+'/publication'"></perun-web-apps-publications-list>
+    </div>
   </div>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading || initLoading"></mat-spinner>
+  <mat-spinner class="ml-auto mr-auto" *ngIf="initLoading"></mat-spinner>
 </div>

--- a/apps/publications/src/app/pages/author-detail/author-detail.component.ts
+++ b/apps/publications/src/app/pages/author-detail/author-detail.component.ts
@@ -21,7 +21,7 @@ import { FilterPublication } from '../../components/publication-filter/publicati
 export class AuthorDetailComponent implements OnInit {
   loading: boolean;
   initLoading: boolean;
-  publications: PublicationForGUI[];
+  publications: PublicationForGUI[] = [];
   selected = new SelectionModel<PublicationForGUI>(true, []);
   tableId = TABLE_PUBLICATION_AUTHOR_DETAIL_PUBLICATIONS;
   author: User;

--- a/apps/publications/src/app/pages/authors-page/authors-page.component.html
+++ b/apps/publications/src/app/pages/authors-page/authors-page.component.html
@@ -7,12 +7,16 @@
   <perun-web-apps-debounce-filter
     (filter)="applyFilter($event)"
     [placeholder]="'AUTHORS_PAGE.FILTER'"></perun-web-apps-debounce-filter>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <perun-web-apps-authors-list
-    *ngIf="!loading"
-    [authors]="authors"
-    [displayedColumns]="['id', 'name', 'organization', 'email', 'numberOfPublications']"
-    [filterValue]="filterValue"
-    [tableId]="tableId">
-  </perun-web-apps-authors-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-authors-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [authors]="authors"
+      [displayedColumns]="['id', 'name', 'organization', 'email', 'numberOfPublications']"
+      [filterValue]="filterValue"
+      [tableId]="tableId">
+    </perun-web-apps-authors-list>
+  </div>
 </div>

--- a/apps/publications/src/app/pages/authors-page/authors-page.component.ts
+++ b/apps/publications/src/app/pages/authors-page/authors-page.component.ts
@@ -10,7 +10,7 @@ import { TABLE_PUBLICATION_AUTHORS } from '@perun-web-apps/config/table-config';
 export class AuthorsPageComponent implements OnInit {
   filterValue = '';
   loading: boolean;
-  authors: Author[];
+  authors: Author[] = [];
   tableId = TABLE_PUBLICATION_AUTHORS;
 
   constructor(private cabinetService: CabinetManagerService) {}

--- a/apps/publications/src/app/pages/categories-page/categories-page.component.html
+++ b/apps/publications/src/app/pages/categories-page/categories-page.component.html
@@ -23,13 +23,17 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'CATEGORIES_PAGE.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <perun-web-apps-categories-list
-    *ngIf="categories && !loading"
-    [categories]="categories"
-    [filterValue]="filterValue"
-    (refreshTable)="refreshTable()"
-    [displayedColumns]="removeAuth ? ['select', 'id', 'name', 'rank'] : ['name', 'rank']"
-    [tableId]="tableId"
-    [selection]="selected"></perun-web-apps-categories-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-categories-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [categories]="categories"
+      [filterValue]="filterValue"
+      (refreshTable)="refreshTable()"
+      [displayedColumns]="removeAuth ? ['select', 'id', 'name', 'rank'] : ['name', 'rank']"
+      [tableId]="tableId"
+      [selection]="selected"></perun-web-apps-categories-list>
+  </div>
 </div>

--- a/apps/publications/src/app/pages/my-publications-page/my-publications-page.component.html
+++ b/apps/publications/src/app/pages/my-publications-page/my-publications-page.component.html
@@ -3,28 +3,30 @@
     <mat-icon class="title-icon">local_library</mat-icon>
     <span class="ml-3 mt-1">{{'MY_PUBLICATIONS.TITLE' | translate}}</span>
   </h1>
-  <div *ngIf="!initLoading">
-    <div class="mt-4">
-      <perun-web-apps-refresh-button (refresh)="refreshTable()"></perun-web-apps-refresh-button>
-      <button
-        mat-flat-button
-        color="warn"
-        class="mr-2"
-        [disabled]="selected.selected.length === 0"
-        (click)="removePublication()">
-        {{'MY_PUBLICATIONS.REMOVE' | translate}}
-      </button>
-      <perun-web-apps-publication-filter
-        (filteredPublication)="filterPublication($event)"></perun-web-apps-publication-filter>
-    </div>
+  <div class="mt-4">
+    <perun-web-apps-refresh-button (refresh)="refreshTable()"></perun-web-apps-refresh-button>
+    <button
+      mat-flat-button
+      color="warn"
+      class="mr-2"
+      [disabled]="selected.selected.length === 0"
+      (click)="removePublication()">
+      {{'MY_PUBLICATIONS.REMOVE' | translate}}
+    </button>
+    <perun-web-apps-publication-filter
+      (filteredPublication)="filterPublication($event)"></perun-web-apps-publication-filter>
+  </div>
 
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
     <perun-web-apps-publications-list
-      *ngIf="!loading"
+      *perunWebAppsLoader="loading; indicator: spinner"
       [publications]="publications"
       [selection]="selected"
       [tableId]="tableId"
       [routerPath]="'/my-publications'">
     </perun-web-apps-publications-list>
   </div>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading || initLoading"></mat-spinner>
 </div>

--- a/apps/publications/src/app/pages/my-publications-page/my-publications-page.component.ts
+++ b/apps/publications/src/app/pages/my-publications-page/my-publications-page.component.ts
@@ -20,8 +20,7 @@ import { Filter } from '../Filter';
 })
 export class MyPublicationsPageComponent implements OnInit {
   loading: boolean;
-  initLoading: boolean;
-  publications: PublicationForGUI[];
+  publications: PublicationForGUI[] = [];
   selected = new SelectionModel<PublicationForGUI>(true, []);
   tableId = TABLE_PUBLICATION_AUTHOR_DETAIL_PUBLICATIONS;
   authorId: number;
@@ -42,11 +41,10 @@ export class MyPublicationsPageComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.initLoading = true;
+    this.loading = true;
 
     this.authResolver.getPerunPrincipal().subscribe((perunPrincipal) => {
       this.authorId = perunPrincipal.userId;
-      this.initLoading = false;
       this.refreshTable();
     });
   }

--- a/apps/publications/src/app/pages/publication-systems-page/publication-systems-page.component.html
+++ b/apps/publications/src/app/pages/publication-systems-page/publication-systems-page.component.html
@@ -5,10 +5,14 @@
   <perun-web-apps-immediate-filter
     (filter)="applyFilter($event)"
     [placeholder]="'PUBLICATION_SYSTEMS_PAGE.FILTER'"></perun-web-apps-immediate-filter>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <perun-web-apps-publication-systems-list
-    *ngIf="publicationSystems && !loading"
-    [publicationSystems]="publicationSystems"
-    [filterValue]="filterValue"
-    [tableId]="tableId"></perun-web-apps-publication-systems-list>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-publication-systems-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [publicationSystems]="publicationSystems"
+      [filterValue]="filterValue"
+      [tableId]="tableId"></perun-web-apps-publication-systems-list>
+  </div>
 </div>

--- a/apps/publications/src/styles.scss
+++ b/apps/publications/src/styles.scss
@@ -342,3 +342,32 @@ mat-icon {
   font-size: 14px !important;
   word-wrap: break-word !important;
 }
+
+.spinner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// TODO: check this style after the migration to Angular 15
+// make the whole dialog grey (including padding space) while the spinner is active
+mat-dialog-container:has(#loading-dialog-spinner) {
+  box-shadow: 0 0 0 24px rgba(0, 0, 0, 0.15) inset;
+  padding-bottom: 0;
+  .position-relative {
+    padding-bottom: 24px;
+  }
+  .spinner-container {
+    margin-bottom: 24px;
+  }
+  .mat-dialog-actions {
+    padding-bottom: 16px;
+  }
+}

--- a/apps/user-profile/src/app/app.module.ts
+++ b/apps/user-profile/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { PrivacyPageComponent } from './pages/privacy-page/privacy-page.componen
 import { HomePageComponent } from './components/home-page/home-page.component';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { AddUnixGroupDialogComponent } from './components/dialogs/add-unix-group-dialog/add-unix-group-dialog.component';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -158,6 +159,7 @@ const loadConfigs: (appConfig: UserProfileConfigService) => () => Promise<void> 
     MatToolbarModule,
     PerunSharedComponentsModule,
     UiAlertsModule,
+    UiLoadersModule,
     MatExpansionModule,
     MatFormFieldModule,
     MatSelectModule,

--- a/apps/user-profile/src/app/components/dialogs/activate-local-account-dialog/activate-local-account-dialog.component.html
+++ b/apps/user-profile/src/app/components/dialogs/activate-local-account-dialog/activate-local-account-dialog.component.html
@@ -1,21 +1,27 @@
-<h1 mat-dialog-title>{{'DIALOGS.ACTIVATE_LOCAL_ACCOUNT.TITLE'|customTranslate | translate}}</h1>
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<div *ngIf="!loading" mat-dialog-content class="dialog-container user-theme">
-  <perun-web-apps-password-form
-    [formGroup]="pwdForm"
-    [namespace]="data.namespace"
-    [language]="lang">
-  </perun-web-apps-password-form>
-</div>
-<div mat-dialog-actions>
-  <button mat-flat-button class="ml-auto mr-2" (click)="cancel()">
-    {{'DIALOGS.ACTIVATE_LOCAL_ACCOUNT.CANCEL'|customTranslate | translate}}
-  </button>
-  <button
-    mat-flat-button
-    color="accent"
-    [disabled]="loading || pwdForm.invalid"
-    (click)="activate()">
-    {{'DIALOGS.ACTIVATE_LOCAL_ACCOUNT.ACTIVATE' | customTranslate | translate}}
-  </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ACTIVATE_LOCAL_ACCOUNT.TITLE'|customTranslate | translate}}</h1>
+    <div mat-dialog-content class="dialog-container">
+      <perun-web-apps-password-form
+        [formGroup]="pwdForm"
+        [namespace]="data.namespace"
+        [language]="lang">
+      </perun-web-apps-password-form>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-flat-button class="ml-auto mr-2" (click)="cancel()">
+        {{'DIALOGS.ACTIVATE_LOCAL_ACCOUNT.CANCEL'|customTranslate | translate}}
+      </button>
+      <button
+        mat-flat-button
+        color="accent"
+        [disabled]="loading || pwdForm.invalid"
+        (click)="activate()">
+        {{'DIALOGS.ACTIVATE_LOCAL_ACCOUNT.ACTIVATE' | customTranslate | translate}}
+      </button>
+    </div>
+  </div>
 </div>

--- a/apps/user-profile/src/app/components/dialogs/add-unix-group-dialog/add-unix-group-dialog.component.html
+++ b/apps/user-profile/src/app/components/dialogs/add-unix-group-dialog/add-unix-group-dialog.component.html
@@ -1,7 +1,9 @@
-<h1 mat-dialog-title>{{'DIALOGS.ADD_UNIX_GROUP.TITLE'|customTranslate | translate}}</h1>
-<div class="user-theme">
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.ADD_UNIX_GROUP.TITLE'|customTranslate | translate}}</h1>
     <div mat-dialog-content class="dialog-container">
       <mat-form-field class="w-100">
         <label class="w-100">

--- a/apps/user-profile/src/app/components/dialogs/remove-alt-password-dialog/remove-alt-password-dialog.component.html
+++ b/apps/user-profile/src/app/components/dialogs/remove-alt-password-dialog/remove-alt-password-dialog.component.html
@@ -1,30 +1,34 @@
-<h1 mat-dialog-title>{{'DIALOGS.REMOVE_ALT_PASSWORD.TITLE' | customTranslate | translate}}</h1>
-<div class="user-theme">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-</div>
-<div mat-dialog-content *ngIf="!loading" class="user-theme">
-  <p>
-    {{'DIALOGS.REMOVE_ALT_PASSWORD.DESCRIPTION' | customTranslate | translate}}
-  </p>
-  <div class="font-weight-bold">
-    {{'DIALOGS.REMOVE_ALT_PASSWORD.ASK' | customTranslate | translate}}
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.REMOVE_ALT_PASSWORD.TITLE' | customTranslate | translate}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{'DIALOGS.REMOVE_ALT_PASSWORD.DESCRIPTION' | customTranslate | translate}}
+      </p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_ALT_PASSWORD.ASK' | customTranslate | translate}}
+      </div>
+      <table mat-table [dataSource]="dataSource" class="w-100">
+        <ng-container matColumnDef="description">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let value">{{value}}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns" class="font-weight-bolder"></tr>
+        <tr mat-row *matRowDef="let value; columns: displayedColumns;"></tr>
+      </table>
+    </div>
+
+    <div mat-dialog-actions>
+      <button mat-flat-button class="ml-auto" (click)="onCancel()">
+        {{'DIALOGS.REMOVE_ALT_PASSWORD.CANCEL' | customTranslate | translate}}
+      </button>
+      <button mat-flat-button class="ml-2" color="warn" (click)="onSubmit()">
+        {{'DIALOGS.REMOVE_ALT_PASSWORD.REMOVE' | customTranslate | translate}}
+      </button>
+    </div>
   </div>
-  <table mat-table [dataSource]="dataSource" class="w-100">
-    <ng-container matColumnDef="description">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let value">{{value}}</td>
-    </ng-container>
-
-    <tr mat-header-row *matHeaderRowDef="displayedColumns" class="font-weight-bolder"></tr>
-    <tr mat-row *matRowDef="let value; columns: displayedColumns;"></tr>
-  </table>
-</div>
-
-<div mat-dialog-actions>
-  <button mat-flat-button class="ml-auto" (click)="onCancel()">
-    {{'DIALOGS.REMOVE_ALT_PASSWORD.CANCEL' | customTranslate | translate}}
-  </button>
-  <button mat-flat-button class="ml-2" color="warn" (click)="onSubmit()">
-    {{'DIALOGS.REMOVE_ALT_PASSWORD.REMOVE' | customTranslate | translate}}
-  </button>
 </div>

--- a/apps/user-profile/src/app/pages/groups-page/groups-page.component.html
+++ b/apps/user-profile/src/app/pages/groups-page/groups-page.component.html
@@ -1,6 +1,6 @@
 <h1 class="page-title pt-2">{{'GROUPS.TITLE' | customTranslate | translate}}</h1>
 <div class="user-theme">
-  <mat-form-field class="mr-2 w-75" *ngIf="!loading">
+  <mat-form-field class="mr-2 w-75" *ngIf="!initialLoading">
     <mat-label>{{'GROUPS.SELECT_VO' | translate}}</mat-label>
     <input
       type="text"
@@ -20,7 +20,7 @@
     </mat-autocomplete>
   </mat-form-field>
 
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
+  <mat-spinner *ngIf="initialLoading" class="mr-auto ml-auto"></mat-spinner>
 
   <perun-web-apps-alert
     alert_type="warn"
@@ -28,19 +28,25 @@
     >{{'GROUPS.NO_GROUPS'| customTranslate | translate}}</perun-web-apps-alert
   >
 
-  <div *ngIf="!loading && userMemberships.length !== 0">
-    <h4 class="page-subtitle">{{'GROUPS.MEMBER_GROUPS' | customTranslate | translate}}</h4>
+  <h4 class="page-subtitle">{{'GROUPS.MEMBER_GROUPS' | customTranslate | translate}}</h4>
+  <div class="position-relative">
     <perun-web-apps-membership-list
+      *perunWebAppsLoader="loading; indicator: spinner"
       [members]="userMemberships"
       [selection]="selection"
       [displayedColumns]="['name', 'description', 'expirationAttribute', 'extend']"
       (extendMembership)="extendMembership($event)"></perun-web-apps-membership-list>
   </div>
 
-  <div *ngIf="!loading && adminMemberships.length !== 0" class="mt-5">
-    <h4 class="page-subtitle">{{'GROUPS.ADMINS_GROUPS' | customTranslate | translate}}</h4>
+  <h4 class="page-subtitle mt-5">{{'GROUPS.ADMINS_GROUPS' | customTranslate | translate}}</h4>
+  <div class="position-relative">
     <perun-web-apps-membership-list
+      *perunWebAppsLoader="loading; indicator: spinner"
       [members]="adminMemberships"
       [displayedColumns]="['name', 'description']"></perun-web-apps-membership-list>
   </div>
+
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
 </div>

--- a/apps/user-profile/src/app/pages/identities-page/identities-page.component.html
+++ b/apps/user-profile/src/app/pages/identities-page/identities-page.component.html
@@ -1,39 +1,42 @@
 <div class="user-theme">
   <h1 class="page-title">{{'IDENTITIES.IDP' | customTranslate | translate}}</h1>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <div *ngIf="!loading">
-    <button mat-flat-button color="accent" (click)="addIdentity()">
-      {{'IDENTITIES.ADD' | customTranslate | translate}}
-    </button>
-    <button
-      (click)="removeIdentity(idpSelection)"
-      [disabled]="idpSelection.selected.length === 0"
-      class="ml-2"
-      color="warn"
-      mat-flat-button>
-      {{'IDENTITIES.REMOVE' | customTranslate | translate}}
-    </button>
+  <button mat-flat-button color="accent" (click)="addIdentity()" [disabled]="loading">
+    {{'IDENTITIES.ADD' | customTranslate | translate}}
+  </button>
+  <button
+    (click)="removeIdentity(idpSelection)"
+    [disabled]="idpSelection.selected.length === 0 || loading"
+    class="ml-2"
+    color="warn"
+    mat-flat-button>
+    {{'IDENTITIES.REMOVE' | customTranslate | translate}}
+  </button>
+  <div class="position-relative">
     <perun-web-apps-user-ext-sources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
       [userExtSources]="idpExtSources"
       [selection]="idpSelection"
       [displayedColumns]="displayedColumnsIdp"
       [loginHeader]="loginIdp"
       [disableRouting]="true"></perun-web-apps-user-ext-sources-list>
+  </div>
 
-    <div *ngIf="displayCertificates">
-      <h1 class="page-title mt-5">{{'IDENTITIES.CERT' | customTranslate | translate}}</h1>
-      <button mat-flat-button color="accent" (click)="addIdentity()">
-        {{'IDENTITIES.ADD' | customTranslate | translate}}
-      </button>
-      <button
-        (click)="removeIdentity(certSelection)"
-        [disabled]="certSelection.selected.length === 0"
-        class="ml-2"
-        color="warn"
-        mat-flat-button>
-        {{'IDENTITIES.REMOVE' | customTranslate | translate}}
-      </button>
+  <div *ngIf="displayCertificates">
+    <h1 class="page-title mt-5">{{'IDENTITIES.CERT' | customTranslate | translate}}</h1>
+    <button mat-flat-button color="accent" (click)="addIdentity()" [disabled]="loading">
+      {{'IDENTITIES.ADD' | customTranslate | translate}}
+    </button>
+    <button
+      (click)="removeIdentity(certSelection)"
+      [disabled]="certSelection.selected.length === 0 || loading"
+      class="ml-2"
+      color="warn"
+      mat-flat-button>
+      {{'IDENTITIES.REMOVE' | customTranslate | translate}}
+    </button>
+    <div class="position-relative">
       <perun-web-apps-user-ext-sources-list
+        *perunWebAppsLoader="loading; indicator: spinner"
         [userExtSources]="certExtSources"
         [selection]="certSelection"
         [extSourceNameHeader]="extSourceNameCert"
@@ -41,21 +44,27 @@
         [displayedColumns]="displayedColumnsCert"
         [disableRouting]="true"></perun-web-apps-user-ext-sources-list>
     </div>
+  </div>
 
-    <h1 class="page-title mt-5">
-      {{'IDENTITIES.OTHER' | customTranslate | translate}}
-      <mat-icon
-        [matTooltip]="'IDENTITIES.OTHER_TOOLTIP' | customTranslate | translate"
-        class="center-icon"
-        matTooltipPosition="above">
-        info_outline
-      </mat-icon>
-    </h1>
+  <h1 class="page-title mt-5">
+    {{'IDENTITIES.OTHER' | customTranslate | translate}}
+    <mat-icon
+      [matTooltip]="'IDENTITIES.OTHER_TOOLTIP' | customTranslate | translate"
+      class="center-icon"
+      matTooltipPosition="above">
+      info_outline
+    </mat-icon>
+  </h1>
+  <div class="position-relative">
     <perun-web-apps-user-ext-sources-list
+      *perunWebAppsLoader="loading; indicator: spinner"
       [userExtSources]="otherExtSources"
       [selection]="otherSelection"
       [extSourceNameHeader]="extSourceNameOther"
       [displayedColumns]="displayedColumnsOther"
       [disableRouting]="true"></perun-web-apps-user-ext-sources-list>
   </div>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
 </div>

--- a/apps/user-profile/src/app/pages/identities-page/identities-page.component.ts
+++ b/apps/user-profile/src/app/pages/identities-page/identities-page.component.ts
@@ -24,6 +24,9 @@ export class IdentitiesPageComponent implements OnInit {
   idpExtSources: RichUserExtSource[] = [];
   certExtSources: RichUserExtSource[] = [];
   otherExtSources: RichUserExtSource[] = [];
+  idpExtSourcesTemp: RichUserExtSource[] = [];
+  certExtSourcesTemp: RichUserExtSource[] = [];
+  otherExtSourcesTemp: RichUserExtSource[] = [];
   idpSelection: SelectionModel<UserExtSource> = new SelectionModel<UserExtSource>(true, []);
   certSelection: SelectionModel<UserExtSource> = new SelectionModel<UserExtSource>(true, []);
   otherSelection: SelectionModel<UserExtSource> = new SelectionModel<UserExtSource>(true, []);
@@ -60,9 +63,9 @@ export class IdentitiesPageComponent implements OnInit {
 
   refreshTables(): void {
     this.loading = true;
-    this.idpExtSources = [];
-    this.certExtSources = [];
-    this.otherExtSources = [];
+    this.idpExtSourcesTemp = [];
+    this.certExtSourcesTemp = [];
+    this.otherExtSourcesTemp = [];
     this.usersManagerService.getRichUserExtSources(this.userId).subscribe((userExtSources) => {
       let count = userExtSources.length;
       userExtSources.forEach((ues) => {
@@ -151,11 +154,16 @@ export class IdentitiesPageComponent implements OnInit {
 
   private addToList(ues: RichUserExtSource): void {
     if (ues.userExtSource.extSource.type.endsWith('Idp')) {
-      this.idpExtSources.push(ues);
+      this.idpExtSourcesTemp.push(ues);
     } else if (ues.userExtSource.extSource.type.endsWith('X509')) {
-      this.certExtSources.push(ues);
+      this.certExtSourcesTemp.push(ues);
     } else {
-      this.otherExtSources.push(ues);
+      this.otherExtSourcesTemp.push(ues);
+    }
+    if (!this.loading) {
+      this.idpExtSources = this.idpExtSourcesTemp;
+      this.certExtSources = this.certExtSourcesTemp;
+      this.otherExtSources = this.otherExtSourcesTemp;
     }
   }
 }

--- a/apps/user-profile/src/app/pages/privacy-page/privacy-page.component.html
+++ b/apps/user-profile/src/app/pages/privacy-page/privacy-page.component.html
@@ -12,12 +12,13 @@
         </mat-panel-title>
       </mat-expansion-panel-header>
       <ng-template matExpansionPanelContent>
-        <mat-spinner class="ml-auto mr-auto" *ngIf="innerLoading"></mat-spinner>
-        <perun-web-apps-attributes-list
-          *ngIf="!innerLoading"
-          [attributes]="attributes"
-          [readonly]="true"
-          [hiddenColumns]="hiddenColumns"></perun-web-apps-attributes-list>
+        <div class="position-relative">
+          <perun-web-apps-attributes-list
+            *perunWebAppsLoader="innerLoading; indicator: spinner"
+            [attributes]="attributes"
+            [readonly]="true"
+            [hiddenColumns]="hiddenColumns"></perun-web-apps-attributes-list>
+        </div>
       </ng-template>
     </mat-expansion-panel>
 
@@ -28,13 +29,17 @@
         </mat-panel-title>
       </mat-expansion-panel-header>
       <ng-template matExpansionPanelContent>
-        <mat-spinner class="ml-auto mr-auto" *ngIf="innerLoading"></mat-spinner>
-        <perun-web-apps-attributes-list
-          *ngIf="!innerLoading"
-          [attributes]="attributes"
-          [readonly]="true"
-          [hiddenColumns]="hiddenColumns"></perun-web-apps-attributes-list>
+        <div class="position-relative">
+          <perun-web-apps-attributes-list
+            *perunWebAppsLoader="innerLoading; indicator: spinner"
+            [attributes]="attributes"
+            [readonly]="true"
+            [hiddenColumns]="hiddenColumns"></perun-web-apps-attributes-list>
+        </div>
       </ng-template>
     </mat-expansion-panel>
+    <ng-template #spinner>
+      <perun-web-apps-loading-table></perun-web-apps-loading-table>
+    </ng-template>
   </mat-accordion>
 </div>

--- a/apps/user-profile/src/app/pages/services-page/services-page.component.html
+++ b/apps/user-profile/src/app/pages/services-page/services-page.component.html
@@ -12,12 +12,16 @@
         </mat-panel-title>
       </mat-expansion-panel-header>
       <ng-template matExpansionPanelContent>
-        <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-        <perun-web-apps-resources-list
-          *ngIf="!loading"
-          [resources]="resources"
-          [displayedColumns]="['name', 'description']"
-          [disableRouting]="true"></perun-web-apps-resources-list>
+        <ng-template #spinner>
+          <perun-web-apps-loading-table></perun-web-apps-loading-table>
+        </ng-template>
+        <div class="position-relative">
+          <perun-web-apps-resources-list
+            *perunWebAppsLoader="loading; indicator: spinner"
+            [resources]="resources"
+            [displayedColumns]="['name', 'description']"
+            [disableRouting]="true"></perun-web-apps-resources-list>
+        </div>
       </ng-template>
     </mat-expansion-panel>
   </mat-accordion>

--- a/apps/user-profile/src/app/pages/services-page/services-page.component.ts
+++ b/apps/user-profile/src/app/pages/services-page/services-page.component.ts
@@ -36,7 +36,11 @@ export class ServicesPageComponent implements OnInit {
   }
 
   getMemberData(vo: Vo): void {
+    if (this.resources.length && this.resources[0].voId === vo.id) {
+      return;
+    }
     this.loading = true;
+    this.resources = [];
     this.membersManagerService.getMemberByUser(vo.id, this.userId).subscribe((member) => {
       this.resourcesManagerService
         .getAssignedRichResourcesWithMember(member.id)

--- a/apps/user-profile/src/app/pages/settings-page/settings-alternative-passwords/settings-alternative-passwords.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-alternative-passwords/settings-alternative-passwords.component.html
@@ -31,13 +31,16 @@
     (click)="removeAltPasswords()">
     {{'ALT_PASSWORDS.REMOVE'|customTranslate | translate}}
   </button>
-  <perun-web-apps-string-list
-    *ngIf="!loading"
-    [values]="displayedValues"
-    [selection]="selection"
-    [alertText]="alertText"
-    [headerColumnText]="headerColumnText
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
+  <div class="position-relative">
+    <perun-web-apps-string-list
+      *perunWebAppsLoader="loading; indicator: spinner"
+      [values]="displayedValues"
+      [selection]="selection"
+      [alertText]="alertText"
+      [headerColumnText]="headerColumnText
 "></perun-web-apps-string-list>
-
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
+  </div>
 </div>

--- a/apps/user-profile/src/app/pages/vos-page/vos-page.component.html
+++ b/apps/user-profile/src/app/pages/vos-page/vos-page.component.html
@@ -2,16 +2,14 @@
 <div class="user-theme">
   <perun-web-apps-immediate-filter
     [placeholder]="'ORGANIZATIONS.FILTER'"
-    (filter)="applyFilter($event)"
-    *ngIf="!loading"></perun-web-apps-immediate-filter>
-  <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
+    (filter)="applyFilter($event)"></perun-web-apps-immediate-filter>
 
-  <div *ngIf="!loading" class="mt-5">
+  <div class="mt-5">
     <h1 class="page-subtitle">{{'ORGANIZATIONS.IS_MEMBER' | customTranslate | translate}}</h1>
-    <div *ngIf="userMemberships.length !== 0">
+    <div class="position-relative" *ngIf="userMemberships.length || loading">
       <perun-web-apps-membership-list
+        *perunWebAppsLoader="loading; indicator: spinner"
         [members]="userMemberships"
-        [selection]="selection"
         [filterValue]="filterValue"
         [displayedColumns]="['name', 'expirationAttribute', 'extend']"
         (extendMembership)="extendMembership($event)">
@@ -19,23 +17,28 @@
     </div>
     <perun-web-apps-alert
       alert_type="warn"
-      *ngIf="userMemberships.length === 0"
+      *ngIf="userMemberships.length === 0  && !loading"
       >{{'ORGANIZATIONS.NO_VOS_ALERT' | customTranslate | translate}}</perun-web-apps-alert
     >
   </div>
 
-  <div *ngIf="!loading" class="mt-5">
+  <div class="mt-5">
     <h1 class="page-subtitle">{{'ORGANIZATIONS.IS_ADMIN' | customTranslate | translate}}</h1>
     <perun-web-apps-alert
-      *ngIf="!adminMemberships.length"
+      *ngIf="!adminMemberships.length && !loading"
       alert_type="warn"
       >{{'ORGANIZATIONS.NO_VOS_ALERT' | customTranslate | translate}}</perun-web-apps-alert
     >
-    <perun-web-apps-membership-list
-      [members]="adminMemberships"
-      *ngIf="adminMemberships.length"
-      [filterValue]="filterValue"
-      [displayedColumns]="['name']">
-    </perun-web-apps-membership-list>
+    <div class="position-relative" *ngIf="adminMemberships.length || loading">
+      <perun-web-apps-membership-list
+        *perunWebAppsLoader="loading; indicator: spinner"
+        [members]="adminMemberships"
+        [filterValue]="filterValue"
+        [displayedColumns]="['name']">
+      </perun-web-apps-membership-list>
+    </div>
   </div>
+  <ng-template #spinner>
+    <perun-web-apps-loading-table></perun-web-apps-loading-table>
+  </ng-template>
 </div>

--- a/apps/user-profile/src/app/pages/vos-page/vos-page.component.ts
+++ b/apps/user-profile/src/app/pages/vos-page/vos-page.component.ts
@@ -6,7 +6,6 @@ import {
   Vo,
 } from '@perun-web-apps/perun/openapi';
 import { StoreService } from '@perun-web-apps/perun/services';
-import { SelectionModel } from '@angular/cdk/collections';
 import { Membership } from '../../components/membership-list/membership-list.component';
 
 @Component({
@@ -19,10 +18,11 @@ export class VosPageComponent implements OnInit {
   loading: boolean;
   userId: number;
   filterValue = '';
-  selection = new SelectionModel<Membership>(false, []);
 
   userMemberships: Membership[] = [];
   adminMemberships: Membership[] = [];
+  userMembershipsTemp: Membership[] = [];
+  adminMembershipsTemp: Membership[] = [];
 
   vosCount = 0;
 
@@ -44,8 +44,8 @@ export class VosPageComponent implements OnInit {
     this.usersService.getVosWhereUserIsMember(this.userId).subscribe((vosMember) => {
       this.usersService.getVosWhereUserIsAdmin(this.userId).subscribe((vosAdmin) => {
         this.vosCount = vosMember.length + vosAdmin.length;
-        this.fillMemberships(vosMember, this.userMemberships);
-        this.fillMemberships(vosAdmin, this.adminMemberships);
+        this.fillMemberships(vosMember, this.userMembershipsTemp);
+        this.fillMemberships(vosAdmin, this.adminMembershipsTemp);
       });
     });
   }
@@ -57,6 +57,10 @@ export class VosPageComponent implements OnInit {
   isEverythingLoaded(): void {
     this.vosCount--;
     this.loading = this.vosCount !== 0;
+    if (!this.loading) {
+      this.userMemberships = this.userMembershipsTemp;
+      this.adminMemberships = this.adminMembershipsTemp;
+    }
   }
 
   extendMembership(membership: Membership): void {

--- a/apps/user-profile/src/styles.scss
+++ b/apps/user-profile/src/styles.scss
@@ -133,6 +133,35 @@ td.mat-cell {
   word-wrap: break-word !important;
 }
 
+.spinner-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// TODO: check this style after the migration to Angular 15
+// make the whole dialog grey (including padding space) while the spinner is active
+mat-dialog-container:has(#loading-dialog-spinner) {
+  box-shadow: 0 0 0 24px rgba(0, 0, 0, 0.15) inset;
+  padding-bottom: 0;
+  .position-relative {
+    padding-bottom: 24px;
+  }
+  .spinner-container {
+    margin-bottom: 24px;
+  }
+  .mat-dialog-actions {
+    padding-bottom: 16px;
+  }
+}
+
 #preloader {
   position: fixed;
   top: 0;

--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.html
@@ -1,15 +1,10 @@
-<div
-  [hidden]="this.dataSource.allObjectCount === 0 && (dataSource.loading$ | async) === false"
-  class="card mt-2">
+<div [hidden]="this.dataSource.allObjectCount === 0" class="card mt-2">
   <perun-web-apps-table-wrapper
     (exportDisplayedData)="exportDisplayedData($event)"
     (exportAllData)="exportAllData($event)"
     [tableId]="tableId"
     [dataLength]="dataSource.allObjectCount"
     [pageSizeOptions]="pageSizeOptions">
-    <div class="spinner-container" *ngIf="dataSource.loading$ | async">
-      <mat-spinner class="ml-auto mr-auto"></mat-spinner>
-    </div>
     <table
       [dataSource]="dataSource"
       class="w-100"
@@ -136,8 +131,6 @@
   </perun-web-apps-table-wrapper>
 </div>
 
-<perun-web-apps-alert
-  *ngIf="this.dataSource.allObjectCount === 0 && (dataSource.loading$ | async) === false"
-  alert_type="warn">
+<perun-web-apps-alert *ngIf="this.dataSource.allObjectCount === 0" alert_type="warn">
   {{'SHARED_LIB.UI.ALERTS.NO_MEMBERS' | translate}}
 </perun-web-apps-alert>

--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.ts
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.ts
@@ -1,9 +1,11 @@
 import {
   AfterViewInit,
   Component,
+  EventEmitter,
   Input,
   OnChanges,
   OnInit,
+  Output,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -42,7 +44,7 @@ import { MatSort } from '@angular/material/sort';
 import { SelectionModel } from '@angular/cdk/collections';
 import { TableConfigService } from '@perun-web-apps/config/table-config';
 import { TableWrapperComponent } from '@perun-web-apps/perun/utils';
-import { merge } from 'rxjs';
+import { merge, Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { ChangeMemberStatusOrExpirationDialogComponent } from '../change-member-status-or-expiration-dialog/change-member-status-or-expiration-dialog.component';
 
@@ -77,7 +79,7 @@ export class MembersDynamicListComponent implements AfterViewInit, OnInit, OnCha
   @Input() updateTable: boolean;
   @Input() isMembersGroup: boolean;
   @Input() disableRouting = false;
-
+  @Output() loading$: EventEmitter<Observable<boolean>> = new EventEmitter<Observable<boolean>>();
   expireGroupAuth: boolean;
   expireVoAuth: boolean;
 
@@ -152,6 +154,7 @@ export class MembersDynamicListComponent implements AfterViewInit, OnInit, OnCha
       this.groupId,
       this.selectedGroupStatuses
     );
+    this.loading$.emit(this.dataSource.loading$);
   }
 
   canBeSelected = (member: RichMember): boolean => !isMemberIndirect(member);

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -8,6 +8,7 @@ import { MatSortModule } from '@angular/material/sort';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
@@ -163,6 +164,8 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     MatPaginatorModule,
     MatProgressSpinnerModule,
     UiAlertsModule,
+    UiLoadersModule,
+    LoaderDirective,
     MatIconModule,
     MatMenuModule,
     MatButtonModule,
@@ -247,7 +250,6 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     AttributeRightsTabGroupComponent,
     AttributeUniqueToggleComponent,
     AttributeCriticalOperationsTogglesComponent,
-    LoaderDirective,
     MailingListsComponent,
     DataQuotasComponent,
     SettingsSSHKeysComponent,
@@ -323,7 +325,6 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     AttributeRightsTabGroupComponent,
     AttributeUniqueToggleComponent,
     AttributeCriticalOperationsTogglesComponent,
-    LoaderDirective,
     MailingListsComponent,
     DataQuotasComponent,
     SettingsSSHKeysComponent,
@@ -342,6 +343,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     DeselectButtonComponent,
     AuditLogSearchSelectComponent,
     ApplicationStateSelectorComponent,
+    LoaderDirective,
   ],
   providers: [
     { provide: DateAdapter, useClass: AppDateAdapter },

--- a/libs/perun/components/src/lib/resources-list/resources-list.component.ts
+++ b/libs/perun/components/src/lib/resources-list/resources-list.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { Group, RichResource } from '@perun-web-apps/perun/openapi';
@@ -27,7 +19,7 @@ import { ResourceWithStatus } from '@perun-web-apps/perun/models';
   templateUrl: './resources-list.component.html',
   styleUrls: ['./resources-list.component.scss'],
 })
-export class ResourcesListComponent implements OnInit, OnChanges {
+export class ResourcesListComponent implements OnChanges {
   @ViewChild(TableWrapperComponent, { static: true }) child: TableWrapperComponent;
   @Input() resources: ResourceWithStatus[] = [];
   @Input() selection = new SelectionModel<ResourceWithStatus>(true, []);
@@ -112,11 +104,8 @@ export class ResourcesListComponent implements OnInit, OnChanges {
     return ResourcesListComponent.getDataForColumn(data, column, this.recentIds);
   };
 
-  ngOnInit(): void {
-    this.disabledRouting = this.disableRouting;
-  }
-
   ngOnChanges(): void {
+    this.disabledRouting = this.disableRouting;
     if (!this.guiAuthResolver.isPerunAdminOrObserver()) {
       this.displayedColumns = this.displayedColumns.filter((column) => column !== 'id');
     }

--- a/libs/perun/components/src/lib/users-dynamic-list/users-dynamic-list.component.html
+++ b/libs/perun/components/src/lib/users-dynamic-list/users-dynamic-list.component.html
@@ -1,15 +1,10 @@
-<div
-  [hidden]="this.dataSource.allObjectCount === 0 && (dataSource.loading$ | async) === false"
-  class="card mt-2">
+<div [hidden]="this.dataSource.allObjectCount === 0" class="card mt-2">
   <perun-web-apps-table-wrapper
     (exportDisplayedData)="exportDisplayedData($event)"
     (exportAllData)="exportAllData($event)"
     [tableId]="tableId"
     [dataLength]="dataSource.allObjectCount"
     [pageSizeOptions]="pageSizeOptions">
-    <div class="spinner-container" *ngIf="dataSource.loading$ | async">
-      <mat-spinner class="ml-auto mr-auto"></mat-spinner>
-    </div>
     <table
       [dataSource]="dataSource"
       class="w-100"
@@ -108,8 +103,6 @@
   </perun-web-apps-table-wrapper>
 </div>
 
-<perun-web-apps-alert
-  *ngIf="this.dataSource.allObjectCount === 0 && (dataSource.loading$ | async) === false"
-  [alert_type]="'warn'">
+<perun-web-apps-alert *ngIf="this.dataSource.allObjectCount === 0" [alert_type]="'warn'">
   {{'SHARED_LIB.UI.ALERTS.NO_USERS' | translate}}
 </perun-web-apps-alert>

--- a/libs/perun/components/src/lib/users-dynamic-list/users-dynamic-list.component.ts
+++ b/libs/perun/components/src/lib/users-dynamic-list/users-dynamic-list.component.ts
@@ -1,4 +1,13 @@
-import { AfterViewInit, Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import {
   Consent,
   ConsentsManagerService,
@@ -24,7 +33,7 @@ import {
   GuiAuthResolver,
   TableCheckbox,
 } from '@perun-web-apps/perun/services';
-import { merge } from 'rxjs';
+import { merge, Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { TableConfigService } from '@perun-web-apps/config/table-config';
 import { MatDialog } from '@angular/material/dialog';
@@ -65,6 +74,7 @@ export class UsersDynamicListComponent implements OnInit, OnChanges, AfterViewIn
   @Input() onlyAllowed: boolean;
   @Input() consentStatuses: ConsentStatus[];
   @Input() includeConsents = false;
+  @Output() loading$: EventEmitter<Observable<boolean>> = new EventEmitter<Observable<boolean>>();
 
   consents: Consent[];
   dataSource: DynamicDataSource<RichUser>;
@@ -141,6 +151,7 @@ export class UsersDynamicListComponent implements OnInit, OnChanges, AfterViewIn
       this.onlyAllowed,
       this.consentStatuses
     );
+    this.loading$.emit(this.dataSource.loading$);
   }
 
   ngOnChanges(): void {

--- a/libs/perun/dialogs/src/lib/bug-report-dialog/bug-report-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/bug-report-dialog/bug-report-dialog.component.html
@@ -1,42 +1,48 @@
-<h1 mat-dialog-title>{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.TITLE' | translate}}</h1>
-<mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-<div class="dialog-container" mat-dialog-content *ngIf="!loading">
-  <mat-form-field>
-    <mat-label>{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.SUBJECT' | translate}}</mat-label>
-    <input #subjectModel="ngModel" [(ngModel)]="subject" matInput required />
-    <mat-error
-      *ngIf="subjectModel.invalid"
-      >{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.SUBJECT_ERROR' | translate}}</mat-error
-    >
-  </mat-form-field>
-  <mat-form-field>
-    <mat-label>{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.MESSAGE' | translate}}</mat-label>
-    <textarea
-      #messageModel="ngModel"
-      [(ngModel)]="message"
-      matInput
-      placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.MESSAGE_PLACEHOLDER' | translate}}"
-      required>
-    </textarea>
-    <mat-error
-      *ngIf="messageModel.invalid"
-      >{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.MESSAGE_ERROR' | translate}}</mat-error
-    >
-  </mat-form-field>
-</div>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <mat-form-field>
+        <mat-label>{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.SUBJECT' | translate}}</mat-label>
+        <input #subjectModel="ngModel" [(ngModel)]="subject" matInput required />
+        <mat-error
+          *ngIf="subjectModel.invalid"
+          >{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.SUBJECT_ERROR' | translate}}</mat-error
+        >
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.MESSAGE' | translate}}</mat-label>
+        <textarea
+          #messageModel="ngModel"
+          [(ngModel)]="message"
+          matInput
+          placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.MESSAGE_PLACEHOLDER' | translate}}"
+          required>
+        </textarea>
+        <mat-error
+          *ngIf="messageModel.invalid"
+          >{{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.MESSAGE_ERROR' | translate}}</mat-error
+        >
+      </mat-form-field>
+    </div>
 
-<div mat-dialog-actions>
-  <div class="ml-auto">
-    <button (click)="dialogRef.close()" mat-button>
-      {{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="sendBugReport()"
-      [disabled]="message === '' || subject === '' || loading"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.SEND' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <div class="ml-auto">
+        <button (click)="dialogRef.close()" mat-button>
+          {{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.CANCEL' | translate}}
+        </button>
+        <button
+          (click)="sendBugReport()"
+          [disabled]="message === '' || subject === '' || loading"
+          class="ml-2"
+          color="accent"
+          mat-flat-button>
+          {{'SHARED_LIB.PERUN.COMPONENTS.BUG_REPORT.SEND' | translate}}
+        </button>
+      </div>
+    </div>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/change-group-expiration-dialog/change-group-expiration-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-group-expiration-dialog/change-group-expiration-dialog.component.html
@@ -1,17 +1,20 @@
-<div class="member-theme">
-  <h1 mat-dialog-title>{{'DIALOGS.CHANGE_GROUP_EXPIRATION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-change-expiration-dialog
-    *ngIf="!loading"
-    [minDate]="minDate"
-    [maxDate]="maxDate"
-    [currentExpiration]="currentExpiration"
-    [newExpiration]="newExpiration"
-    [canExtendMembership]="canExtendMembership"
-    [mode]="'group'"
-    [status]="status"
-    [backButton]="backButton"
-    (statusChange)="changeStatus = true"
-    (expirationChanged)="onExpirationChanged($event)">
-  </perun-web-apps-change-expiration-dialog>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="member-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.CHANGE_GROUP_EXPIRATION.TITLE' | translate}}</h1>
+    <perun-web-apps-change-expiration-dialog
+      [minDate]="minDate"
+      [maxDate]="maxDate"
+      [currentExpiration]="currentExpiration"
+      [newExpiration]="newExpiration"
+      [canExtendMembership]="canExtendMembership"
+      [mode]="'group'"
+      [status]="status"
+      [backButton]="backButton"
+      (statusChange)="changeStatus = true"
+      (expirationChanged)="onExpirationChanged($event)">
+    </perun-web-apps-change-expiration-dialog>
+  </div>
 </div>

--- a/libs/perun/dialogs/src/lib/change-group-resource-assigment-dialog/change-group-resource-assigment-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-group-resource-assigment-dialog/change-group-resource-assigment-dialog.component.html
@@ -1,74 +1,78 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>
-    {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.TITLE' | translate}}
-  </h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div mat-dialog-content *ngIf="!loading">
-    <p class="mb-4">
-      {{group.name}} <span class="text-muted id-font">#{{group.id}}</span> - {{resource.name}}
-      <span class="text-muted id-font">#{{resource.id}}</span>
-    </p>
-    <p>
-      <strong class="mr-2">
-        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.CURRENT' | translate}}
-        :
-      </strong>
-      {{status}}
-    </p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>
+      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.TITLE' | translate}}
+    </h1>
+    <div mat-dialog-content>
+      <p *ngIf="group && resource" class="mb-4">
+        {{group.name}} <span class="text-muted id-font">#{{group.id}}</span> - {{resource.name}}
+        <span class="text-muted id-font">#{{resource.id}}</span>
+      </p>
+      <p>
+        <strong class="mr-2">
+          {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.CURRENT' | translate}}
+          :
+        </strong>
+        {{status}}
+      </p>
 
-    <p>
-      <strong class="mr-2">
-        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.NEW' | translate}}
-        :
-      </strong>
-      {{getReversedStatus()}}
-    </p>
+      <p>
+        <strong class="mr-2">
+          {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.NEW' | translate}}
+          :
+        </strong>
+        {{getReversedStatus()}}
+      </p>
 
-    <span *ngIf="status ==='INACTIVE' || status ==='FAILED'" class="text-muted">
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.ACTIVE_HINT' | translate}}
-    </span>
-    <span *ngIf="status ==='ACTIVE'" class="text-muted">
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.INACTIVE_HINT' | translate}}
-    </span>
-
-    <mat-radio-group
-      class="d-flex flex-column mt-3"
-      *ngIf="status === 'INACTIVE' || status ==='FAILED'"
-      [(ngModel)]="asyncValidation">
-      <span class="font-weight-bold">
-        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.VALIDATE' | translate}}
-        :
+      <span *ngIf="status ==='INACTIVE' || status ==='FAILED'" class="text-muted">
+        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.ACTIVE_HINT' | translate}}
       </span>
-      <mat-radio-button [value]="false">
-        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.SYNC' | translate}}
-      </mat-radio-button>
-      <mat-radio-button [value]="true">
-        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.ASYNC' | translate}}
-      </mat-radio-button>
-    </mat-radio-group>
+      <span *ngIf="status ==='ACTIVE'" class="text-muted">
+        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.INACTIVE_HINT' | translate}}
+      </span>
 
-    <span
-      class="text-muted"
-      *ngIf="(status === 'INACTIVE' || status === 'FAILED') && asyncValidation === false">
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.SYNC_HINT' | translate}}
-    </span>
-    <span
-      class="text-muted"
-      *ngIf="(status === 'INACTIVE' || status ==='FAILED') && asyncValidation === true">
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.ASYNC_HINT' | translate}}
-    </span>
-  </div>
-  <div mat-dialog-actions *ngIf="!loading">
-    <button class="ml-auto mr-2" mat-flat-button (click)="onCancel()">
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.CANCEL' | translate}}
-    </button>
-    <button
-      data-cy="change-status-button"
-      mat-flat-button
-      color="accent"
-      [disabled]="loading"
-      (click)="onSubmit()">
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.'+(status === 'ACTIVE' ? 'DEACTIVATE' : 'ACTIVATE') | translate}}
-    </button>
+      <mat-radio-group
+        class="d-flex flex-column mt-3"
+        *ngIf="status === 'INACTIVE' || status ==='FAILED'"
+        [(ngModel)]="asyncValidation">
+        <span class="font-weight-bold">
+          {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.VALIDATE' | translate}}
+          :
+        </span>
+        <mat-radio-button [value]="false">
+          {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.SYNC' | translate}}
+        </mat-radio-button>
+        <mat-radio-button [value]="true">
+          {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.ASYNC' | translate}}
+        </mat-radio-button>
+      </mat-radio-group>
+
+      <span
+        class="text-muted"
+        *ngIf="(status === 'INACTIVE' || status === 'FAILED') && asyncValidation === false">
+        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.SYNC_HINT' | translate}}
+      </span>
+      <span
+        class="text-muted"
+        *ngIf="(status === 'INACTIVE' || status ==='FAILED') && asyncValidation === true">
+        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.ASYNC_HINT' | translate}}
+      </span>
+    </div>
+    <div mat-dialog-actions>
+      <button class="ml-auto mr-2" mat-flat-button (click)="onCancel()">
+        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.CANCEL' | translate}}
+      </button>
+      <button
+        data-cy="change-status-button"
+        mat-flat-button
+        color="accent"
+        [disabled]="loading"
+        (click)="onSubmit()">
+        {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_GROUP_RESOURCE_ASSIGMENT_DIALOG.'+(status === 'ACTIVE' ? 'DEACTIVATE' : 'ACTIVATE') | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/change-member-status-dialog/change-member-status-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-member-status-dialog/change-member-status-dialog.component.html
@@ -1,44 +1,48 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.CHANGE_STATUS.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <div class="font-weight-bold pb-1">
-      {{'DIALOGS.CHANGE_STATUS.CURRENT_STATUS' | translate}} {{actualStatus | memberStatus}}
-    </div>
-    <div class="text-muted pb-3">{{description}}</div>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.CHANGE_STATUS.TITLE' | translate}}</h1>
+    <div class="dialog-container" mat-dialog-content>
+      <div class="font-weight-bold pb-1">
+        {{'DIALOGS.CHANGE_STATUS.CURRENT_STATUS' | translate}} {{actualStatus | memberStatus}}
+      </div>
+      <div class="text-muted pb-3">{{description}}</div>
 
-    <div *ngIf="allStatuses.length>1" class="font-weight-bold pb-1">
-      {{'DIALOGS.CHANGE_STATUS.NEW_STATUS' | translate}}
-      <mat-form-field *ngIf="!loading" class="mr-2 mt-2">
-        <mat-label>{{'DIALOGS.CHANGE_STATUS.SELECT_STATUS' | translate}}</mat-label>
-        <mat-select (selectionChange)="changeStatus($event)">
-          <mat-option
-            *ngFor="let status of allStatuses"
-            [value]="status"
-            >{{status | memberStatus}}</mat-option
-          >
-        </mat-select>
-      </mat-form-field>
+      <div *ngIf="allStatuses.length>1" class="font-weight-bold pb-1">
+        {{'DIALOGS.CHANGE_STATUS.NEW_STATUS' | translate}}
+        <mat-form-field class="mr-2 mt-2">
+          <mat-label>{{'DIALOGS.CHANGE_STATUS.SELECT_STATUS' | translate}}</mat-label>
+          <mat-select (selectionChange)="changeStatus($event)">
+            <mat-option
+              *ngFor="let status of allStatuses"
+              [value]="status"
+              >{{status | memberStatus}}</mat-option
+            >
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <div *ngIf="allStatuses.length === 1" class="font-weight-bold pb-1">
+        {{'DIALOGS.CHANGE_STATUS.NEW_STATUS' | translate}}
+        {{allStatuses[0] | memberStatus}}
+      </div>
+      <div class="text-muted new-line">
+        <i [innerHTML]="changeMessage"></i>
+      </div>
     </div>
-    <div *ngIf="allStatuses.length === 1" class="font-weight-bold pb-1">
-      {{'DIALOGS.CHANGE_STATUS.NEW_STATUS' | translate}}
-      {{allStatuses[0] | memberStatus}}
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{cancelOrBackButton}}
+      </button>
+      <button
+        (click)="submit()"
+        [disabled]="loading || !selectedStatus"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{submitButtonText}}
+      </button>
     </div>
-    <div class="text-muted new-line">
-      <i [innerHTML]="changeMessage"></i>
-    </div>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{cancelOrBackButton}}
-    </button>
-    <button
-      (click)="submit()"
-      [disabled]="loading || !selectedStatus"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{submitButtonText}}
-    </button>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/change-password-dialog/change-password-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-password-dialog/change-password-dialog.component.html
@@ -1,44 +1,52 @@
-<h1 mat-dialog-title>{{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.TITLE' | translate}}</h1>
-<div class="dialog-container user-theme" mat-dialog-content>
-  <form *ngIf="!loading" [formGroup]="formGroup">
-    <div class="display-flex">
-      <mat-form-field>
-        <mat-label
-          >{{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.OLD_PASSWORD' | translate}}</mat-label
-        >
-        <input
-          formControlName="oldPasswordCtrl"
-          matInput
-          required
-          [type]="showOldPassword ? 'text' : 'password'" />
-        <mat-icon matSuffix (click)="showOldPassword = !showOldPassword">
-          {{showOldPassword ? "visibility_off": "visibility"}}
-        </mat-icon>
-        <mat-error
-          *ngIf="oldPwd.hasError('required')"
-          >{{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.FIELD_EMPTY' | translate}}</mat-error
-        >
-      </mat-form-field>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>
+      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.TITLE' | translate}}
+    </h1>
+    <div class="dialog-container" mat-dialog-content>
+      <form [formGroup]="formGroup">
+        <div class="display-flex">
+          <mat-form-field>
+            <mat-label
+              >{{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.OLD_PASSWORD' | translate}}</mat-label
+            >
+            <input
+              formControlName="oldPasswordCtrl"
+              matInput
+              required
+              [type]="showOldPassword ? 'text' : 'password'" />
+            <mat-icon matSuffix (click)="showOldPassword = !showOldPassword">
+              {{showOldPassword ? "visibility_off": "visibility"}}
+            </mat-icon>
+            <mat-error
+              *ngIf="oldPwd.hasError('required')"
+              >{{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.FIELD_EMPTY' | translate}}</mat-error
+            >
+          </mat-form-field>
 
-      <perun-web-apps-password-form [formGroup]="formGroup" [namespace]="data.namespace">
-      </perun-web-apps-password-form>
+          <perun-web-apps-password-form [formGroup]="formGroup" [namespace]="data.namespace">
+          </perun-web-apps-password-form>
+        </div>
+      </form>
     </div>
-  </form>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-</div>
 
-<div *ngIf="!loading" mat-dialog-actions>
-  <div class="ml-auto">
-    <button (click)="close()" mat-button>
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="changePassword()"
-      [disabled]="formGroup.invalid || formGroup.pending"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.CHANGE' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <div class="ml-auto">
+        <button (click)="close()" mat-button>
+          {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.CANCEL' | translate}}
+        </button>
+        <button
+          (click)="changePassword()"
+          [disabled]="formGroup.invalid || formGroup.pending || loading"
+          class="ml-2"
+          color="accent"
+          mat-flat-button>
+          {{'SHARED_LIB.PERUN.COMPONENTS.CHANGE_PASSWORD_DIALOG.CHANGE' | translate}}
+        </button>
+      </div>
+    </div>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/change-sponsorship-expiration-dialog/change-sponsorship-expiration-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-sponsorship-expiration-dialog/change-sponsorship-expiration-dialog.component.html
@@ -1,12 +1,15 @@
-<div class="member-theme">
-  <h1 mat-dialog-title>{{'DIALOGS.CHANGE_SPONSORSHIP_EXPIRATION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-change-expiration-dialog
-    *ngIf="!loading"
-    [minDate]="minDate"
-    [currentExpiration]="currentExpiration"
-    [newExpiration]="newExpiration"
-    [mode]="'sponsor'"
-    (expirationChanged)="onExpirationChanged($event)">
-  </perun-web-apps-change-expiration-dialog>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="member-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.CHANGE_SPONSORSHIP_EXPIRATION.TITLE' | translate}}</h1>
+    <perun-web-apps-change-expiration-dialog
+      [minDate]="minDate"
+      [currentExpiration]="currentExpiration"
+      [newExpiration]="newExpiration"
+      [mode]="'sponsor'"
+      (expirationChanged)="onExpirationChanged($event)">
+    </perun-web-apps-change-expiration-dialog>
+  </div>
 </div>

--- a/libs/perun/dialogs/src/lib/change-vo-expiration-dialog/change-vo-expiration-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-vo-expiration-dialog/change-vo-expiration-dialog.component.html
@@ -1,17 +1,20 @@
-<div class="member-theme">
-  <h1 mat-dialog-title>{{'DIALOGS.CHANGE_VO_EXPIRATION.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <perun-web-apps-change-expiration-dialog
-    *ngIf="!loading"
-    [minDate]="minDate"
-    [maxDate]="maxDate"
-    [currentExpiration]="currentExpiration"
-    [newExpiration]="newExpiration"
-    [canExtendMembership]="canExtendMembership"
-    [mode]="'vo'"
-    [status]="status"
-    [backButton]="backButton"
-    (statusChange)="changeStatus = true"
-    (expirationChanged)="onExpirationChanged($event)">
-  </perun-web-apps-change-expiration-dialog>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="member-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.CHANGE_VO_EXPIRATION.TITLE' | translate}}</h1>
+    <perun-web-apps-change-expiration-dialog
+      [minDate]="minDate"
+      [maxDate]="maxDate"
+      [currentExpiration]="currentExpiration"
+      [newExpiration]="newExpiration"
+      [canExtendMembership]="canExtendMembership"
+      [mode]="'vo'"
+      [status]="status"
+      [backButton]="backButton"
+      (statusChange)="changeStatus = true"
+      (expirationChanged)="onExpirationChanged($event)">
+    </perun-web-apps-change-expiration-dialog>
+  </div>
 </div>

--- a/libs/perun/dialogs/src/lib/delete-entity-dialog/delete-entity-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/delete-entity-dialog/delete-entity-dialog.component.html
@@ -1,118 +1,124 @@
-<mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-<div *ngIf="!force && !loading">
-  <h1 mat-dialog-title>
-    {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
-    {{entityType}}
-  </h1>
-  <div class="dialog-container" mat-dialog-content>
-    <div *ngIf="!disableForce" class="mb-4">
-      {{'DIALOGS.DELETE_ENTITY.BASIC' | translate: {action: this.anonymize | deleteDialogType} }}
-      {{'DIALOGS.DELETE_ENTITY.ONLY' | translate}}
-      {{entityType}}
-      <span class="font-weight-bold">{{'DIALOGS.DELETE_ENTITY.OR' | translate}}</span>
-      {{entityType}}
-      {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}?
-    </div>
-    <div *ngIf="disableForce" class="mb-4">
-      {{'DIALOGS.DELETE_ENTITY.BASIC' | translate: {action: this.anonymize | deleteDialogType} }}
-      {{entityType}}
-      ?
-    </div>
-    <table [dataSource]="entityNames" class="w-100 table-margin" mat-table>
-      <ng-container matColumnDef="name">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let entity" mat-cell>
-          {{anonymize ? (entity | userFullName) : entity.name }}
-        </td>
-      </ng-container>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <div *ngIf="!force">
+      <h1 mat-dialog-title>
+        {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
+        {{entityType}}
+      </h1>
+      <div class="dialog-container" mat-dialog-content>
+        <div *ngIf="!disableForce" class="mb-4">
+          {{'DIALOGS.DELETE_ENTITY.BASIC' | translate: {action: this.anonymize | deleteDialogType} }}
+          {{'DIALOGS.DELETE_ENTITY.ONLY' | translate}}
+          {{entityType}}
+          <span class="font-weight-bold">{{'DIALOGS.DELETE_ENTITY.OR' | translate}}</span>
+          {{entityType}}
+          {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}?
+        </div>
+        <div *ngIf="disableForce" class="mb-4">
+          {{'DIALOGS.DELETE_ENTITY.BASIC' | translate: {action: this.anonymize | deleteDialogType} }}
+          {{entityType}}
+          ?
+        </div>
+        <table [dataSource]="entityNames" class="w-100 table-margin" mat-table>
+          <ng-container matColumnDef="name">
+            <th *matHeaderCellDef mat-header-cell></th>
+            <td *matCellDef="let entity" mat-cell>
+              {{anonymize ? (entity | userFullName) : entity.name }}
+            </td>
+          </ng-container>
 
-      <tr *matHeaderRowDef="['name']" class="font-weight-bolder" mat-header-row></tr>
-      <tr *matRowDef="let entity; columns: ['name'];" mat-row></tr>
-    </table>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.DELETE_ENTITY.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onDelete()"
-      class="ml-2"
-      data-cy="delete-button-dialog"
-      color="warn"
-      mat-flat-button>
-      {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
-    </button>
-    <button
-      *ngIf="!disableForce"
-      (click)="force = true"
-      class="ml-2"
-      data-cy="force-delete"
-      color="warn"
-      mat-flat-button>
-      <mat-icon>warning</mat-icon>
-      {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
-      {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}
-    </button>
-  </div>
-</div>
-<div *ngIf="force && !loading">
-  <h1 mat-dialog-title>
-    {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
-    {{entityType}}
-    {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}
-  </h1>
-  <div class="dialog-container" mat-dialog-content>
-    <div class="mb-4">
-      {{'DIALOGS.DELETE_ENTITY.WARN' | translate}}:
-      <mat-list>
-        <mat-list-item *ngFor="let relation of relations">
-          <span>
-            <mat-icon class="dot-icon">fiber_manual_record</mat-icon>
-            {{relation}}
-          </span>
-        </mat-list-item>
-      </mat-list>
-      <div *ngIf="anotherMessage">
-        {{anotherMessage}}
+          <tr *matHeaderRowDef="['name']" class="font-weight-bolder" mat-header-row></tr>
+          <tr *matRowDef="let entity; columns: ['name'];" mat-row></tr>
+        </table>
       </div>
-      <perun-web-apps-alert alert_type="warn">
-        {{'DIALOGS.DELETE_ENTITY.ASK' | translate: {action: this.anonymize | deleteDialogType} }}
-        {{entityType}} ?
-      </perun-web-apps-alert>
-      <table mat-table [dataSource]="entityNames" class="w-100 table-margin">
-        <ng-container matColumnDef="name">
-          <th *matHeaderCellDef mat-header-cell></th>
-          <td *matCellDef="let entity" mat-cell>
-            {{anonymize ? (entity | userFullName) : entity.name }}
-          </td>
-        </ng-container>
-
-        <tr *matHeaderRowDef="['name']" class="font-weight-bolder" mat-header-row></tr>
-        <tr *matRowDef="let entity; columns: ['name'];" mat-row></tr>
-      </table>
+      <div mat-dialog-actions>
+        <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+          {{'DIALOGS.DELETE_ENTITY.CANCEL' | translate}}
+        </button>
+        <button
+          (click)="onDelete()"
+          class="ml-2"
+          data-cy="delete-button-dialog"
+          color="warn"
+          mat-flat-button>
+          {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
+        </button>
+        <button
+          *ngIf="!disableForce"
+          (click)="force = true"
+          class="ml-2"
+          data-cy="force-delete"
+          color="warn"
+          mat-flat-button>
+          <mat-icon>warning</mat-icon>
+          {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
+          {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}
+        </button>
+      </div>
     </div>
-    <mat-form-field>
-      <input
-        [formControl]="deleteControl"
-        data-cy="force-delete-control"
-        matInput
-        placeholder="{{'DIALOGS.DELETE_ENTITY.CONTROL' | translate: {action: this.anonymize | deleteDialogType | uppercase} }}" />
-    </mat-form-field>
-  </div>
-  <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.DELETE_ENTITY.CANCEL' | translate}}
-    </button>
-    <button
-      (click)="onDelete()"
-      [disabled]="deleteControl.invalid"
-      class="ml-2"
-      data-cy="force-delete-button"
-      color="warn"
-      mat-flat-button>
-      <mat-icon>warning</mat-icon>
-      {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
-      {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}
-    </button>
+    <div *ngIf="force">
+      <h1 mat-dialog-title>
+        {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
+        {{entityType}}
+        {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}
+      </h1>
+      <div class="dialog-container" mat-dialog-content>
+        <div class="mb-4">
+          {{'DIALOGS.DELETE_ENTITY.WARN' | translate}}:
+          <mat-list>
+            <mat-list-item *ngFor="let relation of relations">
+              <span>
+                <mat-icon class="dot-icon">fiber_manual_record</mat-icon>
+                {{relation}}
+              </span>
+            </mat-list-item>
+          </mat-list>
+          <div *ngIf="anotherMessage">
+            {{anotherMessage}}
+          </div>
+          <perun-web-apps-alert alert_type="warn">
+            {{'DIALOGS.DELETE_ENTITY.ASK' | translate: {action: this.anonymize | deleteDialogType} }}
+            {{entityType}} ?
+          </perun-web-apps-alert>
+          <table mat-table [dataSource]="entityNames" class="w-100 table-margin">
+            <ng-container matColumnDef="name">
+              <th *matHeaderCellDef mat-header-cell></th>
+              <td *matCellDef="let entity" mat-cell>
+                {{anonymize ? (entity | userFullName) : entity.name }}
+              </td>
+            </ng-container>
+
+            <tr *matHeaderRowDef="['name']" class="font-weight-bolder" mat-header-row></tr>
+            <tr *matRowDef="let entity; columns: ['name'];" mat-row></tr>
+          </table>
+        </div>
+        <mat-form-field>
+          <input
+            [formControl]="deleteControl"
+            data-cy="force-delete-control"
+            matInput
+            placeholder="{{'DIALOGS.DELETE_ENTITY.CONTROL' | translate: {action: this.anonymize | deleteDialogType | uppercase} }}" />
+        </mat-form-field>
+      </div>
+      <div mat-dialog-actions>
+        <button (click)="onCancel()" class="ml-auto" mat-flat-button>
+          {{'DIALOGS.DELETE_ENTITY.CANCEL' | translate}}
+        </button>
+        <button
+          (click)="onDelete()"
+          [disabled]="deleteControl.invalid"
+          class="ml-2"
+          data-cy="force-delete-button"
+          color="warn"
+          mat-flat-button>
+          <mat-icon>warning</mat-icon>
+          {{'DIALOGS.DELETE_ENTITY.DELETE' | translate: {action: this.anonymize | deleteDialogType | titlecase} }}
+          {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}
+        </button>
+      </div>
+    </div>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/edit-facility-resource-group-vo-dialog/edit-facility-resource-group-vo-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/edit-facility-resource-group-vo-dialog/edit-facility-resource-group-vo-dialog.component.html
@@ -1,19 +1,21 @@
-<div class="{{theme}}">
-  <h1 *ngIf="dialogType === 0" mat-dialog-title>
-    {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.EDIT_FACILITY' | translate}}
-  </h1>
-  <h1 *ngIf="dialogType === 1" mat-dialog-title>
-    {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.EDIT_RESOURCE' | translate}}
-  </h1>
-  <h1 *ngIf="dialogType === 2" mat-dialog-title>
-    {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.EDIT_VO' | translate}}
-  </h1>
-  <h1 *ngIf="dialogType === 3" mat-dialog-title>
-    {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.EDIT_GROUP' | translate}}
-  </h1>
-  <div mat-dialog-content>
-    <mat-spinner *ngIf="loading" class="mr-auto ml-auto"></mat-spinner>
-    <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 *ngIf="dialogType === 0" mat-dialog-title>
+      {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.EDIT_FACILITY' | translate}}
+    </h1>
+    <h1 *ngIf="dialogType === 1" mat-dialog-title>
+      {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.EDIT_RESOURCE' | translate}}
+    </h1>
+    <h1 *ngIf="dialogType === 2" mat-dialog-title>
+      {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.EDIT_VO' | translate}}
+    </h1>
+    <h1 *ngIf="dialogType === 3" mat-dialog-title>
+      {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.EDIT_GROUP' | translate}}
+    </h1>
+    <div class="dialog-container" mat-dialog-content>
       <mat-form-field *ngIf="dialogType === 2">
         <input
           [value]="shortName"
@@ -41,19 +43,19 @@
           placeholder="{{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.DESCRIPTION' | translate}}:"></textarea>
       </mat-form-field>
     </div>
-  </div>
 
-  <div mat-dialog-actions>
-    <button (click)="cancel()" class="ml-auto" mat-flat-button>
-      {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.CANCEL_BUTTON' | translate}}
-    </button>
-    <button
-      (click)="submit()"
-      [disabled]="loading || nameCtrl.invalid || descriptionCtrl.invalid"
-      class="ml-2"
-      color="accent"
-      mat-flat-button>
-      {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.SUBMIT_BUTTON' | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button (click)="cancel()" class="ml-auto" mat-flat-button>
+        {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.CANCEL_BUTTON' | translate}}
+      </button>
+      <button
+        (click)="submit()"
+        [disabled]="loading || nameCtrl.invalid || descriptionCtrl.invalid"
+        class="ml-2"
+        color="accent"
+        mat-flat-button>
+        {{'DIALOGS.EDIT_FACILITY_RESOURCE_GROUP_VO.SUBMIT_BUTTON' | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/group-sync-detail-dialog/group-sync-detail-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/group-sync-detail-dialog/group-sync-detail-dialog.component.html
@@ -1,57 +1,61 @@
-<div class="{{theme}}">
-  <h1 mat-dialog-title>{{'DIALOGS.GROUP_SYNC_DETAIL.TITLE' | translate}}</h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" class="dialog-container" mat-dialog-content>
-    <mat-form-field>
-      <input
-        matInput
-        [value]="group.name"
-        readonly
-        placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.GROUP_NAME' | translate}}" />
-    </mat-form-field>
-    <mat-form-field>
-      <input
-        matInput
-        [value]="syncType | translate"
-        readonly
-        placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.SYNCHRONIZATION' | translate}}" />
-    </mat-form-field>
-    <mat-form-field>
-      <input
-        matInput
-        [value]="syncState"
-        readonly
-        placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.LAST_SYNC_STATE' | translate}}" />
-    </mat-form-field>
-    <mat-form-field>
-      <input
-        matInput
-        [value]="syncTime | translate"
-        readonly
-        placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.LAST_SYNC_TIME' | translate}}" />
-    </mat-form-field>
-    <mat-form-field>
-      <input
-        matInput
-        [value]="'DIALOGS.GROUP_SYNC_DETAIL.SYNC_INTERVAL_MINUTES' | translate : {interval: syncInterval}"
-        readonly
-        placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.SYNC_INTERVAL' | translate}}" />
-    </mat-form-field>
-  </div>
-  <div mat-dialog-actions>
-    <div class="ml-auto">
-      <button (click)="onCancel()" class="ml-2" mat-flat-button>
-        {{'DIALOGS.GROUP_SYNC_DETAIL.CANCEL' | translate}}
-      </button>
-      <button
-        (click)="onForce()"
-        *ngIf="type === 'BASIC' || type === 'STRUCTURED'"
-        [disabled]="loading"
-        class="ml-2"
-        color="accent"
-        mat-flat-button>
-        {{'DIALOGS.GROUP_SYNC_DETAIL.FORCE' | translate}}
-      </button>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{'DIALOGS.GROUP_SYNC_DETAIL.TITLE' | translate}}</h1>
+    <div *ngIf="group" class="dialog-container" mat-dialog-content>
+      <mat-form-field>
+        <input
+          matInput
+          [value]="group.name"
+          readonly
+          placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.GROUP_NAME' | translate}}" />
+      </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          [value]="syncType | translate"
+          readonly
+          placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.SYNCHRONIZATION' | translate}}" />
+      </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          [value]="syncState"
+          readonly
+          placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.LAST_SYNC_STATE' | translate}}" />
+      </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          [value]="syncTime | translate"
+          readonly
+          placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.LAST_SYNC_TIME' | translate}}" />
+      </mat-form-field>
+      <mat-form-field>
+        <input
+          matInput
+          [value]="'DIALOGS.GROUP_SYNC_DETAIL.SYNC_INTERVAL_MINUTES' | translate : {interval: syncInterval}"
+          readonly
+          placeholder="{{'DIALOGS.GROUP_SYNC_DETAIL.SYNC_INTERVAL' | translate}}" />
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions>
+      <div class="ml-auto">
+        <button (click)="onCancel()" class="ml-2" mat-flat-button>
+          {{'DIALOGS.GROUP_SYNC_DETAIL.CANCEL' | translate}}
+        </button>
+        <button
+          (click)="onForce()"
+          *ngIf="type === 'BASIC' || type === 'STRUCTURED'"
+          [disabled]="loading"
+          class="ml-2"
+          color="accent"
+          mat-flat-button>
+          {{'DIALOGS.GROUP_SYNC_DETAIL.FORCE' | translate}}
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/member-tree-view-dialog/member-tree-view-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/member-tree-view-dialog/member-tree-view-dialog.component.html
@@ -1,66 +1,38 @@
-<div class="group-theme">
-  <h1 mat-dialog-title>
-    {{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.TITLE' | translate:{ 'name': userName} }}
-  </h1>
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content class="mr-0">
-    <p>{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.INFO' | translate}}</p>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="group-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>
+      {{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.TITLE' | translate:{ 'name': userName} }}
+    </h1>
+    <div *ngIf="dataSource" mat-dialog-content class="mr-0">
+      <p>{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.INFO' | translate}}</p>
 
-    <mat-form-field class="filter-field ml-2">
-      <input
-        matInput
-        [formControl]="formControl"
-        placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.FILTER' | translate}}" />
-    </mat-form-field>
-    <perun-web-apps-alert
-      *ngIf="!dataSource.data.length"
-      >{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.NO_PATHS'|translate}}</perun-web-apps-alert
-    >
-    <mat-tree
-      *ngIf="dataSource.data.length"
-      [dataSource]="dataSource"
-      [treeControl]="treeControl"
-      class="example-tree">
-      <!-- This is the tree node template for leaf nodes -->
-      <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
-        <li class="mat-tree-node">
-          <div
-            class="row flex-nowrap"
-            [class.cursor-pointer]="node.direct || node.include"
-            [class.act-disabled]="!node.direct && !node.include"
-            (click)="navigate(node.id, node.include)">
-            <button mat-icon-button></button>
-            <div [ngStyle]="{'min-width': getMinWidth(node.level)}" class="mt-auto mb-auto">
-              <span>{{node.name | parseGroupName}}</span>
-              <span
-                *ngIf="node.direct"
-                class="text-muted ml-2"
-                >{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.DIRECT' | translate}}</span
-              >
-              <span
-                *ngIf="node.include"
-                class="text-muted ml-2"
-                >{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.INCLUDE' | translate}}</span
-              >
-            </div>
-            <span class="text-muted ml-3">{{node.description}}</span>
-          </div>
-        </li>
-      </mat-tree-node>
-      <!-- This is the tree node template for expandable nodes -->
-      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-        <li>
-          <div class="mat-tree-node">
-            <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'Toggle ' + node.name">
-              <mat-icon class="mr-3">
-                {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
-              </mat-icon>
-            </button>
+      <mat-form-field class="filter-field ml-2">
+        <input
+          matInput
+          [formControl]="formControl"
+          placeholder="{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.FILTER' | translate}}" />
+      </mat-form-field>
+      <perun-web-apps-alert
+        *ngIf="!dataSource.data.length"
+        >{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.NO_PATHS'|translate}}</perun-web-apps-alert
+      >
+      <mat-tree
+        *ngIf="dataSource.data.length"
+        [dataSource]="dataSource"
+        [treeControl]="treeControl"
+        class="example-tree">
+        <!-- This is the tree node template for leaf nodes -->
+        <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+          <li class="mat-tree-node">
             <div
+              class="row flex-nowrap"
               [class.cursor-pointer]="node.direct || node.include"
               [class.act-disabled]="!node.direct && !node.include"
-              (click)="navigate(node.id, node.include)"
-              class="row flex-nowrap">
+              (click)="navigate(node.id, node.include)">
+              <button mat-icon-button></button>
               <div [ngStyle]="{'min-width': getMinWidth(node.level)}" class="mt-auto mb-auto">
                 <span>{{node.name | parseGroupName}}</span>
                 <span
@@ -76,19 +48,51 @@
               </div>
               <span class="text-muted ml-3">{{node.description}}</span>
             </div>
-          </div>
-          <ul [class.example-tree-invisible]="!treeControl.isExpanded(node)">
-            <ng-container matTreeNodeOutlet></ng-container>
-          </ul>
-        </li>
-      </mat-nested-tree-node>
-    </mat-tree>
-  </div>
-  <div mat-dialog-actions>
-    <div class="ml-auto">
-      <button (click)="onCancel()" mat-flat-button>
-        {{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.CLOSE' | translate}}
-      </button>
+          </li>
+        </mat-tree-node>
+        <!-- This is the tree node template for expandable nodes -->
+        <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+          <li>
+            <div class="mat-tree-node">
+              <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'Toggle ' + node.name">
+                <mat-icon class="mr-3">
+                  {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
+                </mat-icon>
+              </button>
+              <div
+                [class.cursor-pointer]="node.direct || node.include"
+                [class.act-disabled]="!node.direct && !node.include"
+                (click)="navigate(node.id, node.include)"
+                class="row flex-nowrap">
+                <div [ngStyle]="{'min-width': getMinWidth(node.level)}" class="mt-auto mb-auto">
+                  <span>{{node.name | parseGroupName}}</span>
+                  <span
+                    *ngIf="node.direct"
+                    class="text-muted ml-2"
+                    >{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.DIRECT' | translate}}</span
+                  >
+                  <span
+                    *ngIf="node.include"
+                    class="text-muted ml-2"
+                    >{{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.INCLUDE' | translate}}</span
+                  >
+                </div>
+                <span class="text-muted ml-3">{{node.description}}</span>
+              </div>
+            </div>
+            <ul [class.example-tree-invisible]="!treeControl.isExpanded(node)">
+              <ng-container matTreeNodeOutlet></ng-container>
+            </ul>
+          </li>
+        </mat-nested-tree-node>
+      </mat-tree>
+    </div>
+    <div mat-dialog-actions>
+      <div class="ml-auto">
+        <button (click)="onCancel()" mat-flat-button>
+          {{'SHARED_LIB.PERUN.COMPONENTS.MEMBER_TREEVIEW_DIALOG.CLOSE' | translate}}
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/perun-dialogs.module.ts
+++ b/libs/perun/dialogs/src/lib/perun-dialogs.module.ts
@@ -24,6 +24,8 @@ import { ClipboardModule } from '@angular/cdk/clipboard';
 import { MatIconModule } from '@angular/material/icon';
 import { PerunPipesModule } from '@perun-web-apps/perun/pipes';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
+import { LoaderDirective } from '@perun-web-apps/perun/directives';
 import { AttributeValueListDeleteDialogComponent } from './attribute-value-list-delete-dialog/attribute-value-list-delete-dialog.component';
 import { ChangeEmailDialogComponent } from './change-email-dialog/change-email-dialog.component';
 import { UniversalConfirmationItemsDialogComponent } from './universal-confirmation-items-dialog/universal-confirmation-items-dialog.component';
@@ -63,6 +65,8 @@ import { RequestChangeDataQuotaDialogComponent } from './request-change-data-quo
     MatIconModule,
     PerunPipesModule,
     UiAlertsModule,
+    UiLoadersModule,
+    LoaderDirective,
     RouterModule,
     MatTreeModule,
     MatSelectModule,

--- a/libs/perun/dialogs/src/lib/remove-string-value-dialog/remove-string-value-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/remove-string-value-dialog/remove-string-value-dialog.component.html
@@ -1,33 +1,34 @@
-<h1 mat-dialog-title>{{title}}</h1>
-<div class="user-theme">
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-</div>
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>{{title}}</h1>
+    <div mat-dialog-content>
+      <p>
+        {{description}}
+      </p>
+      <div class="font-weight-bold">
+        {{'DIALOGS.REMOVE_STRING_VALUE.ASK' | customTranslate | translate}}
+      </div>
+      <table *ngIf="dataSource.data.length" [dataSource]="dataSource" class="w-100" mat-table>
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let value">{{value}}</td>
+        </ng-container>
 
-<div *ngIf="!loading" class="user-theme">
-  <div mat-dialog-content>
-    <p>
-      {{description}}
-    </p>
-    <div class="font-weight-bold">
-      {{'DIALOGS.REMOVE_STRING_VALUE.ASK' | customTranslate | translate}}
+        <tr mat-header-row *matHeaderRowDef="displayedColumns" class="font-weight-bolder"></tr>
+        <tr mat-row *matRowDef="let value; columns: displayedColumns;"></tr>
+      </table>
     </div>
-    <table *ngIf="dataSource.data.length" [dataSource]="dataSource" class="w-100" mat-table>
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let value">{{value}}</td>
-      </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns" class="font-weight-bolder"></tr>
-      <tr mat-row *matRowDef="let value; columns: displayedColumns;"></tr>
-    </table>
-  </div>
-
-  <div mat-dialog-actions>
-    <button mat-flat-button class="ml-auto" (click)="onCancel()">
-      {{'DIALOGS.REMOVE_STRING_VALUE.CANCEL' | customTranslate | translate}}
-    </button>
-    <button mat-flat-button class="ml-2" color="warn" (click)="onSubmit()">
-      {{'DIALOGS.REMOVE_STRING_VALUE.REMOVE' | customTranslate | translate}}
-    </button>
+    <div mat-dialog-actions>
+      <button mat-flat-button class="ml-auto" (click)="onCancel()">
+        {{'DIALOGS.REMOVE_STRING_VALUE.CANCEL' | customTranslate | translate}}
+      </button>
+      <button mat-flat-button class="ml-2" color="warn" (click)="onSubmit()">
+        {{'DIALOGS.REMOVE_STRING_VALUE.REMOVE' | customTranslate | translate}}
+      </button>
+    </div>
   </div>
 </div>

--- a/libs/perun/dialogs/src/lib/remove-user-ext-source-dialog/remove-user-ext-source-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/remove-user-ext-source-dialog/remove-user-ext-source-dialog.component.html
@@ -1,10 +1,11 @@
-<h1 mat-dialog-title>
-  {{'SHARED_LIB.PERUN.COMPONENTS.REMOVE_USER_EXT_SOURCE.TITLE' | customTranslate | translate}}
-</h1>
-<div class="{{theme}}">
-  <mat-spinner *ngIf="loading" class="ml-auto mr-auto"></mat-spinner>
-
-  <div *ngIf="!loading">
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="{{theme}} position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>
+      {{'SHARED_LIB.PERUN.COMPONENTS.REMOVE_USER_EXT_SOURCE.TITLE' | customTranslate | translate}}
+    </h1>
     <div mat-dialog-content>
       <p>
         {{'SHARED_LIB.PERUN.COMPONENTS.REMOVE_USER_EXT_SOURCE.DESCRIPTION' | customTranslate | translate}}

--- a/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.html
@@ -1,7 +1,6 @@
 <div class="{{theme}}">
   <h1 mat-dialog-title>{{this.data.title | translate}}</h1>
-  <mat-spinner class="ml-auto mr-auto" *ngIf="loading"></mat-spinner>
-  <div *ngIf="!loading" mat-dialog-content>
+  <div mat-dialog-content>
     <p>
       {{this.data.description | translate}}
     </p>
@@ -31,7 +30,6 @@
       mat-flat-button
       class="ml-2"
       color="warn"
-      [disabled]="loading"
       (click)="onSubmit()"
       *ngIf="data.type === 'remove'">
       {{'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_REMOVE_ITEMS_DIALOG.REMOVE_BUTTON' | translate}}
@@ -40,7 +38,6 @@
       mat-flat-button
       class="ml-2"
       color="accent"
-      [disabled]="loading"
       (click)="onSubmit()"
       *ngIf="data.type === 'confirmation'">
       {{'SHARED_LIB.PERUN.COMPONENTS.UNIVERSAL_REMOVE_ITEMS_DIALOG.SUBMIT_BUTTON' | translate}}

--- a/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/universal-confirmation-items-dialog/universal-confirmation-items-dialog.component.ts
@@ -21,7 +21,6 @@ export class UniversalConfirmationItemsDialogComponent implements OnInit {
   displayedColumns: string[] = ['name'];
   dataSource: MatTableDataSource<string>;
   theme: string;
-  loading = false;
 
   constructor(
     public dialogRef: MatDialogRef<UniversalConfirmationItemsDialogComponent>,

--- a/libs/perun/directives/src/lib/loader.directive.ts
+++ b/libs/perun/directives/src/lib/loader.directive.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 
 @Directive({
+  standalone: true,
   selector: '[perunWebAppsLoader]',
 })
 /**

--- a/libs/perun/login/src/lib/perun-login.module.ts
+++ b/libs/perun/login/src/lib/perun-login.module.ts
@@ -12,6 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
+import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
 
 @NgModule({
   imports: [
@@ -25,6 +26,7 @@ import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
     ReactiveFormsModule,
     MatInputModule,
     UiAlertsModule,
+    UiLoadersModule,
   ],
   declarations: [LoginScreenComponent, LoginScreenBaseComponent, LoginScreenServiceAccessComponent],
   exports: [LoginScreenBaseComponent, LoginScreenComponent, LoginScreenServiceAccessComponent],

--- a/libs/ui/loaders/.eslintrc.json
+++ b/libs/ui/loaders/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "parserOptions": {
+    "project": ["libs/ui/loaders/tsconfig.*?.json"]
+  }
+}

--- a/libs/ui/loaders/README.md
+++ b/libs/ui/loaders/README.md
@@ -1,0 +1,7 @@
+# ui-loaders
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `ng test ui-loaders` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/ui/loaders/jest.config.ts
+++ b/libs/ui/loaders/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  coverageDirectory: '../../../coverage/libs/ui/loaders',
+  globals: { 'ts-jest': { tsconfig: '<rootDir>/tsconfig.spec.json' } },
+  displayName: 'ui-loaders',
+};

--- a/libs/ui/loaders/src/index.ts
+++ b/libs/ui/loaders/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/ui-loaders.module';

--- a/libs/ui/loaders/src/lib/loading-dialog/loading-dialog.component.html
+++ b/libs/ui/loaders/src/lib/loading-dialog/loading-dialog.component.html
@@ -1,0 +1,3 @@
+<div id="loading-dialog-spinner" class="spinner-container">
+  <mat-spinner></mat-spinner>
+</div>

--- a/libs/ui/loaders/src/lib/loading-dialog/loading-dialog.component.ts
+++ b/libs/ui/loaders/src/lib/loading-dialog/loading-dialog.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'perun-web-apps-loading-dialog',
+  templateUrl: './loading-dialog.component.html',
+  styleUrls: ['./loading-dialog.component.scss'],
+})
+export class LoadingDialogComponent {}

--- a/libs/ui/loaders/src/lib/loading-table/loading-table.component.html
+++ b/libs/ui/loaders/src/lib/loading-table/loading-table.component.html
@@ -1,0 +1,3 @@
+<div class="spinner-container">
+  <mat-spinner></mat-spinner>
+</div>

--- a/libs/ui/loaders/src/lib/loading-table/loading-table.component.ts
+++ b/libs/ui/loaders/src/lib/loading-table/loading-table.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'perun-web-apps-loading-table',
+  templateUrl: './loading-table.component.html',
+  styleUrls: ['./loading-table.component.scss'],
+})
+export class LoadingTableComponent {}

--- a/libs/ui/loaders/src/lib/ui-loaders.module.ts
+++ b/libs/ui/loaders/src/lib/ui-loaders.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { CommonModule } from '@angular/common';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { LoadingTableComponent } from './loading-table/loading-table.component';
+import { LoadingDialogComponent } from './loading-dialog/loading-dialog.component';
+
+@NgModule({
+  imports: [MatIconModule, CommonModule, MatProgressSpinnerModule],
+  declarations: [LoadingTableComponent, LoadingDialogComponent],
+  exports: [LoadingTableComponent, LoadingDialogComponent],
+})
+export class UiLoadersModule {}

--- a/libs/ui/loaders/tsconfig.json
+++ b/libs/ui/loaders/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "target": "es2020"
+  },
+  "include": [],
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/ui/loaders/tsconfig.lib.json
+++ b/libs/ui/loaders/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": []
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/ui/loaders/tsconfig.spec.json
+++ b/libs/ui/loaders/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -93,6 +93,9 @@
       ],
       "@perun-web-apps/ui/material": [
         "libs/ui/material/src/index.ts"
+      ],
+      "@perun-web-apps/ui/loaders": [
+        "libs/ui/loaders/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
* Two new loader components were created and used across all apps (LoadingTableComponent and LoadingDialogComponent).
* The use case when some dialog includes also table was checked and it should work correctly (only one spinner should be visible).
* Another possible candidates for new loader components are "entity-detail-page" and "overview" components, but it is usually not possible to display some data (data are not fetched yet) during the loading behind the spinner for these components. Since it is not about UX but only about "consistency" or possible future easier changes, I did not implemented it in this PR.