### PR TITLE
fix: Unify member status and expiration change

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/copy-sponsored-members-dialog/copy-sponsored-members-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/copy-sponsored-members-dialog/copy-sponsored-members-dialog.component.html
@@ -51,7 +51,10 @@
         </perun-web-apps-alert>
         <h6>{{'DIALOGS.COPY_SPONSORED_MEMBERS.EXPIRATION' | translate}}</h6>
         <mat-checkbox [(ngModel)]="pickExpiration">Pick new expiration date</mat-checkbox>
-        <perun-web-apps-expiration-select *ngIf="pickExpiration" (datePicker)="expiration = $event">
+        <perun-web-apps-expiration-select
+          *ngIf="pickExpiration"
+          [minDate]="minDate"
+          (expirationSelected)="expiration = $event">
         </perun-web-apps-expiration-select>
       </div>
     </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/copy-sponsored-members-dialog/copy-sponsored-members-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/copy-sponsored-members-dialog/copy-sponsored-members-dialog.component.ts
@@ -43,6 +43,7 @@ export class CopySponsoredMembersDialogComponent implements OnInit {
   sourceSponsorSelected = false;
   filter: string;
   expiration = 'never';
+  minDate = new Date();
   pickExpiration = false;
   disableSelf = false;
   isPerunAdmin = false;

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.html
@@ -141,7 +141,7 @@
             <h6 class="mt-4">{{'DIALOGS.CREATE_SPONSORED_MEMBER.EXPIRATION' | translate}}</h6>
             <perun-web-apps-expiration-select
               [minDate]="minDate"
-              (datePicker)="setExpiration($event)"
+              (expirationSelected)="setExpiration($event)"
               class="mt-2">
             </perun-web-apps-expiration-select>
           </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-sponsored-member-dialog/create-sponsored-member-dialog.component.ts
@@ -24,7 +24,6 @@ import {
   StoreService,
 } from '@perun-web-apps/perun/services';
 import { UntypedFormBuilder, UntypedFormGroup, ValidatorFn, Validators } from '@angular/forms';
-import { formatDate } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 import { CustomValidators, emailRegexString, enableFormControl } from '@perun-web-apps/perun/utils';
 import { loginAsyncValidator } from '@perun-web-apps/perun/namespace-password-form';
@@ -245,11 +244,7 @@ export class CreateSponsoredMemberDialogComponent implements OnInit, AfterViewIn
   }
 
   setExpiration(newExpiration: string): void {
-    if (newExpiration === 'never') {
-      this.expiration = 'never';
-    } else {
-      this.expiration = formatDate(newExpiration, 'yyyy-MM-dd', 'en-GB');
-    }
+    this.expiration = newExpiration;
   }
 
   getStepperNextConditions(): boolean {

--- a/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.html
@@ -110,7 +110,7 @@
           <div class="mt-2">
             <h5 class="mb-4">{{'DIALOGS.GENERATE_SPONSORED_MEMBERS.EXPIRATION' | translate}}</h5>
             <perun-web-apps-expiration-select
-              (datePicker)="setExpiration($event)"
+              (expirationSelected)="setExpiration($event)"
               [minDate]="minDate"
               [expiration]="expiration">
             </perun-web-apps-expiration-select>

--- a/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/generate-sponsored-members-dialog/generate-sponsored-members-dialog.component.ts
@@ -148,11 +148,7 @@ export class GenerateSponsoredMembersDialogComponent implements OnInit {
   }
 
   setExpiration(newExpiration: string): void {
-    if (newExpiration === 'never') {
-      this.expiration = 'never';
-    } else {
-      this.expiration = formatDate(newExpiration, 'yyyy-MM-dd', 'en-GB');
-    }
+    this.expiration = newExpiration;
   }
 
   onSubmit(): void {

--- a/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.html
@@ -55,7 +55,9 @@
     <div>
       <br />
       <h6>{{'DIALOGS.SPONSOR_EXISTING_MEMBER.EXPIRATION' | translate}}</h6>
-      <perun-web-apps-expiration-select [minDate]="minDate" (datePicker)="setExpiration($event)">
+      <perun-web-apps-expiration-select
+        [minDate]="minDate"
+        (expirationSelected)="setExpiration($event)">
       </perun-web-apps-expiration-select>
     </div>
   </div>

--- a/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/sponsor-existing-member-dialog/sponsor-existing-member-dialog.component.ts
@@ -6,7 +6,6 @@ import {
   StoreService,
 } from '@perun-web-apps/perun/services';
 import { MembersManagerService, RichMember, RichUser, User } from '@perun-web-apps/perun/openapi';
-import { formatDate } from '@angular/common';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { SelectionModel } from '@angular/cdk/collections';
 import { Urns } from '@perun-web-apps/perun/urns';
@@ -95,11 +94,7 @@ export class SponsorExistingMemberDialogComponent implements OnInit {
   }
 
   setExpiration(newExpiration: string): void {
-    if (newExpiration === 'never') {
-      this.expiration = 'never';
-    } else {
-      this.expiration = formatDate(newExpiration, 'yyyy-MM-dd', 'en-GB');
-    }
+    this.expiration = newExpiration;
   }
 
   onSearchByString(): void {

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1590,7 +1590,7 @@
       "CHANGE_NO_VALID_TO_DISABLED": "DISABLED status means that the member is archived and is not allowed to any services. Member can't enable/extend membership by himself.",
       "SUCCESS": "Member status was changed",
       "CANCEL": "Cancel",
-      "BACK": "Back",
+      "CLOSE": "Close",
       "CHANGE_STATUS": "Change status",
       "CHANGE_STATUS_WITH_EXPIRATION": "Change status and set expiration"
     },
@@ -1875,9 +1875,9 @@
     },
     "CHANGE_EXPIRATION": {
       "CURRENT_EXPIRATION": "Current expiration: ",
-      "NEW_EXPIRATION": "New expiration:         ",
+      "SELECT_NEW": "Select new expiration date.",
       "DATE_LABEL": "Expire to a date",
-      "VO_RULES": "Set by organization rules",
+      "VO_RULES": "Set by Organization rules",
       "GROUP_RULES": "Set by Group rules",
       "EXPIRATION_NEVER": "Never expire",
       "WRONG_FORMAT": "The date has to be in format yyyy-mm-dd",

--- a/libs/perun/components/src/lib/change-member-status-or-expiration-dialog/change-member-status-or-expiration-dialog.component.html
+++ b/libs/perun/components/src/lib/change-member-status-or-expiration-dialog/change-member-status-or-expiration-dialog.component.html
@@ -1,23 +1,17 @@
 <div class="{{theme}}">
   <div class="dialog-container" mat-dialog-content>
-    <perun-web-apps-member-overview-membership
-      *ngIf="!groupId"
-      [member]="member"
-      [voId]="voId"
-      [openedInDialog]="true"
-      (statusChanged)="statusChanged = $event">
+    <perun-web-apps-member-overview-membership *ngIf="!groupId" [member]="member" [voId]="voId">
     </perun-web-apps-member-overview-membership>
     <perun-web-apps-member-overview-groups
       *ngIf="groupId"
       [member]="member"
       [voId]="voId"
-      [openedInDialog]="true"
-      (statusChanged)="statusChanged = $event">
+      [requiresGroupSelect]="false">
     </perun-web-apps-member-overview-groups>
   </div>
   <div mat-dialog-actions>
-    <button (click)="cancel()" class="ms-auto" mat-flat-button>
-      {{'DIALOGS.CHANGE_STATUS.CANCEL' | translate}}
+    <button (click)="close()" class="ms-auto" mat-flat-button>
+      {{'DIALOGS.CHANGE_STATUS.CLOSE' | translate}}
     </button>
   </div>
 </div>

--- a/libs/perun/components/src/lib/change-member-status-or-expiration-dialog/change-member-status-or-expiration-dialog.component.ts
+++ b/libs/perun/components/src/lib/change-member-status-or-expiration-dialog/change-member-status-or-expiration-dialog.component.ts
@@ -18,7 +18,6 @@ export class ChangeMemberStatusOrExpirationDialogComponent implements OnInit {
   voId: number;
   groupId: number;
   member: RichMember;
-  statusChanged = false;
 
   constructor(
     public dialogRef: MatDialogRef<ChangeMemberStatusOrExpirationDialogComponent>,
@@ -32,11 +31,7 @@ export class ChangeMemberStatusOrExpirationDialogComponent implements OnInit {
     this.member = this.data.member;
   }
 
-  cancel(): void {
-    if (this.statusChanged) {
-      this.dialogRef.close();
-    } else {
-      this.dialogRef.close('closedWithoutChange');
-    }
+  close(): void {
+    this.dialogRef.close();
   }
 }

--- a/libs/perun/components/src/lib/member-overview-groups/member-overview-groups.component.html
+++ b/libs/perun/components/src/lib/member-overview-groups/member-overview-groups.component.html
@@ -1,65 +1,33 @@
-<mat-card-header *ngIf="!openedInDialog">
-  <mat-card-title>
-    <h1 class="page-subtitle">{{'MEMBER_DETAIL.OVERVIEW.GROUP_MEMBERSHIP' | translate}}</h1>
-  </mat-card-title>
-</mat-card-header>
-<h1 *ngIf="openedInDialog" mat-dialog-title>
-  {{'MEMBER_DETAIL.OVERVIEW.GROUP_MEMBERSHIP' | translate}}
-</h1>
-<mat-card-content class="column-center">
-  <perun-web-apps-group-search-select
-    *ngIf="!initLoading && !openedInDialog"
-    (groupSelected)="groupIsSelected($event)"
-    [firstSelectedGroup]="selectedGroup"
-    [groups]="groups">
-  </perun-web-apps-group-search-select>
-  <mat-spinner *ngIf="(loading || initLoading) && !noGroups" class="me-auto ms-auto"></mat-spinner>
-  <perun-web-apps-alert
-    alert_type="warn"
-    *ngIf="noGroups"
-    >{{'MEMBER_DETAIL.OVERVIEW.NO_GROUPS_FOUND' | translate}}</perun-web-apps-alert
-  >
-  <div *ngIf="!loading">
-    <table
-      [dataSource]="groupMembershipDataSource"
-      [class]="openedInDialog ? 'me-auto' : 'ms-auto me-auto'"
-      mat-table>
-      <ng-container matColumnDef="attName">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let attribute" class="fw-bold" mat-cell>{{attribute}}:</td>
-      </ng-container>
-      <ng-container matColumnDef="attValue">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let attribute" class="column-center" mat-cell>
-          <div class="d-flex align-items-center" *ngIf="attribute === 'Status'">
-            <i
-              class="material-icons vert-center me-1 {{(selectedMember.groupStatus | groupStatusIconColor)}}">
-              {{selectedMember.groupStatus | memberStatusIcon}}
-            </i>
-            <b class="vert-top">
-              {{selectedMember.groupStatus | transformMemberStatus}}
-            </b>
-            <button
-              *ngIf="authResolver.isThisVoAdmin(voId) || authResolver.isThisGroupAdmin(selectedGroup.id)"
-              (click)="changeStatus()"
-              mat-icon-button>
-              <mat-icon>edit</mat-icon>
-            </button>
-          </div>
-          <div class="d-flex align-items-center" *ngIf="attribute === 'Expiration'">
-            <i class="column-center">
-              {{expiration | parseDate}}
-            </i>
-            <button
-              *ngIf="authResolver.isThisVoAdmin(voId) || authResolver.isThisGroupAdmin(selectedGroup.id)"
-              (click)="changeExpiration()"
-              mat-icon-button>
-              <mat-icon>edit</mat-icon>
-            </button>
-          </div>
-        </td>
-      </ng-container>
-      <tr *matRowDef="let attribute; columns: displayedColumns;" mat-row></tr>
-    </table>
+<div *perunWebAppsLoader="loading; indicator: spinner">
+  <mat-card-header>
+    <mat-card-title>
+      <h1 class="page-subtitle">{{'MEMBER_DETAIL.OVERVIEW.GROUP_MEMBERSHIP' | translate}}</h1>
+    </mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <perun-web-apps-group-search-select
+      *ngIf="requiresGroupSelect"
+      (groupSelected)="groupIsSelected($event)"
+      [firstSelectedGroup]="selectedGroup"
+      [groups]="groups">
+    </perun-web-apps-group-search-select>
+    <perun-web-apps-alert *ngIf="groups.length === 0" alert_type="warn">
+      {{'MEMBER_DETAIL.OVERVIEW.NO_GROUPS_FOUND' | translate}}
+    </perun-web-apps-alert>
+    <perun-web-apps-membership-status-settings
+      *ngIf="groups.length !== 0 && selectedMember"
+      [status]="selectedMember.groupStatus"
+      [editStatusAuth]="editAuth"
+      [editExpirationAuth]="editAuth"
+      [expiration]="expiration"
+      [showExpiration]="showExpiration"
+      (changeStatus)="changeStatus()"
+      (changeExpiration)="changeExpiration()">
+    </perun-web-apps-membership-status-settings>
+  </mat-card-content>
+</div>
+<ng-template #spinner>
+  <div class="spinner-container">
+    <mat-spinner></mat-spinner>
   </div>
-</mat-card-content>
+</ng-template>

--- a/libs/perun/components/src/lib/member-overview-membership/member-overview-membership.component.html
+++ b/libs/perun/components/src/lib/member-overview-membership/member-overview-membership.component.html
@@ -1,55 +1,25 @@
-<mat-card-header *ngIf="!openedInDialog">
-  <mat-card-title>
-    <h1 class="page-subtitle">
-      {{'MEMBER_DETAIL.OVERVIEW.ORGANIZATION_MEMBERSHIP' | translate}}
-    </h1>
-  </mat-card-title>
-</mat-card-header>
-<h1 *ngIf="openedInDialog" mat-dialog-title>
-  {{'MEMBER_DETAIL.OVERVIEW.ORGANIZATION_MEMBERSHIP' | translate}}
-</h1>
-<mat-card-content>
-  <mat-spinner *ngIf="loading" class="me-auto ms-auto"></mat-spinner>
-  <div *ngIf="!loading">
-    <table
-      [dataSource]="voMembershipDataSource"
-      [class]="openedInDialog ? 'me-auto' : 'ms-auto me-auto'"
-      mat-table>
-      <ng-container matColumnDef="attName">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let attribute" class="fw-bold" mat-cell>{{attribute}}:</td>
-      </ng-container>
-      <ng-container matColumnDef="attValue">
-        <th *matHeaderCellDef mat-header-cell></th>
-        <td *matCellDef="let attribute" class="column-center" mat-cell>
-          <div class="d-flex align-items-center" *ngIf="attribute === 'Status'">
-            <i class="material-icons vert-center me-1 {{(member | memberStatusIconColor)}}">
-              {{member.status | memberStatusIcon}}
-            </i>
-            <b class="vert-top">
-              {{member.status | transformMemberStatus}}
-            </b>
-            <button
-              *ngIf="authResolver.isThisVoAdmin(voId) && !(member | memberStatusDisabled)"
-              (click)="changeStatus()"
-              mat-icon-button>
-              <mat-icon>edit</mat-icon>
-            </button>
-          </div>
-          <div class="d-flex align-items-center" *ngIf="attribute === 'Expiration'">
-            <i class="column-center">
-              {{voExpiration | parseDate}}
-            </i>
-            <button
-              *ngIf="authResolver.isThisVoAdmin(voId) && !(member | memberStatusDisabled)"
-              (click)="changeVoExpiration()"
-              mat-icon-button>
-              <mat-icon>edit</mat-icon>
-            </button>
-          </div>
-        </td>
-      </ng-container>
-      <tr *matRowDef="let attribute; columns: displayedColumns;" mat-row></tr>
-    </table>
+<div *perunWebAppsLoader="loading; indicator: spinner">
+  <mat-card-header>
+    <mat-card-title>
+      <h1 class="page-subtitle">
+        {{'MEMBER_DETAIL.OVERVIEW.ORGANIZATION_MEMBERSHIP' | translate}}
+      </h1>
+    </mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <perun-web-apps-membership-status-settings
+      [status]="member.status"
+      [editStatusAuth]="editAuth"
+      [editExpirationAuth]="editAuth"
+      [expiration]="expiration"
+      [showExpiration]="expirationAuth && expirationRelevant"
+      (changeStatus)="changeStatus()"
+      (changeExpiration)="changeExpiration()">
+    </perun-web-apps-membership-status-settings>
+  </mat-card-content>
+</div>
+<ng-template #spinner>
+  <div class="spinner-container">
+    <mat-spinner></mat-spinner>
   </div>
-</mat-card-content>
+</ng-template>

--- a/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.ts
+++ b/libs/perun/components/src/lib/members-dynamic-list/members-dynamic-list.component.ts
@@ -198,15 +198,13 @@ export class MembersDynamicListComponent implements AfterViewInit, OnInit, OnCha
     } else if (!this.expireGroupAuth || this.isMembersGroup || indirect === 'INDIRECT') return;
 
     const config = getDefaultDialogConfig();
-    config.minWidth = '280px';
+    config.width = '400px';
     config.data = { member: member, voId: this.voId, groupId: groupId };
 
     const dialogRef = this.dialog.open(ChangeMemberStatusOrExpirationDialogComponent, config);
 
-    dialogRef.afterClosed().subscribe((result) => {
-      if (!result) {
-        this.loadMembersPage();
-      }
+    dialogRef.afterClosed().subscribe(() => {
+      this.loadMembersPage();
     });
   }
 

--- a/libs/perun/components/src/lib/membership-status-settings/membership-status-settings.component.html
+++ b/libs/perun/components/src/lib/membership-status-settings/membership-status-settings.component.html
@@ -1,0 +1,24 @@
+<div class="d-flex flex-row align-items-center justify-content-between field-height">
+  <b>{{'MEMBER_DETAIL.OVERVIEW.STATUS' | translate}}</b>
+  <div class="d-flex flex-row align-items-center justify-content-center">
+    <i class="material-icons me-1 {{(status | groupStatusIconColor)}}">
+      {{status | memberStatusIcon}}
+    </i>
+    <span class="me-2">{{status | transformMemberStatus}}</span>
+    <button *ngIf="editStatusAuth" (click)="onChangeStatus()" mat-icon-button>
+      <mat-icon>edit</mat-icon>
+    </button>
+  </div>
+</div>
+<mat-divider *ngIf="showExpiration"></mat-divider>
+<div
+  *ngIf="showExpiration"
+  class="d-flex flex-row align-items-center align-items-center justify-content-between field-height">
+  <b>{{'MEMBER_DETAIL.OVERVIEW.EXPIRATION' | translate}}</b>
+  <div class="d-flex flex-row align-items-center justify-content-center">
+    <i class="me-2"> {{expiration | parseDate}} </i>
+    <button *ngIf="editExpirationAuth" (click)="onChangeExpiration()" mat-icon-button>
+      <mat-icon>edit</mat-icon>
+    </button>
+  </div>
+</div>

--- a/libs/perun/components/src/lib/membership-status-settings/membership-status-settings.component.scss
+++ b/libs/perun/components/src/lib/membership-status-settings/membership-status-settings.component.scss
@@ -1,0 +1,3 @@
+.field-height {
+  min-height: 50px;
+}

--- a/libs/perun/components/src/lib/membership-status-settings/membership-status-settings.component.ts
+++ b/libs/perun/components/src/lib/membership-status-settings/membership-status-settings.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'perun-web-apps-membership-status-settings',
+  templateUrl: './membership-status-settings.component.html',
+  styleUrls: ['./membership-status-settings.component.scss'],
+})
+export class MembershipStatusSettingsComponent {
+  @Input() status = '';
+  @Input() expiration: string;
+  @Input() showExpiration = true;
+  @Input() editExpirationAuth = false;
+  @Input() editStatusAuth = false;
+  @Output() changeStatus = new EventEmitter<void>();
+  @Output() changeExpiration = new EventEmitter<void>();
+
+  onChangeStatus(): void {
+    this.changeStatus.emit();
+  }
+
+  onChangeExpiration(): void {
+    this.changeExpiration.emit();
+  }
+}

--- a/libs/perun/components/src/lib/perun-components.module.ts
+++ b/libs/perun/components/src/lib/perun-components.module.ts
@@ -120,6 +120,7 @@ import { AuthorizedGroupsCellComponent } from './authorized-groups-cell/authoriz
 import { StringSearchSelectComponent } from './string-search-select/string-search-select.component';
 import { BlockedLoginsDynamicListComponent } from './blocked-logins-dynamic-list/blocked-logins-dynamic-list.component';
 import { NamespaceSearchSelectComponent } from './namespace-search-select/namespace-search-select.component';
+import { MembershipStatusSettingsComponent } from './membership-status-settings/membership-status-settings.component';
 
 @Injectable()
 export class AppDateAdapter extends NativeDateAdapter {
@@ -272,6 +273,7 @@ export const APP_DATE_FORMATS: MatDateFormats = {
     ShowNotificationHistoryDialogComponent,
     BlockedLoginsDynamicListComponent,
     NamespaceSearchSelectComponent,
+    MembershipStatusSettingsComponent,
   ],
   exports: [
     VosListComponent,

--- a/libs/perun/dialogs/src/lib/change-expiration-dialog/change-expiration-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-expiration-dialog/change-expiration-dialog.component.html
@@ -1,70 +1,27 @@
 <div class="member-theme">
   <div mat-dialog-content>
     <p>
-      <strong>{{'DIALOGS.CHANGE_EXPIRATION.CURRENT_EXPIRATION'|translate}}</strong>
+      <strong>
+        {{'DIALOGS.CHANGE_EXPIRATION.CURRENT_EXPIRATION' | translate}}
+      </strong>
       {{currentExpiration | parseDate}}
     </p>
-    <p>
-      <strong>{{'DIALOGS.CHANGE_EXPIRATION.NEW_EXPIRATION'|translate}}</strong>
-      {{newExpiration ? (newExpiration | parseDate) : 'never'}}
-    </p>
-
-    <mat-radio-group [(ngModel)]="newExpiration" class="d-flex flex-column">
-      <mat-radio-button value="{{expirationControl.value}}">
-        <mat-form-field color="primary" class="cursor-pointer" (click)="picker.open()">
-          <mat-label>{{'DIALOGS.CHANGE_EXPIRATION.DATE_LABEL'|translate}}</mat-label>
-          <input
-            (dateChange)="setExpiration()"
-            [min]="minDate"
-            [max]="maxDate"
-            [formControl]="expirationControl"
-            [matDatepicker]="picker"
-            class="disable"
-            readonly
-            matInput />
-          <mat-datepicker-toggle
-            [for]="picker"
-            [disabled]="false"
-            matSuffix></mat-datepicker-toggle>
-          <mat-datepicker #picker [disabled]="false"></mat-datepicker>
-        </mat-form-field>
-      </mat-radio-button>
-      <mat-radio-button
-        class="bottom-padding"
-        value="voRules"
-        *ngIf="canExtendMembership && mode === 'vo'">
-        {{'DIALOGS.CHANGE_EXPIRATION.VO_RULES'|translate}}
-      </mat-radio-button>
-      <mat-radio-button
-        class="bottom-padding"
-        value="groupRules"
-        *ngIf="canExtendMembership && mode === 'group'">
-        {{'DIALOGS.CHANGE_EXPIRATION.GROUP_RULES'|translate}}
-      </mat-radio-button>
-      <mat-radio-button value="never">
-        <span class="cursor-pointer">
-          {{'DIALOGS.CHANGE_EXPIRATION.EXPIRATION_NEVER'|translate}}
-        </span>
-      </mat-radio-button>
-    </mat-radio-group>
-    <perun-web-apps-alert
-      alert_type="info"
-      *ngIf="status === 'EXPIRED' && (newExpiration === 'never' || parseDate(expirationControl.value) > currentDate)"
-      >{{'DIALOGS.CHANGE_EXPIRATION.STATUS_CHANGE_INFO' | translate}}</perun-web-apps-alert
-    >
+    <p>{{'DIALOGS.CHANGE_EXPIRATION.SELECT_NEW' | translate}}</p>
+    <perun-web-apps-expiration-select
+      [expiration]="currentExpiration"
+      [allowNever]="status === 'VALID'"
+      [canExtendInVo]="canExtendInVo"
+      [canExtendInGroup]="canExtendInGroup"
+      [minDate]="minDate"
+      [maxDate]="maxDate"
+      (expirationSelected)="setExpiration($event)">
+    </perun-web-apps-expiration-select>
   </div>
   <div mat-dialog-actions>
-    <button (click)="onCancel()" class="ms-auto" mat-flat-button>
-      {{backButton ?
-      ('DIALOGS.CHANGE_EXPIRATION.BACK' | translate) :
-      ('DIALOGS.CHANGE_EXPIRATION.CANCEL' | translate)}}
+    <button (click)="onCancel()" class="ms-auto me-2" mat-flat-button>
+      {{'DIALOGS.CHANGE_EXPIRATION.CANCEL' | translate}}
     </button>
-    <button
-      (click)="onChange()"
-      [disabled]="expirationControl.invalid"
-      class="ms-2"
-      color="accent"
-      mat-flat-button>
+    <button (click)="onChangeExpiration()" color="accent" mat-flat-button>
       {{'DIALOGS.CHANGE_EXPIRATION.SAVE' | translate}}
     </button>
   </div>

--- a/libs/perun/dialogs/src/lib/change-expiration-dialog/change-expiration-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/change-expiration-dialog/change-expiration-dialog.component.ts
@@ -1,7 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
-import { formatDate } from '@angular/common';
 
 @Component({
   selector: 'perun-web-apps-change-expiration-dialog',
@@ -9,58 +7,44 @@ import { formatDate } from '@angular/common';
   styleUrls: ['./change-expiration-dialog.component.scss'],
 })
 export class ChangeExpirationDialogComponent implements OnInit {
-  @Input() currentExpiration: string;
-  @Input() newExpiration: string;
-  @Input() canExtendMembership = false;
-  @Input() minDate: Date;
-  @Input() maxDate: Date;
-  @Input() mode: 'group' | 'vo' | 'sponsor';
   @Input() status: string;
-  @Input() backButton: boolean;
+  @Input() currentExpiration: string;
+  @Input() canExtendInVo = false;
+  @Input() canExtendInGroup = false;
   @Output() expirationChanged: EventEmitter<string> = new EventEmitter<string>();
-  @Output() statusChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-  successMessage: string;
-  expirationControl: UntypedFormControl = new UntypedFormControl(null);
-  currentDate: string;
+  newExpiration: string;
+  minDate: Date;
+  maxDate: Date;
 
   constructor(private dialogRef: MatDialogRef<ChangeExpirationDialogComponent>) {}
 
   ngOnInit(): void {
-    const today = new Date();
-    this.currentDate = formatDate(
-      new Date(today.getFullYear(), today.getMonth(), today.getDate()),
-      'yyyy-MM-dd',
-      'en_US'
-    );
-    if (this.newExpiration !== 'never') {
-      this.expirationControl.setValue(this.newExpiration);
-    }
+    this.setDateBounds();
   }
 
-  parseDate(value: string): string {
-    return formatDate(value, 'yyyy-MM-dd', 'en_US');
-  }
-
-  onChange(): void {
-    if (
-      this.status === 'EXPIRED' &&
-      (this.newExpiration === 'never' ||
-        this.parseDate(this.expirationControl.value as string) > this.currentDate)
-    ) {
-      this.statusChange.emit(true);
-    }
+  onChangeExpiration(): void {
     this.expirationChanged.emit(this.newExpiration);
   }
 
   onCancel(): void {
-    this.dialogRef.close({ success: false });
+    this.dialogRef.close(false);
   }
 
-  setExpiration(): void {
-    this.newExpiration = formatDate(this.expirationControl.value as Date, 'yyyy-MM-dd', 'en');
-    this.expirationControl.setValue(
-      formatDate(this.expirationControl.value as Date, 'yyyy-MM-dd', 'en')
-    );
+  setExpiration(newExp: string): void {
+    this.newExpiration = newExp;
+  }
+
+  private setDateBounds(): void {
+    if (this.status === 'VALID') {
+      this.minDate = new Date();
+      this.maxDate = null;
+    } else if (this.status === 'EXPIRED') {
+      this.minDate = null;
+      this.maxDate = new Date();
+    } else {
+      // Change expiration of sponsorship
+      this.minDate = new Date();
+    }
   }
 }

--- a/libs/perun/dialogs/src/lib/change-group-expiration-dialog/change-group-expiration-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-group-expiration-dialog/change-group-expiration-dialog.component.html
@@ -5,15 +5,9 @@
   <div *perunWebAppsLoader="loading; indicator: spinner">
     <h1 mat-dialog-title>{{'DIALOGS.CHANGE_GROUP_EXPIRATION.TITLE' | translate}}</h1>
     <perun-web-apps-change-expiration-dialog
-      [minDate]="minDate"
-      [maxDate]="maxDate"
-      [currentExpiration]="currentExpiration"
-      [newExpiration]="newExpiration"
-      [canExtendMembership]="canExtendMembership"
-      [mode]="'group'"
       [status]="status"
-      [backButton]="backButton"
-      (statusChange)="changeStatus = true"
+      [currentExpiration]="expiration"
+      [canExtendInGroup]="canExtendMembership"
       (expirationChanged)="onExpirationChanged($event)">
     </perun-web-apps-change-expiration-dialog>
   </div>

--- a/libs/perun/dialogs/src/lib/change-group-expiration-dialog/change-group-expiration-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/change-group-expiration-dialog/change-group-expiration-dialog.component.ts
@@ -6,16 +6,15 @@ import {
   MembersManagerService,
 } from '@perun-web-apps/perun/openapi';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { TranslateService } from '@ngx-translate/core';
-import { NotificatorService } from '@perun-web-apps/perun/services';
+import { NotificatorService, PerunTranslateService } from '@perun-web-apps/perun/services';
 import { Urns } from '@perun-web-apps/perun/urns';
+import { iif, mergeMap, of, switchMap } from 'rxjs';
 
 export interface ChangeGroupExpirationDialogData {
   groupId: number;
   memberId: number;
   expirationAttr: Attribute;
   status: string;
-  backButton?: boolean;
 }
 
 @Component({
@@ -25,15 +24,9 @@ export interface ChangeGroupExpirationDialogData {
 })
 export class ChangeGroupExpirationDialogComponent implements OnInit {
   loading = false;
-  maxDate: Date;
-  minDate: Date;
-  currentExpiration: string;
-  newExpiration: string;
+  expiration: string;
   status: string;
   canExtendMembership = false;
-  changeStatus: boolean;
-  backButton: boolean;
-  private successMessage: string;
   private expirationAttr: Attribute = null;
 
   constructor(
@@ -42,54 +35,33 @@ export class ChangeGroupExpirationDialogComponent implements OnInit {
     private attributesManagerService: AttributesManagerService,
     private memberManager: MembersManagerService,
     private groupManager: GroupsManagerService,
-    private translate: TranslateService,
+    private translate: PerunTranslateService,
     private notificator: NotificatorService
-  ) {
-    translate
-      .get('DIALOGS.CHANGE_EXPIRATION.SUCCESS')
-      .subscribe((res: string) => (this.successMessage = res));
-  }
+  ) {}
 
   ngOnInit(): void {
-    this.status = this.data.status;
-    this.backButton = this.data.backButton;
     this.loading = true;
-    const currentDate = new Date();
-    if (this.data.status !== 'VALID') {
-      this.maxDate =
-        this.data.status === 'EXPIRED'
-          ? undefined
-          : new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
-    } else {
-      this.minDate = new Date(
-        currentDate.getFullYear(),
-        currentDate.getMonth(),
-        currentDate.getDate()
-      );
-    }
+    this.status = this.data.status;
 
     this.expirationAttr = this.data.expirationAttr;
-    this.currentExpiration = (this.expirationAttr?.value as string) ?? 'never';
-    this.newExpiration = this.currentExpiration;
+    this.expiration = (this.expirationAttr?.value as string) ?? 'never';
 
     if (this.data.status === 'VALID') {
       this.attributesManagerService
         .getGroupAttributeByName(this.data.groupId, Urns.GROUP_DEF_EXPIRATION_RULES)
+        .pipe(
+          switchMap((attr) => {
+            if (!attr.value) return of(false);
+            return this.groupManager.canExtendMembershipInGroup(
+              this.data.memberId,
+              this.data.groupId
+            );
+          })
+        )
         .subscribe({
-          next: (attr) => {
-            if (attr.value !== null) {
-              this.groupManager
-                .canExtendMembershipInGroup(this.data.memberId, this.data.groupId)
-                .subscribe({
-                  next: (canExtend) => {
-                    this.canExtendMembership = !!canExtend;
-                    this.loading = false;
-                  },
-                  error: () => (this.loading = false),
-                });
-            } else {
-              this.loading = false;
-            }
+          next: (canExtend) => {
+            this.canExtendMembership = canExtend;
+            this.loading = false;
           },
           error: () => (this.loading = false),
         });
@@ -100,50 +72,27 @@ export class ChangeGroupExpirationDialogComponent implements OnInit {
 
   onExpirationChanged(newExp: string): void {
     this.loading = true;
-    if (newExp === 'groupRules') {
-      this.groupManager.extendMembershipInGroup(this.data.memberId, this.data.groupId).subscribe({
+    this.expirationAttr.value = newExp === 'never' ? null : newExp;
+
+    const extend$ = this.groupManager.extendMembershipInGroup(
+      this.data.memberId,
+      this.data.groupId
+    );
+    const change$ = this.attributesManagerService.setMemberGroupAttributes({
+      member: this.data.memberId,
+      group: this.data.groupId,
+      attributes: [this.expirationAttr],
+    });
+
+    of(newExp)
+      .pipe(mergeMap((exp) => iif(() => exp === 'groupRules', extend$, change$)))
+      .subscribe({
         next: () => {
           this.loading = false;
-          this.notificator.showSuccess(this.successMessage);
-          this.dialogRef.close({ success: true });
+          this.notificator.showInstantSuccess('DIALOGS.CHANGE_EXPIRATION.SUCCESS');
+          this.dialogRef.close(true);
         },
         error: () => (this.loading = false),
       });
-    } else {
-      this.expirationAttr.value = newExp === 'never' ? null : newExp;
-
-      this.attributesManagerService
-        .setMemberGroupAttributes({
-          member: this.data.memberId,
-          group: this.data.groupId,
-          attributes: [this.expirationAttr],
-        })
-        .subscribe({
-          next: () => {
-            if (this.changeStatus && this.status === 'EXPIRED') {
-              this.groupManager
-                .setGroupsMemberStatus(this.data.memberId, this.data.groupId, 'VALID')
-                .subscribe({
-                  next: (member) => {
-                    this.translate
-                      .get('DIALOGS.CHANGE_STATUS.SUCCESS')
-                      .subscribe((success: string) => {
-                        this.notificator.showSuccess(success);
-                        this.loading = false;
-                        this.notificator.showSuccess(this.successMessage);
-                        this.dialogRef.close({ success: true, member: member });
-                      });
-                  },
-                  error: () => (this.loading = false),
-                });
-            } else {
-              this.loading = false;
-              this.notificator.showSuccess(this.successMessage);
-              this.dialogRef.close({ success: true });
-            }
-          },
-          error: () => (this.loading = false),
-        });
-    }
   }
 }

--- a/libs/perun/dialogs/src/lib/change-member-status-dialog/change-member-status-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-member-status-dialog/change-member-status-dialog.component.html
@@ -32,7 +32,7 @@
         [expiration]="expiration"
         [maxDate]="maxDate"
         [minDate]="minDate"
-        (datePicker)="setExpiration($event)">
+        (expirationSelected)="setExpiration($event)">
       </perun-web-apps-expiration-select>
     </div>
     <div mat-dialog-actions>

--- a/libs/perun/dialogs/src/lib/change-member-status-dialog/change-member-status-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/change-member-status-dialog/change-member-status-dialog.component.ts
@@ -95,11 +95,7 @@ export class ChangeMemberStatusDialogComponent implements OnInit {
   }
 
   setExpiration(newExpiration: string): void {
-    if (newExpiration === 'never') {
-      this.expiration = 'never';
-    } else {
-      this.expiration = formatDate(newExpiration, 'yyyy-MM-dd', 'en-GB');
-    }
+    this.expiration = newExpiration;
   }
 
   cancel(): void {
@@ -120,10 +116,8 @@ export class ChangeMemberStatusDialogComponent implements OnInit {
             })
             .subscribe({
               next: () => {
-                this.translate.get('DIALOGS.CHANGE_STATUS.SUCCESS').subscribe((success: string) => {
-                  this.notificatorService.showSuccess(success);
-                  this.dialogRef.close(member);
-                });
+                this.notificatorService.showInstantSuccess('DIALOGS.CHANGE_STATUS.SUCCESS');
+                this.dialogRef.close(member);
               },
               error: () => (this.loading = false),
             });
@@ -143,12 +137,8 @@ export class ChangeMemberStatusDialogComponent implements OnInit {
               })
               .subscribe({
                 next: () => {
-                  this.translate
-                    .get('DIALOGS.CHANGE_STATUS.SUCCESS')
-                    .subscribe((success: string) => {
-                      this.notificatorService.showSuccess(success);
-                      this.dialogRef.close(member);
-                    });
+                  this.notificatorService.showInstantSuccess('DIALOGS.CHANGE_STATUS.SUCCESS');
+                  this.dialogRef.close(member);
                 },
                 error: () => (this.loading = false),
               });

--- a/libs/perun/dialogs/src/lib/change-sponsorship-expiration-dialog/change-sponsorship-expiration-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-sponsorship-expiration-dialog/change-sponsorship-expiration-dialog.component.html
@@ -5,10 +5,7 @@
   <div *perunWebAppsLoader="loading; indicator: spinner">
     <h1 mat-dialog-title>{{'DIALOGS.CHANGE_SPONSORSHIP_EXPIRATION.TITLE' | translate}}</h1>
     <perun-web-apps-change-expiration-dialog
-      [minDate]="minDate"
       [currentExpiration]="currentExpiration"
-      [newExpiration]="newExpiration"
-      [mode]="'sponsor'"
       (expirationChanged)="onExpirationChanged($event)">
     </perun-web-apps-change-expiration-dialog>
   </div>

--- a/libs/perun/dialogs/src/lib/change-vo-expiration-dialog/change-vo-expiration-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/change-vo-expiration-dialog/change-vo-expiration-dialog.component.html
@@ -5,15 +5,9 @@
   <div *perunWebAppsLoader="loading; indicator: spinner">
     <h1 mat-dialog-title>{{'DIALOGS.CHANGE_VO_EXPIRATION.TITLE' | translate}}</h1>
     <perun-web-apps-change-expiration-dialog
-      [minDate]="minDate"
-      [maxDate]="maxDate"
-      [currentExpiration]="currentExpiration"
-      [newExpiration]="newExpiration"
-      [canExtendMembership]="canExtendMembership"
-      [mode]="'vo'"
       [status]="status"
-      [backButton]="backButton"
-      (statusChange)="changeStatus = true"
+      [currentExpiration]="expiration"
+      [canExtendInVo]="canExtendMembership"
       (expirationChanged)="onExpirationChanged($event)">
     </perun-web-apps-change-expiration-dialog>
   </div>

--- a/libs/perun/dialogs/src/lib/expiration-select/expiration-select.component.html
+++ b/libs/perun/dialogs/src/lib/expiration-select/expiration-select.component.html
@@ -1,7 +1,4 @@
 <mat-radio-group [(ngModel)]="expiration" (change)="emitDate()" class="d-flex flex-column">
-  <mat-radio-button *ngIf="allowNever" value="never">
-    {{'DIALOGS.CHANGE_EXPIRATION.EXPIRATION_NEVER'|translate}}
-  </mat-radio-button>
   <mat-radio-button value="{{expirationControl.value}}">
     <mat-form-field color="primary" class="cursor-pointer me-3" (click)="picker.open()">
       <mat-label>{{'DIALOGS.CHANGE_EXPIRATION.DATE_LABEL'|translate}}</mat-label>
@@ -17,5 +14,14 @@
       <mat-datepicker-toggle [for]="picker" [disabled]="false" matSuffix></mat-datepicker-toggle>
       <mat-datepicker #picker [disabled]="false"></mat-datepicker>
     </mat-form-field>
+  </mat-radio-button>
+  <mat-radio-button *ngIf="canExtendInVo" class="mb-2" value="voRules">
+    {{'DIALOGS.CHANGE_EXPIRATION.VO_RULES'|translate}}
+  </mat-radio-button>
+  <mat-radio-button *ngIf="canExtendInGroup" class="mb-2" value="groupRules">
+    {{'DIALOGS.CHANGE_EXPIRATION.GROUP_RULES'|translate}}
+  </mat-radio-button>
+  <mat-radio-button *ngIf="allowNever" value="never">
+    {{'DIALOGS.CHANGE_EXPIRATION.EXPIRATION_NEVER'|translate}}
   </mat-radio-button>
 </mat-radio-group>

--- a/libs/perun/dialogs/src/lib/expiration-select/expiration-select.component.ts
+++ b/libs/perun/dialogs/src/lib/expiration-select/expiration-select.component.ts
@@ -11,18 +11,29 @@ import { MatDatepickerInputEvent } from '@angular/material/datepicker';
 export class ExpirationSelectComponent implements OnInit, OnChanges {
   @Input() expiration = 'never';
   @Input() allowNever = true;
+  @Input() canExtendInVo = false;
+  @Input() canExtendInGroup = false;
   @Input() minDate: Date = null;
   @Input() maxDate: Date = null;
-  @Output() datePicker: EventEmitter<string> = new EventEmitter<string>();
+  @Output() expirationSelected: EventEmitter<string> = new EventEmitter<string>();
   expirationControl = new FormControl<string>(null);
 
   ngOnInit(): void {
-    const defaultDate = this.maxDate ? this.maxDate : this.minDate;
-    this.expirationControl.setValue(formatDate(defaultDate, 'yyyy-MM-dd', 'en-GB'));
+    // Set preselected value
+    let expDate: Date = null;
+    // Current expiration value, if not "never", has the highest priority
+    if (this.expiration !== 'never') {
+      expDate = new Date(this.expiration);
+    }
+    // Select one of the bounds as a suggestion if expiration is "never"
+    const defExp = this.maxDate ? this.maxDate : this.minDate;
+    expDate = expDate ? expDate : defExp;
+    // Assume at least one of the candidate values was set
+    this.expirationControl.setValue(this.parseDate(expDate));
   }
 
   ngOnChanges(): void {
-    // Change selected date to be in [min, max] range
+    // Change selected date to be in [min, max] range in case one of the bounds changes
     const selectedExpiration = new Date(this.expirationControl.value);
     let validExpiration = selectedExpiration;
     if (this.minDate && selectedExpiration < this.minDate) {
@@ -31,21 +42,22 @@ export class ExpirationSelectComponent implements OnInit, OnChanges {
       validExpiration = this.maxDate;
     }
 
-    this.expirationControl.setValue(formatDate(validExpiration, 'yyyy-MM-dd', 'en-GB'));
+    this.expirationControl.setValue(this.parseDate(validExpiration));
   }
 
   setExpiration(exp: MatDatepickerInputEvent<Date>): void {
-    this.expiration = formatDate(exp.value, 'yyyy-MM-dd', 'en-GB');
-    this.expirationControl.setValue(formatDate(exp.value, 'yyyy-MM-dd', 'en-GB'));
+    this.expiration = this.parseDate(exp.value);
+    this.expirationControl.setValue(this.expiration);
 
     this.emitDate();
   }
 
   emitDate(): void {
-    if (this.expiration !== 'never' && this.expirationControl.value === '') {
-      return;
-    }
+    // Emitted date has correct format, and the value is always valid
+    this.expirationSelected.emit(this.expiration);
+  }
 
-    this.datePicker.emit(this.expiration);
+  private parseDate(d: Date): string {
+    return formatDate(d, 'yyyy-MM-dd', 'en-GB');
   }
 }

--- a/libs/perun/pipes/src/lib/group-status-icon-color.ts
+++ b/libs/perun/pipes/src/lib/group-status-icon-color.ts
@@ -12,7 +12,7 @@ export class GroupStatusIconColorPipe implements PipeTransform {
         color = 'red';
         break;
       default:
-        color = '';
+        color = 'black';
     }
     return `${color}${isMembersGroup || membershipType ? ' cursor-default' : ''}`;
   }

--- a/libs/perun/pipes/src/lib/member-status-icon-color.pipe.ts
+++ b/libs/perun/pipes/src/lib/member-status-icon-color.pipe.ts
@@ -23,11 +23,8 @@ export class MemberStatusIconColorPipe implements PipeTransform {
       case 'INVALID':
         color = 'red';
         break;
-      case 'DISABLED':
-        color = 'black';
-        break;
       default:
-        return ``;
+        return 'BLACK';
     }
 
     return `${color}${indirect === 'UNALTERABLE' ? ' cursor-default' : ''}`;


### PR DESCRIPTION
* In all cases expiration-select component is used
* Expiration-select now allows to use Vo,Group rules for extention
* Changing expiration now always allows to choose sensible date
* Changing expiration alone can never lead to status change
* Refactored connected components, mostly removed unnecessary code