### PR TITLE
fix: fixed bug that caused overlay components to block gui

### DIFF
--- a/apps/admin-gui/src/app/core/services/common/cache-route-reuse-strategy.ts
+++ b/apps/admin-gui/src/app/core/services/common/cache-route-reuse-strategy.ts
@@ -111,6 +111,12 @@ export class CacheRouteReuseStrategy implements RouteReuseStrategy {
     while (document.getElementsByTagName('mat-tooltip-component').length > 0) {
       document.getElementsByTagName('mat-tooltip-component')[0].remove();
     }
+    // Do not cache components in the overlay to prevent a bug where they would stay on screen after rerouting
+    if (document.getElementsByClassName('cdk-overlay-container').length > 0) {
+      while (document.getElementsByClassName('cdk-overlay-container')[0].children.length > 0) {
+        document.getElementsByClassName('cdk-overlay-container')[0].children[0].remove();
+      }
+    }
 
     this.handlers.set(this.getKey(route), {
       routeHandle: detachedTree,


### PR DESCRIPTION
* if the back button was used while an overlay component was present on a cached page, the component would not close and block the rest of the gui
* components in the overlay are no longer cached