### PR TITLE
fix: add new defaul acr value

### DIFF
--- a/apps/admin-gui/src/assets/config/defaultConfig.json
+++ b/apps/admin-gui/src/assets/config/defaultConfig.json
@@ -20,7 +20,8 @@
     "oauth_redirect_uri": "http://localhost:4200/api-callback",
     "oauth_scopes": "openid profile perun_api perun_admin offline_access",
     "oauth_response_type": "code",
-    "oauth_offline_access_consent_prompt": true
+    "oauth_offline_access_consent_prompt": true,
+    "oauth_acr_value": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport https://refeds.org/profile/sfa https://refeds.org/profile/mfa"
   },
   "proxy_logout": true,
   "mfa": {

--- a/apps/consolidator/src/assets/config/defaultConfig.json
+++ b/apps/consolidator/src/assets/config/defaultConfig.json
@@ -11,7 +11,8 @@
     "oauth_scopes": "openid profile perun_api perun_admin offline_access target user_identifiers",
     "oauth_response_type": "code",
     "user_info_endpoint_url": "https://proxy.aai.muni.cz/OIDC/userinfo",
-    "oauth_offline_access_consent_prompt": true
+    "oauth_offline_access_consent_prompt": true,
+    "oauth_acr_value": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport https://refeds.org/profile/sfa https://refeds.org/profile/mfa"
   },
   "proxy_logout": true,
   "mfa": {

--- a/apps/linker/src/assets/config/defaultConfig.json
+++ b/apps/linker/src/assets/config/defaultConfig.json
@@ -10,7 +10,8 @@
     "oauth_load_user_info": true,
     "oauth_scopes": "openid profile perun_api offline_access target user_identifiers",
     "oauth_response_type": "code",
-    "oauth_offline_access_consent_prompt": true
+    "oauth_offline_access_consent_prompt": true,
+    "oauth_acr_value": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport https://refeds.org/profile/sfa https://refeds.org/profile/mfa"
   },
   "mfa": {
     "url_en": "https://mfa.id.muni.cz/"

--- a/apps/password-reset/src/assets/config/defaultConfig.json
+++ b/apps/password-reset/src/assets/config/defaultConfig.json
@@ -12,7 +12,8 @@
     "oauth_redirect_uri": "http://localhost:4200/api-callback",
     "oauth_scopes": "openid profile perun_api offline_access",
     "oauth_response_type": "code",
-    "oauth_offline_access_consent_prompt": true
+    "oauth_offline_access_consent_prompt": true,
+    "oauth_acr_value": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport https://refeds.org/profile/sfa https://refeds.org/profile/mfa"
   },
   "mfa": {
     "url_en": "https://mfa.id.muni.cz/"

--- a/apps/publications/src/assets/config/defaultConfig.json
+++ b/apps/publications/src/assets/config/defaultConfig.json
@@ -11,7 +11,8 @@
     "oauth_redirect_uri": "http://localhost:4200/api-callback",
     "oauth_scopes": "openid profile perun_api perun_admin offline_access",
     "oauth_response_type": "code",
-    "oauth_offline_access_consent_prompt": true
+    "oauth_offline_access_consent_prompt": true,
+    "oauth_acr_value": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport https://refeds.org/profile/sfa https://refeds.org/profile/mfa"
   },
   "proxy_logout": true,
   "mfa": {

--- a/apps/user-profile/src/assets/config/defaultConfig.json
+++ b/apps/user-profile/src/assets/config/defaultConfig.json
@@ -18,7 +18,8 @@
     "oauth_redirect_uri": "http://localhost:4200/api-callback",
     "oauth_scopes": "openid profile perun_api offline_access",
     "oauth_response_type": "code",
-    "oauth_offline_access_consent_prompt": true
+    "oauth_offline_access_consent_prompt": true,
+    "oauth_acr_value": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport https://refeds.org/profile/sfa https://refeds.org/profile/mfa"
   },
   "proxy_logout": true,
   "password_namespace_attributes": [

--- a/libs/perun/models/src/lib/ConfigProperties.ts
+++ b/libs/perun/models/src/lib/ConfigProperties.ts
@@ -9,6 +9,7 @@ export interface OidcClient {
   user_info_endpoint_url: string;
   filters: Record<string, string>;
   oauth_offline_access_consent_prompt: boolean;
+  oauth_acr_value: string;
 }
 
 interface PerunTheme {

--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -103,8 +103,11 @@ export class AuthService {
     //So the refreshing of the token is not triggered by multiple tabs at the same time
     const timeoutFactor = 0.5 + randomSalt;
 
-    const customQueryParams = !filterValue ? {} : { acr_values: filterValue };
     const oidcClientProperties: OidcClient = this.store.getProperty('oidc_client');
+    const acr = oidcClientProperties.oauth_acr_value;
+    const customQueryParams = !filterValue
+      ? { acr_values: acr }
+      : { acr_values: filterValue + ' ' + acr };
     if (
       oidcClientProperties.oauth_scopes.split(' ').includes('offline_access') &&
       oidcClientProperties.oauth_offline_access_consent_prompt


### PR DESCRIPTION
* There is a new option to define default acr value in config file.
* The default value of this property enables to correctly handle information about already performed mfa - if the idp requires mfa by itself, Perun applications should skip its own mfa logic, because user already has valid mfa session on proxy.

BREAKING CHANGE: new string property oauth_acr_value in defaultConfig.json