### PR TITLE
fix: Highlight table column headers

### DIFF
--- a/apps/admin-gui/src/_styles.scss
+++ b/apps/admin-gui/src/_styles.scss
@@ -1693,4 +1693,5 @@ table .mdc-text-field--outlined {
   position: sticky !important;
   top: 0;
   z-index: 100;
+  font-weight: bold !important;
 }

--- a/apps/consolidator/src/_styles.scss
+++ b/apps/consolidator/src/_styles.scss
@@ -267,4 +267,5 @@ mat-icon {
   position: sticky !important;
   top: 0;
   z-index: 100;
+  font-weight: bold !important;
 }

--- a/apps/publications/src/_styles.scss
+++ b/apps/publications/src/_styles.scss
@@ -439,4 +439,5 @@ mat-form-field mat-icon {
   position: sticky !important;
   top: 0;
   z-index: 100;
+  font-weight: bold !important;
 }

--- a/apps/user-profile/src/_styles.scss
+++ b/apps/user-profile/src/_styles.scss
@@ -338,4 +338,5 @@ mat-list-item .mat-mdc-form-field-subscript-wrapper {
   position: sticky !important;
   top: 0;
   z-index: 100;
+  font-weight: bold !important;
 }


### PR DESCRIPTION
* Table header is now bold to distinguish form table cells