### PR TITLE
fix(lib): move mfa logic from sessionStorage to localStorage

### DIFF
--- a/libs/perun/services/src/lib/ApiInterceptor.ts
+++ b/libs/perun/services/src/lib/ApiInterceptor.ts
@@ -52,7 +52,7 @@ export class ApiInterceptor implements HttpInterceptor {
       this.isCallToPerunApi(req.url) &&
       !this.isLoggedIn() &&
       !this.dialogRefSessionExpiration &&
-      !sessionStorage.getItem('mfaRequired')
+      !localStorage.getItem('mfaRequired')
     ) {
       const config = getDefaultDialogConfig();
       config.width = '450px';

--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -110,7 +110,7 @@ export class AuthService {
     ) {
       customQueryParams['prompt'] = 'consent';
     }
-    if (sessionStorage.getItem('mfa_route') || sessionStorage.getItem('mfaProcessed')) {
+    if (sessionStorage.getItem('mfa_route') || localStorage.getItem('mfaProcessed')) {
       customQueryParams['acr_values'] = 'https://refeds.org/profile/mfa';
     }
     if (sessionStorage.getItem('mfa_route')) {

--- a/libs/perun/services/src/lib/init-auth.service.ts
+++ b/libs/perun/services/src/lib/init-auth.service.ts
@@ -172,7 +172,7 @@ export class InitAuthService {
       sessionStorage.setItem('auth:queryParams', queryParams);
       return Promise.resolve();
     } else if (this.storeService.getProperty('auto_auth_redirect')) {
-      if (!sessionStorage.getItem('mfaProcessed')) {
+      if (!localStorage.getItem('mfaProcessed')) {
         localStorage.setItem('routeAuthGuard', window.location.pathname);
       }
       return (

--- a/libs/perun/services/src/lib/mfa-handler.service.ts
+++ b/libs/perun/services/src/lib/mfa-handler.service.ts
@@ -44,7 +44,7 @@ export class MfaHandlerService {
 
     dialogVerifyRef.afterClosed().subscribe((result) => {
       if (result) {
-        sessionStorage.setItem('mfaRequired', 'true');
+        localStorage.setItem('mfaRequired', 'true');
 
         // save tokens - if MFA will NOT be successful, we will need to give them back to oauth storage
         sessionStorage.setItem('oldAccessToken', this.oauthService.getAccessToken());
@@ -80,8 +80,8 @@ export class MfaHandlerService {
         if (newWindow?.closed) {
           clearInterval(timer);
           dialogRef.close();
-          sessionStorage.removeItem('mfaRequired');
-          sessionStorage.removeItem('mfaProcessed');
+          localStorage.removeItem('mfaRequired');
+          localStorage.removeItem('mfaProcessed');
           // if the window is closed without successful MFA, then give back previous tokens to the oauth storage
           if (this.oauthService.getAccessToken() === null) {
             localStorage.setItem('access_token', sessionStorage.getItem('oldAccessToken'));
@@ -115,13 +115,13 @@ export class MfaHandlerService {
    * multi factor authentication
    */
   mfaWindowForceLogout(): void {
-    if (sessionStorage.getItem('mfaRequired') && !sessionStorage.getItem('mfaProcessed')) {
-      sessionStorage.setItem('mfaProcessed', 'true');
+    if (localStorage.getItem('mfaRequired') && !localStorage.getItem('mfaProcessed')) {
+      localStorage.setItem('mfaProcessed', 'true');
       this.oauthService.logOut(true);
       this.authService.loadOidcConfigData();
       return void this.oauthService.loadDiscoveryDocumentAndLogin();
     } else {
-      sessionStorage.removeItem('mfaRequired');
+      localStorage.removeItem('mfaRequired');
     }
   }
 
@@ -130,8 +130,8 @@ export class MfaHandlerService {
    * If MFA is successfully done, then close the window
    */
   closeMfaWindow(): void {
-    if (sessionStorage.getItem('mfaProcessed') && !sessionStorage.getItem('mfaRequired')) {
-      sessionStorage.removeItem('mfaProcessed');
+    if (localStorage.getItem('mfaProcessed') && !localStorage.getItem('mfaRequired')) {
+      localStorage.removeItem('mfaProcessed');
       window.close();
     }
   }


### PR DESCRIPTION
* There were some flags stored in sessionStorage which allow to handle mfa logic correctly across windows. The idea was, that the sessionStorage is copied between windows when the new window is opended via window.open(). It works in Chrome and Firefox, but e.g. in Vivaldi the behavior is different and the sessionStorage is not copied. According to this the better way is to store these flags in localStorage.