### PR TITLE
fix(admin): unify color of mat-slide-toggles

### DIFF
--- a/apps/admin-gui/src/app/shared/components/settings-toggle-item/settings-toggle-item.component.html
+++ b/apps/admin-gui/src/app/shared/components/settings-toggle-item/settings-toggle-item.component.html
@@ -6,8 +6,7 @@
       class="setting-item clickable">
       {{title}}
     </label>
-    <mat-slide-toggle #toggle [(ngModel)]="modelValue" class="ms-4" color="primary">
-    </mat-slide-toggle>
+    <mat-slide-toggle #toggle [(ngModel)]="modelValue" class="ms-4"></mat-slide-toggle>
   </div>
   <div [@openClose]="toggle.checked ? 'open' : 'closed'" class="ms-1">
     <ng-content></ng-content>

--- a/apps/admin-gui/src/app/vos/components/expiration-settings/expiration-settings.component.html
+++ b/apps/admin-gui/src/app/vos/components/expiration-settings/expiration-settings.component.html
@@ -6,11 +6,7 @@
       class="settings-header">
       {{'VO_MANAGEMENT.SETTINGS.EXPIRATION.TITLE' | translate}}
     </h1>
-    <mat-slide-toggle
-      #mainToggle
-      class="ms-4"
-      [(ngModel)]="currentConfiguration.enabled"
-      color="primary">
+    <mat-slide-toggle #mainToggle class="ms-4" [(ngModel)]="currentConfiguration.enabled">
     </mat-slide-toggle>
   </div>
 

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
@@ -35,8 +35,7 @@
           (change)="updateAutoRegistration()"
           [disabled]="!changeAutoRegistration"
           [ngModel]="autoRegistrationEnabled"
-          #autoRegToggle
-          color="primary">
+          #autoRegToggle>
           {{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.ALLOW_EMBEDDED' | translate}}
         </mat-slide-toggle>
       </div>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-subgroups/group-subgroups.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-subgroups/group-subgroups.component.html
@@ -37,7 +37,6 @@
     (change)="selected.clear()"
     [(ngModel)]="showGroupList"
     class="me-1"
-    color="primary"
     labelPosition="before"></mat-slide-toggle>
   <label class="slide-label" (click)="labelToggle()">
     {{'GROUP_DETAIL.SUBGROUPS.LIST_VIEW' | translate}}

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-groups/vo-groups.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-groups/vo-groups.component.html
@@ -31,12 +31,7 @@
   <label class="slide-label" (click)="labelToggle()"
     >{{'VO_DETAIL.GROUPS.TREE_VIEW' | translate}}
   </label>
-  <mat-slide-toggle
-    #toggle
-    (change)="removeAllGroups()"
-    [(ngModel)]="showGroupList"
-    class="me-1"
-    color="primary">
+  <mat-slide-toggle #toggle (change)="removeAllGroups()" [(ngModel)]="showGroupList" class="me-1">
   </mat-slide-toggle>
   <label class="slide-label" (click)="labelToggle()"
     >{{'VO_DETAIL.GROUPS.LIST_VIEW' | translate}}

--- a/libs/perun/components/src/lib/attribute-critical-operations-toggles/attribute-critical-operations-toggles.component.html
+++ b/libs/perun/components/src/lib/attribute-critical-operations-toggles/attribute-critical-operations-toggles.component.html
@@ -1,6 +1,5 @@
 <mat-slide-toggle
   class="toggle-font"
-  color="accent"
   labelPosition="before"
   data-cy="toggle-read-critical"
   [(ngModel)]="readOperation"
@@ -10,7 +9,6 @@
 <br />
 <mat-slide-toggle
   class="toggle-font"
-  color="accent"
   labelPosition="before"
   [(ngModel)]="writeOperation"
   (toggleChange)="writeOperationChanged.emit(!writeOperation)">

--- a/libs/perun/components/src/lib/attribute-unique-toggle/attribute-unique-toggle.component.html
+++ b/libs/perun/components/src/lib/attribute-unique-toggle/attribute-unique-toggle.component.html
@@ -5,7 +5,6 @@
   matTooltipPosition="above"
   matTooltip="{{'SHARED_LIB.PERUN.COMPONENTS.ATTRIBUTE_UNIQUE_TOGGLE.TOOLTIP'| translate}}">
   <mat-slide-toggle
-    color="accent"
     labelPosition="before"
     [(ngModel)]="attDef.unique"
     [disabled]="disabled.disable">


### PR DESCRIPTION
* The color attribute was removed from mat-slide-toggle tags so the default accent color is used across all GUI.