### PR TITLE
fix: browser history for change password dialog

### DIFF
--- a/libs/perun/components/src/lib/password-reset/password-reset.component.ts
+++ b/libs/perun/components/src/lib/password-reset/password-reset.component.ts
@@ -95,13 +95,19 @@ export class PasswordResetComponent implements OnInit {
 
     const dialogRef = this.dialog.open(ChangePasswordDialogComponent, config);
 
-    dialogRef.afterClosed().subscribe(() => {
-      void this.router.navigate([], {
-        queryParams: {
-          namespace: null,
-        },
-        queryParamsHandling: 'merge',
-      });
+    dialogRef.afterClosed().subscribe((state) => {
+      if (state === undefined) {
+        // closed by browser back button
+        void this.router.navigate([], {
+          queryParams: {
+            namespace: null,
+          },
+          queryParamsHandling: 'merge',
+        });
+      } else {
+        // Confirmed or Closed by buttons
+        window.history.back();
+      }
     });
   }
 }


### PR DESCRIPTION
* There was a bug during the process of changing password - when user is in the dialog and finish the it by clicking on Cancel or Confirm, then the browser back button behaves incorrectly.