### PR TITLE
fix(admin): align icons of Manageable entities on home page with text

### DIFF
--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-card/dashboard-card.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-dashboard/dashboard-card/dashboard-card.component.html
@@ -1,6 +1,6 @@
 <div class="card p-3">
-  <div class="flex-column card-title">
-    <mat-icon [svgIcon]="svgIcon" class="cover-image"></mat-icon>
+  <div class="d-flex flex-row align-items-center gap-2 card-title">
+    <mat-icon [svgIcon]="svgIcon" class="d-flex cover-image"></mat-icon>
     {{this.title | translate}}
     <span matTooltip="{{this.roleTooltipInfo | translate }}" matTooltipPosition="above">
       <mat-icon class="dashboard-icon">info_outline</mat-icon>


### PR DESCRIPTION
Added display property for cover-image to align icons with the text.