### PR TITLE
fix(lib): remove white spaces from the full name pipe

### DIFF
--- a/libs/perun/pipes/src/lib/user-full-name.pipe.ts
+++ b/libs/perun/pipes/src/lib/user-full-name.pipe.ts
@@ -14,6 +14,6 @@ export class UserFullNamePipe implements PipeTransform {
       value.titleAfter,
     ];
 
-    return nameParts.join(' ');
+    return nameParts.filter((part) => !!part).join(' ');
   }
 }


### PR DESCRIPTION
* All parts of full name are joined with space, but if there is some part of the name missing (e.g. middle name), there are more white spaces in the full name.