### PR TITLE
feat: use cookies in requests

### DIFF
--- a/apps/admin-gui/src/app/app.module.ts
+++ b/apps/admin-gui/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { NgScrollbarModule } from 'ngx-scrollbar';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { PerunLoginModule } from '@perun-web-apps/perun/login';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
+import { isRunningLocally } from '@perun-web-apps/perun/utils';
 
 export const API_INTERCEPTOR_PROVIDER: Provider = {
   provide: HTTP_INTERCEPTORS,
@@ -41,7 +42,7 @@ export function httpLoaderFactory(http: HttpClient): TranslateHttpLoader {
 export function apiConfigFactory(store: StoreService): Configuration {
   const params: ConfigurationParameters = {
     basePath: store.getProperty('api_url'),
-    // set configuration parameters here.
+    withCredentials: !isRunningLocally() /* add cookies to keep same session for BA access */,
   };
   return new Configuration(params);
 }

--- a/apps/consolidator/src/app/app.module.ts
+++ b/apps/consolidator/src/app/app.module.ts
@@ -25,7 +25,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
 import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
-import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
+import { isRunningLocally, PerunUtilsModule } from '@perun-web-apps/perun/utils';
 import { GeneralModule } from '@perun-web-apps/general';
 import { LibLinkerModule } from '@perun-web-apps/lib-linker';
 import { ListOfIdentitiesComponent } from './components/list-of-identities/list-of-identities.component';
@@ -44,6 +44,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
 export function apiConfigFactory(store: StoreService): Configuration {
   const params: ConfigurationParameters = {
     basePath: store.getProperty('api_url'),
+    withCredentials: !isRunningLocally() /* add cookies to keep same session for BA access */,
   };
   return new Configuration(params);
 }

--- a/apps/linker/src/app/app.module.ts
+++ b/apps/linker/src/app/app.module.ts
@@ -22,7 +22,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { UiAlertsModule } from '@perun-web-apps/ui/alerts';
 import { UiLoadersModule } from '@perun-web-apps/ui/loaders';
-import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
+import { isRunningLocally, PerunUtilsModule } from '@perun-web-apps/perun/utils';
 import { GeneralModule } from '@perun-web-apps/general';
 import { OAuthModule } from 'angular-oauth2-oidc';
 import { LibLinkerModule } from '@perun-web-apps/lib-linker';
@@ -43,6 +43,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
 export function apiConfigFactory(store: StoreService): Configuration {
   const params: ConfigurationParameters = {
     basePath: store.getProperty('api_url'),
+    withCredentials: !isRunningLocally() /* add cookies to keep same session for BA access */,
   };
   return new Configuration(params);
 }

--- a/apps/password-reset/src/app/app.module.ts
+++ b/apps/password-reset/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { InvalidRequestAlertComponent } from './components/invalid-request-alert
 import { PerunNamespacePasswordFormModule } from '@perun-web-apps/perun/namespace-password-form';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 import { PerunLoginModule } from '@perun-web-apps/perun/login';
+import { isRunningLocally } from '@perun-web-apps/perun/utils';
 
 export const API_INTERCEPTOR_PROVIDER: Provider = {
   provide: HTTP_INTERCEPTORS,
@@ -42,6 +43,7 @@ export function httpLoaderFactory(http: HttpClient): TranslateHttpLoader {
 export function apiConfigFactory(store: StoreService): Configuration {
   const params: ConfigurationParameters = {
     basePath: store.getProperty('api_url'),
+    withCredentials: !isRunningLocally() /* add cookies to keep same session for BA access */,
   };
   return new Configuration(params);
 }

--- a/apps/publications/src/app/app.module.ts
+++ b/apps/publications/src/app/app.module.ts
@@ -51,7 +51,7 @@ import { AddAuthorsComponent } from './components/add-authors/add-authors.compon
 import { AddThanksComponent } from './components/add-thanks/add-thanks.component';
 import { ImportPublicationsPageComponent } from './pages/create-publication-page/import-publications-page/import-publications-page.component';
 import { YearRangeComponent } from './components/year-range/year-range.component';
-import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
+import { isRunningLocally, PerunUtilsModule } from '@perun-web-apps/perun/utils';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { PerunSharedComponentsModule } from '@perun-web-apps/perun/components';
 
@@ -68,6 +68,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
 export function apiConfigFactory(store: StoreService): Configuration {
   const params: ConfigurationParameters = {
     basePath: store.getProperty('api_url'),
+    withCredentials: !isRunningLocally() /* add cookies to keep same session for BA access */,
   };
   return new Configuration(params);
 }

--- a/apps/user-profile/src/app/app.module.ts
+++ b/apps/user-profile/src/app/app.module.ts
@@ -64,7 +64,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AddAuthImgDialogComponent } from './components/dialogs/add-auth-img-dialog/add-auth-img-dialog.component';
 import { MatRadioModule } from '@angular/material/radio';
 import { PerunLoginModule } from '@perun-web-apps/perun/login';
-import { PerunUtilsModule } from '@perun-web-apps/perun/utils';
+import { isRunningLocally, PerunUtilsModule } from '@perun-web-apps/perun/utils';
 import { MatMenuModule } from '@angular/material/menu';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { ConsentsPageComponent } from './pages/consents-page/consents-page.component';
@@ -92,6 +92,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
 export function apiConfigFactory(store: StoreService): Configuration {
   const params: ConfigurationParameters = {
     basePath: store.getProperty('api_url'),
+    withCredentials: !isRunningLocally() /* add cookies to keep same session for BA access */,
   };
   return new Configuration(params);
 }

--- a/libs/perun/utils/src/lib/perun-utils.ts
+++ b/libs/perun/utils/src/lib/perun-utils.ts
@@ -868,3 +868,10 @@ export function isMemberIndirectString(member: RichMember): string {
 export function containsExactlyInAnyOrder(array1: string[], array2: string[]): boolean {
   return array1.length === array2.length && array1.every((v) => array2.includes(v));
 }
+
+/**
+ * Return true, if GUI is run locally, false otherwise.
+ */
+export function isRunningLocally(): boolean {
+  return location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+}


### PR DESCRIPTION
* without sending cookies, sessions for service-access (basic auth) are renewed on backend for each request
* that causes extsource loa to be updated which then updates relevant attribute (2 audit messages for EACH request!)
* this was not a problem for oidc access, because session was not renewed in case of missing cookies
* withCredentials header will solve problem for renewing sessions, but requests will fail if apache configuration does not allow domain for this behavior
* localhost is not supported origin, therefore we only add withCredentials header to calls from domain not coming from localhost