### PR TITLE
fix(profile): add a meaningful error message when call to MFA API fails.

### DIFF
--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component.html
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component.html
@@ -2,7 +2,7 @@
 <div [hidden]="loadingMfa">
   <span
     class="toggle-and-button"
-    [matTooltip]="'AUTHENTICATION.MFA_DISABLED' | customTranslate | translate"
+    [matTooltip]="errorTooltip | customTranslate | translate"
     [matTooltipDisabled]="mfaAvailable"
     matTooltipPosition="right">
     <mat-slide-toggle

--- a/apps/user-profile/src/app/pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component.ts
+++ b/apps/user-profile/src/app/pages/settings-page/settings-authorization/mfa-settings/mfa-settings.component.ts
@@ -23,6 +23,7 @@ export class MfaSettingsComponent implements OnInit {
 
   mfaAvailable = false;
   loadingMfa = false;
+  errorTooltip = 'AUTHENTICATION.MFA_DISABLED';
 
   enforceMfa: boolean;
   enableDetailSettings: boolean;
@@ -60,6 +61,7 @@ export class MfaSettingsComponent implements OnInit {
       },
       error: (err) => {
         console.error(err);
+        this.errorTooltip = 'AUTHENTICATION.MFA_ERROR';
         this.loadingMfa = false;
       },
     });

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -139,6 +139,7 @@
     "MFA": "Vícefázové ověření",
     "MFA_TOGGLE": "Zapnout vícefázové ověření pro všechny služby",
     "MFA_DISABLED": "Potřebujete mít alespoň jeden aktivní MFA token.",
+    "MFA_ERROR": "Při ověřování dostupnosti MFA došlo k chybě, prosím opakujte akci později.",
     "MFA_SAVE": "Uložit nastavení",
     "NEW_IMG": "Nový obrázek",
     "DELETE_IMG": "Vymazat obrázek",

--- a/apps/user-profile/src/assets/i18n/en.json
+++ b/apps/user-profile/src/assets/i18n/en.json
@@ -139,6 +139,7 @@
     "MFA": "Multi-factor authentication",
     "MFA_TOGGLE": "Turn on multi-factor authentication for all services",
     "MFA_DISABLED": "You need to have at least one active MFA token.",
+    "MFA_ERROR": "An error occurred while verifying MFA availability, please try again later.",
     "MFA_SAVE": "Save settings",
     "NEW_IMG": "New image",
     "DELETE_IMG": "Delete image",


### PR DESCRIPTION
* when call to MFA API fails on setting-auth page, display meaningful message instead of telling the user he has no active MFA tokens