### PR TITLE
fix: don't overlap text in delete dialog

### DIFF
--- a/libs/perun/dialogs/src/lib/delete-entity-dialog/delete-entity-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/delete-entity-dialog/delete-entity-dialog.component.html
@@ -9,7 +9,7 @@
         {{entityType}}
       </h1>
       <div class="dialog-container" mat-dialog-content>
-        <div *ngIf="!disableForce" class="mb-4">
+        <div *ngIf="!disableForce">
           {{'DIALOGS.DELETE_ENTITY.BASIC' | translate: {action: this.anonymize | deleteDialogType} }}
           {{'DIALOGS.DELETE_ENTITY.ONLY' | translate}}
           {{entityType}}
@@ -17,7 +17,7 @@
           {{entityType}}
           {{'DIALOGS.DELETE_ENTITY.RELATIONS' | translate}}?
         </div>
-        <div *ngIf="disableForce" class="mb-4">
+        <div *ngIf="disableForce">
           {{'DIALOGS.DELETE_ENTITY.BASIC' | translate: {action: this.anonymize | deleteDialogType} }}
           {{entityType}}
           ?

--- a/libs/perun/dialogs/src/lib/delete-entity-dialog/delete-entity-dialog.component.scss
+++ b/libs/perun/dialogs/src/lib/delete-entity-dialog/delete-entity-dialog.component.scss
@@ -4,6 +4,5 @@
 }
 
 .table-margin {
-  margin-top: -50px;
   margin-bottom: 20px;
 }


### PR DESCRIPTION
* changed delete-entity-dialog margins to fix text overlap