### PR TITLE
fix: do not show sesssion expiration dialog during mfa

### DIFF
--- a/libs/perun/services/src/lib/ApiInterceptor.ts
+++ b/libs/perun/services/src/lib/ApiInterceptor.ts
@@ -51,7 +51,8 @@ export class ApiInterceptor implements HttpInterceptor {
       apiUrl !== undefined &&
       this.isCallToPerunApi(req.url) &&
       !this.isLoggedIn() &&
-      !this.dialogRefSessionExpiration
+      !this.dialogRefSessionExpiration &&
+      !sessionStorage.getItem('mfaRequired')
     ) {
       const config = getDefaultDialogConfig();
       config.width = '450px';


### PR DESCRIPTION
* There was a bug that during step-up authentication process the session expiration dialog was shown.
* I believe that this one added condition should solve this problem without any other side effects.