### PR TITLE
build: fix maven build after updating Angular to version 15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>${frontend-plugin.version}</version>
         <configuration>
-          <nodeVersion>v15.5.1</nodeVersion>
-          <npmVersion>7.19.0</npmVersion>
+          <nodeVersion>v18.15.0</nodeVersion>
+          <npmVersion>9.5.0</npmVersion>
           <workingDirectory>src/main/web/</workingDirectory>
         </configuration>
         <executions>
@@ -38,6 +38,9 @@
             <goals>
               <goal>npm</goal>
             </goals>
+            <configuration>
+              <arguments>install --legacy-peer-deps</arguments>
+            </configuration>
           </execution>
           <execution>
             <id>admin-gui</id>


### PR DESCRIPTION
* In the maven pom.xml file node version upgraded, npm version upgraded and temporarily added parameter --legacy-peer-deps to npm install.