### PR TITLE
fix(admin): fixed block logins dialog

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/block-logins-dialog/block-logins-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/block-logins-dialog/block-logins-dialog.component.html
@@ -23,6 +23,7 @@
       <perun-web-apps-namespace-search-select
         *ngIf="data.namespaceOptions.length > 0 && !isGlobal"
         [namespaceOptions]="data.namespaceOptions"
+        [namespace]="selectedNamespace"
         [disableAutoSelect]="true"
         [customFindPlaceholder]="'DIALOGS.BLOCK_LOGINS.FIND_PLACEHOLDER'"
         (namespaceSelected)="selectedNamespace = $event">


### PR DESCRIPTION
The chosen namespace does not disappear while changing block options.