### PR TITLE
fix(admin): authorization for delete facility

### DIFF
--- a/apps/admin-gui/src/app/facilities/pages/facility-select-page/facility-select-page.component.html
+++ b/apps/admin-gui/src/app/facilities/pages/facility-select-page/facility-select-page.component.html
@@ -19,16 +19,21 @@
     color="accent">
     {{'FACILITY_MANAGEMENT.CREATE' | translate}}
   </button>
-  <button
-    mat-flat-button
-    class="me-2"
-    data-cy="delete-facility-button"
-    [disabled]="selection.selected.length === 0"
-    *ngIf="deleteAuth"
-    (click)="onDelete()"
-    color="warn">
-    {{'FACILITY_MANAGEMENT.DELETE' | translate}}
-  </button>
+  <span
+    [matTooltipDisabled]="selection.selected.length === 0 || ([selection.selected[0]?.facility] | isAuthorized: 'deleteFacility_Facility_Boolean_policy')"
+    [matTooltipPosition]="'below'"
+    matTooltip="{{'FACILITY_MANAGEMENT.DELETE_PERMISSION_HINT' | translate}}">
+    <button
+      mat-flat-button
+      class="me-2"
+      data-cy="delete-facility-button"
+      [disabled]="selection.selected.length === 0 || !([selection.selected[0]?.facility] | isAuthorized: 'deleteFacility_Facility_Boolean_policy')"
+      *ngIf="deleteAuth"
+      (click)="onDelete()"
+      color="warn">
+      {{'FACILITY_MANAGEMENT.DELETE' | translate}}
+    </button>
+  </span>
   <perun-web-apps-immediate-filter
     [autoFocus]="true"
     (filter)="applyFilter($event)"

--- a/apps/admin-gui/src/app/facilities/pages/facility-select-page/facility-select-page.component.ts
+++ b/apps/admin-gui/src/app/facilities/pages/facility-select-page/facility-select-page.component.ts
@@ -37,10 +37,7 @@ export class FacilitySelectPageComponent implements OnInit, AfterViewChecked {
 
   ngOnInit(): void {
     this.createAuth = this.guiAuthResolver.isAuthorized('createFacility_Facility_policy', []);
-    this.deleteAuth = this.guiAuthResolver.isAuthorized(
-      'deleteFacility_Facility_Boolean_policy',
-      []
-    );
+    this.deleteAuth = this.guiAuthResolver.isFacilityAdmin();
     this.refreshTable();
   }
 

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -72,7 +72,8 @@
     "TITLE": "Select facility",
     "FILTER_PLACEHOLDER": "Filter by name, Id, description, owner, host or destination",
     "CREATE": "Create",
-    "DELETE": "Delete"
+    "DELETE": "Delete",
+    "DELETE_PERMISSION_HINT": "You don't have permission to delete selected facility"
   },
   "CONSENTS": {
     "STATUS": "Consent status",


### PR DESCRIPTION
* There was used a policy which evaluates also given object (facility), so there is not possible to paste an empty array.
* Now the button is removed, when user doesn't have any suficient role (facility admin or perun admin) and if user has facility admin, authorization for selected facility will be evaluated additionally.
* This issue was discovered thanks to e2e tests and this PR should fix then again.