### PR TITLE
feat(admin): sponsored member create dialog input fields fix

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.html
@@ -87,7 +87,7 @@
             </mat-form-field>
 
             <mat-form-field
-              matTooltip="{{'DIALOGS.CREATE_SPONSORED_MEMBER.LOGIN_DISABLED' | translate}}"
+              matTooltip="{{(this.selectedNamespace === null ? 'DIALOGS.CREATE_SPONSORED_MEMBER.NO_NAMESPACE_SELECTED' : 'DIALOGS.CREATE_SPONSORED_MEMBER.LOGIN_DISABLED') | translate}}"
               [matTooltipDisabled]="namespaceControl.get('login').enabled"
               matTooltipPosition="left">
               <input
@@ -116,7 +116,7 @@
             </mat-form-field>
 
             <span
-              matTooltip="{{'DIALOGS.CREATE_SPONSORED_MEMBER.PASSWORD_RESET_DISABLED' | translate}}"
+              matTooltip="{{(this.selectedNamespace === null ? 'DIALOGS.CREATE_SPONSORED_MEMBER.NO_NAMESPACE_SELECTED' : 'DIALOGS.CREATE_SPONSORED_MEMBER.PASSWORD_RESET_DISABLED') | translate}}"
               [matTooltipDisabled]="namespaceControl.get('passwordReset').enabled"
               matTooltipPosition="left">
               <mat-checkbox

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
@@ -187,7 +187,10 @@ export class CreateSponsoredMemberDialogComponent implements OnInit {
 
   onNamespaceChanged(namespc: string): void {
     this.selectedNamespace = namespc;
-    const rules = this.parsedRules.get(namespc);
+    const rules =
+      this.selectedNamespace === null
+        ? { login: 'disabled', password: 'disabled' }
+        : this.parsedRules.get(namespc);
     const login = this.namespaceControl.get('login');
     const password = this.namespaceControl.get('passwordCtrl');
     const passwordAgain = this.namespaceControl.get('passwordAgainCtrl');
@@ -308,6 +311,7 @@ export class CreateSponsoredMemberDialogComponent implements OnInit {
       if (this.namespaceOptions.length === 0) {
         this.functionalityNotSupported = true;
       }
+      this.onNamespaceChanged(this.selectedNamespace);
       this.loading = false;
       this.cd.detectChanges();
     });
@@ -330,6 +334,11 @@ export class CreateSponsoredMemberDialogComponent implements OnInit {
       );
 
       this.parsedRules.set(rule.namespaceName, fieldTypes);
+    }
+
+    // if there is single option, pre-select it
+    if (this.namespaceOptions.length === 1) {
+      this.selectedNamespace = this.namespaceOptions[0];
     }
   }
 }

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2035,7 +2035,8 @@
       "SPONSORSHIP_LABEL": "Sponsorship",
       "USER_TITLE": "User name",
       "NAMESPACE_TITLE": "Namespace details",
-      "SPONSORSHIP_TITLE": "Sponsorship options"
+      "SPONSORSHIP_TITLE": "Sponsorship options",
+      "NO_NAMESPACE_SELECTED": "Select namespace first"
     },
     "GENERATE_SPONSORED_MEMBERS": {
       "TITLE": "Generate sponsored members",

--- a/libs/perun/namespace-password-form/src/lib/password-form/password-form.component.ts
+++ b/libs/perun/namespace-password-form/src/lib/password-form/password-form.component.ts
@@ -62,6 +62,12 @@ export class PasswordFormComponent implements OnInit, OnChanges {
   }
 
   getPasswordDisabledTooltip(): string {
+    if (this.namespace === null) {
+      return this.translator.instant(
+        'DIALOGS.CREATE_SPONSORED_MEMBER.NO_NAMESPACE_SELECTED'
+      ) as string;
+    }
+
     if (this.tooltipPwdViaEmail) {
       return this.translator.instant(
         'SHARED_LIB.PERUN.COMPONENTS.PASSWORD_FORM_FIELD.TOOLTIP_PASSWORD_VIA_EMAIL'


### PR DESCRIPTION
* login and password input fields are disabled by default (namespace must be selected first)
* internationalized message added