### PR TITLE
fix: bug fixes after angular 15 migration

### DIFF
--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-users/facility-allowed-users.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-users/facility-allowed-users.component.html
@@ -30,6 +30,7 @@
         [vos]="vos"
         (voSelected)="voSelected($event)"
         [vo]="selectedVo"
+        [disableAutoSelect]="true"
         class="search-select">
       </perun-web-apps-vo-search-select>
       <perun-web-apps-resource-search-select
@@ -37,12 +38,14 @@
         (resourceSelected)="resourceSelected($event)"
         [displayStatus]="false"
         [resource]="selectedResource"
+        [disableAutoSelect]="true"
         class="search-select">
       </perun-web-apps-resource-search-select>
       <perun-web-apps-service-search-select
         [services]="filteredServices"
         (serviceSelected)="serviceSelected($event)"
         [service]="selectedService"
+        [disableAutoSelect]="true"
         class="search-select">
       </perun-web-apps-service-search-select>
       <mat-form-field class="search-select" *ngIf="globalForceConsents && facilityForceConsents">
@@ -69,10 +72,10 @@
     [onlyAllowed]="allowed"
     [facilityId]="facility.id"
     [searchString]="filterValue"
-    [resourceId]="selectedResource.id === -1 ? null : selectedResource.id"
-    [serviceId]="selectedService.id === -1 ? null : selectedService.id"
+    [resourceId]="selectedResource?.id"
+    [serviceId]="selectedService?.id"
     [tableId]="tableId"
-    [voId]="selectedVo.id === -1 ? null : selectedVo.id"
+    [voId]="selectedVo?.id"
     [consentStatuses]="selectedConsentStatuses"
     [includeConsents]="globalForceConsents && facilityForceConsents">
   </perun-web-apps-users-dynamic-list>

--- a/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-users/facility-allowed-users.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/facility-detail-page/facility-allowed-users/facility-allowed-users.component.ts
@@ -38,19 +38,14 @@ export class FacilityAllowedUsersComponent implements OnInit {
 
   allowed = true;
 
-  emptyResource: Resource = { id: -1, beanName: 'Resource', name: 'No filter' };
-  resources: Resource[] = [this.emptyResource];
-  filteredResources: Resource[] = [this.emptyResource];
-  selectedResource: Resource = this.emptyResource;
-
-  emptyVo: Vo = { id: -1, beanName: 'Vo', name: 'No filter' };
-  vos: Vo[] = [this.emptyVo];
-  selectedVo: Vo = this.emptyVo;
-
-  emptyService: Service = { id: -1, beanName: 'Service', name: 'No filter' };
-  services: Service[] = [this.emptyService];
-  filteredServices: Service[] = [this.emptyService];
-  selectedService: Service = this.emptyService;
+  resources: Resource[] = [];
+  filteredResources: Resource[] = [];
+  selectedResource: Resource;
+  vos: Vo[] = [];
+  selectedVo: Vo;
+  services: Service[] = [];
+  filteredServices: Service[] = [];
+  selectedService: Service;
 
   globalForceConsents: boolean;
   facilityForceConsents: boolean;
@@ -99,13 +94,13 @@ export class FacilityAllowedUsersComponent implements OnInit {
 
   changeFilter(): void {
     this.filtersCount = this.allowed ? 1 : 0;
-    if (this.selectedVo.id !== -1) {
+    if (this.selectedVo) {
       this.filtersCount += 1;
     }
-    if (this.selectedResource.id !== -1) {
+    if (this.selectedResource) {
       this.filtersCount += 1;
     }
-    if (this.selectedService.id !== -1) {
+    if (this.selectedService) {
       this.filtersCount += 1;
     }
     if (this.selectedConsentStatuses.length > 0) {
@@ -115,12 +110,15 @@ export class FacilityAllowedUsersComponent implements OnInit {
 
   clearFilters(): void {
     this.allowed = false;
-    this.selectedVo = this.emptyVo;
-    this.selectedResource = this.emptyResource;
-    this.selectedService = this.emptyService;
+    this.selectedVo = undefined;
+    this.selectedResource = undefined;
+    this.selectedService = undefined;
     this.selectedConsentStatuses = [];
     this.statuses.setValue(this.selectedConsentStatuses);
     this.filtersCount = 0;
+    this.voSelected(this.selectedVo);
+    this.resourceSelected(this.selectedResource);
+    this.serviceSelected(this.selectedService);
   }
 
   refreshPage(): void {
@@ -128,15 +126,15 @@ export class FacilityAllowedUsersComponent implements OnInit {
 
     this.facilityService.getAssignedResourcesForFacility(this.facility.id).subscribe(
       (resources) => {
-        this.resources = [this.emptyResource].concat(resources);
+        this.resources = resources;
         this.filteredResources = this.resources;
 
         this.facilityService.getAllowedVos(this.facility.id).subscribe(
           (vos) => {
-            this.vos = [this.emptyVo].concat(vos);
+            this.vos = vos;
             this.serviceService.getAssignedServices(this.facility.id).subscribe(
               (services) => {
-                this.services = [this.emptyService].concat(services);
+                this.services = services;
                 this.filteredServices = this.services;
                 this.loading = false;
               },
@@ -155,48 +153,36 @@ export class FacilityAllowedUsersComponent implements OnInit {
   }
 
   voSelected(vo: Vo): void {
-    // prevents "fake" triggers
-    if (this.selectedVo.id === vo.id) {
-      return;
-    }
-
     this.selectedVo = vo;
-    this.selectedResource = this.emptyResource;
-    this.selectedService = this.emptyService;
+    this.selectedResource = undefined;
+    this.selectedService = undefined;
 
-    if (vo.id === -1) {
+    if (!vo) {
       this.filteredResources = this.resources;
       this.filteredServices = this.services;
     } else {
       this.filteredResources = this.resources.filter((res) => res.voId === vo.id);
       this.serviceService.getAssignedServicesVo(this.facility.id, vo.id).subscribe(
         (services) => {
-          this.filteredServices = [this.emptyService].concat(services);
+          this.filteredServices = services;
           this.loading = false;
         },
         () => (this.loading = false)
       );
-
-      this.filteredResources = [this.emptyResource].concat(this.filteredResources);
     }
     this.changeFilter();
   }
 
   resourceSelected(resource: Resource): void {
-    // prevents "fake" triggers
-    if (this.selectedResource.id === resource.id) {
-      return;
-    }
-
     this.selectedResource = resource;
-    this.selectedService = this.emptyService;
+    this.selectedService = undefined;
 
-    if (resource.id === -1) {
+    if (resource === undefined) {
       this.filteredServices = this.services;
     } else {
       this.resourceService.getAssignedServicesToResource(resource.id).subscribe(
         (services) => {
-          this.filteredServices = [this.emptyService].concat(services);
+          this.filteredServices = services;
           this.loading = false;
         },
         () => (this.loading = false)

--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-bans/member-bans.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-bans/member-bans.component.ts
@@ -1,5 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { EnrichedBanOnVo, Member, VosManagerService } from '@perun-web-apps/perun/openapi';
+import {
+  EnrichedBanOnVo,
+  Member,
+  RichMember,
+  VosManagerService,
+} from '@perun-web-apps/perun/openapi';
 import { EntityStorageService } from '@perun-web-apps/perun/services';
 import { BanOnEntityListColumn } from '@perun-web-apps/perun/components';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
@@ -34,7 +39,15 @@ export class MemberBansComponent implements OnInit {
     this.loading = true;
     this.voService.getVoBanForMember(this.member.id).subscribe({
       next: (ban) => {
-        this.bans = [{ ban: ban, member: null, vo: null }];
+        if (ban) {
+          this.bans = [
+            {
+              ban: ban,
+              member: this.member as RichMember,
+              vo: { id: this.member.voId, beanName: 'Vo' },
+            },
+          ];
+        }
         this.loading = false;
       },
       error: () => (this.loading = false),

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-hierarchical-inclusion/vo-settings-hierarchical-inclusion.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-hierarchical-inclusion/vo-settings-hierarchical-inclusion.component.html
@@ -1,7 +1,12 @@
 <h1 class="page-subtitle">{{'VO_DETAIL.SETTINGS.HIERARCHICAL_INCLUSION.TITLE' | translate}}</h1>
 <div class="display-flex">
   <perun-web-apps-refresh-button (click)="loadAllowedGroups()"></perun-web-apps-refresh-button>
-  <button (click)="addGroupsInclusion()" mat-flat-button class="me-2 action-button" color="accent">
+  <button
+    [disabled]="!selectedParentVo"
+    (click)="addGroupsInclusion()"
+    mat-flat-button
+    class="me-2 action-button"
+    color="accent">
     {{'VO_DETAIL.SETTINGS.HIERARCHICAL_INCLUSION.ADD' | translate}}
   </button>
   <button
@@ -16,7 +21,8 @@
     <perun-web-apps-vo-search-select
       *ngIf="parentVos.length > 0"
       [vos]="parentVos"
-      (voSelected)="voSelected($event)">
+      (voSelected)="voSelected($event)"
+      [disableAutoSelect]="true">
     </perun-web-apps-vo-search-select>
   </div>
 </div>

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-member-organizations/add-member-organization-dialog/add-member-organization-dialog.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-member-organizations/add-member-organization-dialog/add-member-organization-dialog.component.html
@@ -5,7 +5,7 @@
   <mat-spinner *ngIf="loading" class="ms-auto me-auto"></mat-spinner>
   <div *ngIf="!loading" mat-dialog-content class="dialog-container">
     <mat-stepper #stepper [linear]="true">
-      <mat-step>
+      <mat-step [completed]="!(voSelection.selected.length === 0)">
         <ng-template
           matStepLabel
           >{{'VO_DETAIL.SETTINGS.MEMBER_ORGANIZATIONS.ADD_MEMBER_ORGANIZATION.SELECTION_STEP' | translate}}</ng-template


### PR DESCRIPTION
* fixed a bug where user could skip to second step of the add member org dialog without actually picking a VO
* removed "No filter" dummy objects from resource assigned users page filters
* fixed a bug where the bans table for the member wouldn't load if the user had no bans, also added Vo object to the EnrichedBanForVo object to avoid exceptions in ban on entity list
* fixed a bug where user could try to add a group inclusion without a VO selected, resulting in an empty dialog