### PR TITLE
fix(admin): allow to change approval style for embedded group applications

### DIFF
--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
@@ -3,8 +3,8 @@
 </h1>
 <mat-spinner *ngIf="loading" class="ms-auto me-auto"> </mat-spinner>
 <div *ngIf="!noApplicationForm">
-  <div *ngIf="!loading" class="d-flex w-50">
-    <div [ngClass]="autoRegistrationEnabled ? 'w-75' : 'w-50'">
+  <div *ngIf="!loading" class="d-flex w-75">
+    <div>
       <div class="fw-bold">
         {{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MODULE_NAME' | translate}}:
         {{applicationForm.moduleClassName}}
@@ -15,40 +15,31 @@
           >{{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.APPLICATION_TYPE' | translate}}</span
         >:
 
-        <mat-icon class="align-bottom" matTooltip="Initial">arrow_right_alt</mat-icon>
+        <mat-icon class="align-middle" matTooltip="Initial">arrow_right_alt</mat-icon>
         {{applicationForm.automaticApproval ?
         ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.AUTOMATIC'| translate) : ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MANUAL'| translate)}}
         ,
-        <mat-icon class="align-bottom" matTooltip="Extension">restore</mat-icon>
-        {{applicationForm.automaticApprovalExtension ?
+        <span [ngClass]="autoRegistrationEnabled ? '' : 'me-2'">
+          <mat-icon class="align-middle" matTooltip="Extension">restore</mat-icon>
+          {{applicationForm.automaticApprovalExtension ?
         ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.AUTOMATIC'| translate) : ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MANUAL'| translate)}}
+        </span>
 
-        <span *ngIf="autoRegistrationEnabled">
+        <span *ngIf="autoRegistrationEnabled" class="me-2">
           ,
-          <mat-icon class="align-bottom" matTooltip="Embedded">nat</mat-icon>
+          <mat-icon class="align-middle" matTooltip="Embedded">nat</mat-icon>
           {{applicationForm.automaticApprovalEmbedded ?
           ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.AUTOMATIC'| translate) : ('GROUP_DETAIL.SETTINGS.APPLICATION_FORM.MANUAL'| translate)}}
         </span>
+        <button *ngIf="editAuth" (click)="settings()" mat-stroked-button>
+          <i class="material-icons">edit</i>
+          {{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.SETTINGS_BUTTON' | translate}}
+        </button>
       </div>
-      <div *ngIf="voHasEmbeddedGroupApplication">
-        <mat-slide-toggle
-          (change)="updateAutoRegistration()"
-          [disabled]="!changeAutoRegistration"
-          [ngModel]="autoRegistrationEnabled"
-          #autoRegToggle>
-          {{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.ALLOW_EMBEDDED' | translate}}
-        </mat-slide-toggle>
-      </div>
-    </div>
-    <div class="w-25">
-      <button
-        *ngIf="editAuth"
-        (click)="settings()"
-        class="ms-auto action-button"
-        mat-stroked-button>
-        <i class="material-icons">edit</i>
-        {{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.SETTINGS_BUTTON' | translate}}
-      </button>
+      <span *ngIf="autoRegistrationEnabled">
+        <mat-icon class="align-bottom">info</mat-icon>
+        {{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.ALLOW_EMBEDDED' | translate}}
+      </span>
     </div>
   </div>
 
@@ -80,7 +71,7 @@
       {{'VO_DETAIL.SETTINGS.APPLICATION_FORM.SAVE_BUTTON' | translate}}
     </button>
 
-    <button (click)="copy()" *ngIf="editAuth" class="me-2 action-button" mat-stroked-button>
+    <button (click)="copy()" *ngIf="editAuth" class="me-2" mat-stroked-button>
       <i class="material-icons">file_copy</i>
       {{'GROUP_DETAIL.SETTINGS.APPLICATION_FORM.COPY_GROUP_BUTTON' | translate}}
     </button>

--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.ts
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.ts
@@ -42,9 +42,7 @@ export class GroupSettingsApplicationFormComponent implements OnInit {
   group: Group;
   editAuth = false;
   createEmptyForm = false;
-  voHasEmbeddedGroupApplication = false;
   autoRegistrationEnabled: boolean;
-  changeAutoRegistration: boolean;
   refreshApplicationForm = false;
   // to recognize new items in other items' dependencies
   private idCounter = -1;
@@ -81,7 +79,6 @@ export class GroupSettingsApplicationFormComponent implements OnInit {
                 'urn:perun:group:attribute-def:virt:autoRegistrationEnabled'
               )
               .subscribe((attr) => {
-                this.voHasEmbeddedGroupApplication = attr.value !== null;
                 this.autoRegistrationEnabled = !!attr.value;
                 this.loading = false;
               });
@@ -107,10 +104,6 @@ export class GroupSettingsApplicationFormComponent implements OnInit {
     );
     this.createEmptyForm = this.guiAuthResolver.isAuthorized(
       'createApplicationFormInGroup_Group_policy',
-      [this.group]
-    );
-    this.changeAutoRegistration = this.guiAuthResolver.isAuthorized(
-      'addGroupsToAutoRegistration_List<Group>_policy',
       [this.group]
     );
   }
@@ -254,36 +247,5 @@ export class GroupSettingsApplicationFormComponent implements OnInit {
   clear(): void {
     this.applicationFormItems = [];
     this.itemsChanged = true;
-  }
-
-  updateAutoRegistration(): void {
-    this.autoRegToggle.setDisabledState(true);
-    if (this.autoRegistrationEnabled) {
-      this.registrarManager.deleteGroupsFromAutoRegistration([this.group.id]).subscribe(
-        () => {
-          this.autoRegistrationEnabled = !this.autoRegistrationEnabled;
-          this.translate
-            .get('VO_DETAIL.SETTINGS.APPLICATION_FORM.CHANGE_SETTINGS_SUCCESS')
-            .subscribe((successMessage: string) => {
-              this.notificator.showSuccess(successMessage);
-            });
-          this.autoRegToggle.setDisabledState(false);
-        },
-        () => this.autoRegToggle.setDisabledState(false)
-      );
-    } else {
-      this.registrarManager.addGroupsToAutoRegistration([this.group.id]).subscribe(
-        () => {
-          this.autoRegistrationEnabled = !this.autoRegistrationEnabled;
-          this.translate
-            .get('VO_DETAIL.SETTINGS.APPLICATION_FORM.CHANGE_SETTINGS_SUCCESS')
-            .subscribe((successMessage: string) => {
-              this.notificator.showSuccess(successMessage);
-            });
-          this.autoRegToggle.setDisabledState(false);
-        },
-        () => this.autoRegToggle.setDisabledState(false)
-      );
-    }
   }
 }

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -734,7 +734,7 @@
         "CLEAR": "Clear form",
         "CLEAR_TOOLTIP": "Removes all form items",
         "CHANGE_SETTINGS_SUCCESS": "Application form settings successfully changed.",
-        "ALLOW_EMBEDDED": "Allowed for embedded applications"
+        "ALLOW_EMBEDDED": "This group is allowed for embedded applications"
       },
       "NOTIFICATIONS": {
         "TITLE": "Email notifications",


### PR DESCRIPTION
* Now it is possible to set approval style also for embedded group applications on a subgroup level.
* Toogle was replaced by info text. Previously it was possible to change autoRegistration on an organization level from app detail, but now we don't want to allow this feature due to subgroup level of autoRegistration.
* Also some little refactor was done for this page.