### PR TITLE
fix(admin): correct button layout in edit attribute definition dialog

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component.html
@@ -84,11 +84,11 @@
           mat-stroked-button>
           {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.SHOW_KEYS' | translate}}
         </button>
-        <button (click)="onCopy()" class="ms-auto" mat-stroked-button>
-          {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.COPY_FOR_IMPORT' | translate}}
-        </button>
-        <button (click)="onCancel()" class="ms-2" mat-stroked-button>
+        <button (click)="onCancel()" class="ms-auto" mat-stroked-button>
           {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.CANCEL' | translate}}
+        </button>
+        <button (click)="onCopy()" class="ms-2" mat-stroked-button>
+          {{'DIALOGS.EDIT_ATTRIBUTE_DEFINITION.COPY_FOR_IMPORT' | translate}}
         </button>
         <button
           class="ms-2"


### PR DESCRIPTION
Cancel button is now on the left in the edit attribute definition dialog.