### PR TITLE
fix(admin): remove icons on roles overview page

### DIFF
--- a/apps/admin-gui/src/app/shared/components/roles-list/roles-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/roles-list/roles-page.component.html
@@ -15,7 +15,6 @@
     #panel>
     <mat-expansion-panel-header>
       <mat-panel-title>
-        <mat-icon class="me-2" mat-card-avatar svgIcon="perun-user-dark"></mat-icon>
         <p class="mt-auto mb-auto">{{role | displayedRole}}</p>
       </mat-panel-title>
     </mat-expansion-panel-header>


### PR DESCRIPTION
Removed icons from individual roles on roles overveiw page, because they served no real purpose, providing no additional information.