### PR TITLE
chore: change commitlint rules

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -18,6 +18,7 @@
     }
   },
   "rules": {
-    "scope-enum": [2, "always", ["admin", "profile", "pwdreset", "consolidator", "linker", "publications", "openapi", "lib", "npm", "deps", "deps-dev"]]
+    "scope-enum": [2, "always", ["admin", "profile", "pwdreset", "consolidator", "linker", "publications", "openapi", "lib", "npm", "deps", "deps-dev"]],
+    "body-max-line-length": [2, "always", 200]
   }
 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,8 @@ name: Check
 
 on:
   pull_request:
+    branches-ignore:
+      - '*dependabot/npm_and_yarn/*'
 
 jobs:
   run-commitlint-on-pr:


### PR DESCRIPTION
* The body-max-line-length rule was raised from the default 100 characters to 200 characters.
* Branches from the dependabot (with usual prefix dependabot/npm_and_yarn/) are now excluded from the commlint check.