### PR TITLE
feat(lib): password reset on profile opens modal window

### DIFF
--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -3161,6 +3161,15 @@
           "FIELD_EMPTY": "This field cannot be empty",
           "SUCCESS": "Password has been changed successfully,"
         },
+        "RESET_PASSWORD_DIALOG": {
+          "LOGIN": "Login",
+          "NAMESPACE": "Namespace",
+          "TITLE": "Reset password",
+          "CANCEL": "Cancel",
+          "CHANGE": "Confirm",
+          "FIELD_EMPTY": "This field cannot be empty",
+          "SUCCESS": "Password has been reset successfully,"
+        },
         "PASSWORD_FORM_FIELD": {
           "PASSWORD": "Password",
           "PASSWORD_AGAIN": "Confirm password",

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -412,6 +412,15 @@
           "FIELD_EMPTY": "Tohle políčko musí být vyplněné.",
           "SUCCESS": "Heslo bylo úspěšně změněno"
         },
+        "RESET_PASSWORD_DIALOG": {
+          "LOGIN": "Jméno",
+          "NAMESPACE": "Namespace",
+          "TITLE": "Resetovat heslo",
+          "CANCEL": "Zrušit",
+          "CHANGE": "Potvrdit",
+          "FIELD_EMPTY": "Tohle políčko musí být vyplněné.",
+          "SUCCESS": "Heslo bylo úspěšně resetováno"
+        },
         "PASSWORD_FORM_FIELD": {
           "PASSWORD": "Nové heslo",
           "PASSWORD_AGAIN": "Znovu zadejte nové heslo",

--- a/apps/user-profile/src/assets/i18n/en.json
+++ b/apps/user-profile/src/assets/i18n/en.json
@@ -480,6 +480,15 @@
           "FIELD_EMPTY": "This field cannot be empty",
           "SUCCESS": "Password has been changed successfully,"
         },
+        "RESET_PASSWORD_DIALOG": {
+          "LOGIN": "Login",
+          "NAMESPACE": "Namespace",
+          "TITLE": "Reset password",
+          "CANCEL": "Cancel",
+          "CHANGE": "Confirm",
+          "FIELD_EMPTY": "This field cannot be empty",
+          "SUCCESS": "Password has been reset successfully,"
+        },
         "PASSWORD_FORM_FIELD": {
           "PASSWORD": "New password",
           "PASSWORD_AGAIN": "New password again",

--- a/libs/perun/components/src/lib/password-reset/password-reset.component.html
+++ b/libs/perun/components/src/lib/password-reset/password-reset.component.html
@@ -32,7 +32,7 @@
           <th *matHeaderCellDef mat-header-cell></th>
           <td *matCellDef="let login" mat-cell>
             <button
-              (click)="resetPassword(login.friendlyNameParameter)"
+              (click)="resetPassword(login)"
               [disabled]="!logins.includes(login)"
               color="accent"
               mat-flat-button>

--- a/libs/perun/components/src/lib/password-reset/password-reset.component.ts
+++ b/libs/perun/components/src/lib/password-reset/password-reset.component.ts
@@ -1,16 +1,12 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Attribute, AttributesManagerService } from '@perun-web-apps/perun/openapi';
-import {
-  EntityStorageService,
-  OtherApplicationsService,
-  StoreService,
-} from '@perun-web-apps/perun/services';
+import { EntityStorageService, StoreService } from '@perun-web-apps/perun/services';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
 import { ChangePasswordDialogComponent } from '@perun-web-apps/perun/dialogs';
+import { PasswordResetDialogComponent } from '@perun-web-apps/perun/dialogs';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AppType } from '@perun-web-apps/perun/models';
 
 @Component({
   selector: 'perun-web-apps-password-reset',
@@ -32,7 +28,6 @@ export class PasswordResetComponent implements OnInit {
     private dialog: MatDialog,
     private route: ActivatedRoute,
     private router: Router,
-    private otherApplicationService: OtherApplicationsService,
     private entityStorageService: EntityStorageService
   ) {}
 
@@ -69,11 +64,16 @@ export class PasswordResetComponent implements OnInit {
     });
   }
 
-  resetPassword(login: string): void {
-    window.open(
-      this.otherApplicationService.getUrlForOtherApplication(AppType.PwdReset, login),
-      '_blank'
-    );
+  resetPassword(login: Attribute): void {
+    const config = getDefaultDialogConfig();
+    config.width = '600px';
+    config.data = {
+      mode: 'reset',
+      login: String(login.value),
+      namespace: login.friendlyName.split(':')[1],
+    };
+
+    this.dialog.open(PasswordResetDialogComponent, config);
   }
 
   changePassword(login: Attribute): void {

--- a/libs/perun/dialogs/src/index.ts
+++ b/libs/perun/dialogs/src/index.ts
@@ -28,3 +28,4 @@ export * from './lib/remove-string-value-dialog/remove-string-value-dialog.compo
 export * from './lib/show-ssh-dialog/show-ssh-dialog.component';
 export * from './lib/show-notification-history-dialog/show-notification-history-dialog.component';
 export * from './lib/delete-user-dialog/delete-user-dialog.component';
+export * from './lib/password-reset-dialog/password-reset-dialog.component';

--- a/libs/perun/dialogs/src/lib/password-reset-dialog/password-reset-dialog.component.html
+++ b/libs/perun/dialogs/src/lib/password-reset-dialog/password-reset-dialog.component.html
@@ -1,0 +1,43 @@
+<ng-template #spinner>
+  <perun-web-apps-loading-dialog></perun-web-apps-loading-dialog>
+</ng-template>
+<div class="user-theme position-relative">
+  <div *perunWebAppsLoader="loading; indicator: spinner">
+    <h1 mat-dialog-title>
+      {{'SHARED_LIB.PERUN.COMPONENTS.RESET_PASSWORD_DIALOG.TITLE' | translate}}
+    </h1>
+    <div class="dialog-container" mat-dialog-content>
+      <p *ngIf="data.login" class="subtitle">
+        <em>
+          {{'SHARED_LIB.PERUN.COMPONENTS.RESET_PASSWORD_DIALOG.LOGIN' | translate}}:
+          {{data.login}}
+        </em>
+      </p>
+      <p *ngIf="data.namespace" class="subtitle">
+        <em>
+          {{'SHARED_LIB.PERUN.COMPONENTS.RESET_PASSWORD_DIALOG.NAMESPACE' | translate}}:
+          {{data.namespace}}
+        </em>
+      </p>
+      <perun-web-apps-password-form
+        [formGroup]="newPasswdForm"
+        [namespace]="data.namespace"
+        [language]="language">
+      </perun-web-apps-password-form>
+
+      <div mat-dialog-actions class="ms-auto justify-content-end">
+        <button (click)="close()" mat-stroked-button>
+          {{'SHARED_LIB.PERUN.COMPONENTS.RESET_PASSWORD_DIALOG.CANCEL' | translate}}
+        </button>
+        <button
+          (click)="onSubmit()"
+          [disabled]="newPasswdForm.invalid || newPasswdForm.pending || loading"
+          class="ms-2"
+          color="accent"
+          mat-flat-button>
+          {{'SHARED_LIB.PERUN.COMPONENTS.RESET_PASSWORD_DIALOG.CHANGE' | translate}}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/libs/perun/dialogs/src/lib/password-reset-dialog/password-reset-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/password-reset-dialog/password-reset-dialog.component.ts
@@ -1,0 +1,94 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import {
+  ApiRequestConfigurationService,
+  NotificatorService,
+  StoreService,
+} from '@perun-web-apps/perun/services';
+import { UsersManagerService } from '@perun-web-apps/perun/openapi';
+import { loginAsyncValidator } from '@perun-web-apps/perun/namespace-password-form';
+import { FormBuilder, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
+import { CustomValidators } from '@perun-web-apps/perun/utils';
+import { PasswordLabels } from '@perun-web-apps/perun/models';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+export interface ResetPasswordDialogData {
+  namespace: string;
+  login: string;
+}
+
+@Component({
+  selector: 'perun-web-apps-password-reset-dialog',
+  templateUrl: './password-reset-dialog.component.html',
+  styleUrls: ['./password-reset-dialog.component.scss'],
+})
+export class PasswordResetDialogComponent implements OnInit {
+  loading = false;
+  language = 'en';
+  newPasswdForm: FormGroup<{
+    passwordCtrl: FormControl<string>;
+    passwordAgainCtrl: FormControl<string>;
+  }>;
+  labels: PasswordLabels;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: ResetPasswordDialogData,
+    private dialogRef: MatDialogRef<PasswordResetDialogComponent>,
+    private storeService: StoreService,
+    private translate: TranslateService,
+    private apiRequestConfiguration: ApiRequestConfigurationService,
+    private usersService: UsersManagerService,
+    private formBuilder: FormBuilder,
+    private notificator: NotificatorService
+  ) {}
+
+  ngOnInit(): void {
+    this.newPasswdForm = this.formBuilder.group(
+      {
+        passwordCtrl: [
+          '',
+          Validators.required,
+          [
+            loginAsyncValidator(
+              this.data.namespace,
+              this.usersService,
+              this.apiRequestConfiguration
+            ),
+          ],
+        ],
+        passwordAgainCtrl: ['', Validators.required],
+      },
+      {
+        validators: CustomValidators.passwordMatchValidator as ValidatorFn,
+      }
+    );
+    this.setLabels(this.translate.currentLang);
+  }
+
+  onSubmit(): void {
+    this.loading = true;
+    this.usersService
+      .changePasswordForLogin({
+        login: this.data.login,
+        namespace: this.data.namespace,
+        newPassword: this.newPasswdForm.value.passwordCtrl,
+      })
+      .subscribe(() => {
+        this.notificator.showInstantSuccess(
+          'SHARED_LIB.PERUN.COMPONENTS.RESET_PASSWORD_DIALOG.SUCCESS'
+        );
+        this.loading = false;
+        this.dialogRef.close(true);
+      });
+  }
+
+  close(): void {
+    this.dialogRef.close(false);
+  }
+
+  private setLabels(lang: string): void {
+    this.labels = this.storeService.getProperty(
+      lang === 'en' ? 'password_labels' : 'password_labels_cs'
+    );
+  }
+}

--- a/libs/perun/dialogs/src/lib/perun-dialogs.module.ts
+++ b/libs/perun/dialogs/src/lib/perun-dialogs.module.ts
@@ -48,6 +48,7 @@ import { ExportDataDialogComponent } from './exporting-data-dialog/export-data-d
 import { RequestChangeDataQuotaDialogComponent } from './request-change-data-quota-dialog/request-change-data-quota-dialog.component';
 import { ExpirationSelectComponent } from './expiration-select/expiration-select.component';
 import { DeleteUserDialogComponent } from './delete-user-dialog/delete-user-dialog.component';
+import { PasswordResetDialogComponent } from './password-reset-dialog/password-reset-dialog.component';
 
 @NgModule({
   imports: [
@@ -103,6 +104,7 @@ import { DeleteUserDialogComponent } from './delete-user-dialog/delete-user-dial
     RequestChangeDataQuotaDialogComponent,
     ExpirationSelectComponent,
     DeleteUserDialogComponent,
+    PasswordResetDialogComponent,
   ],
   exports: [
     ChangeExpirationDialogComponent,
@@ -128,6 +130,7 @@ import { DeleteUserDialogComponent } from './delete-user-dialog/delete-user-dial
     RequestChangeDataQuotaDialogComponent,
     ExpirationSelectComponent,
     DeleteUserDialogComponent,
+    PasswordResetDialogComponent,
   ],
 })
 export class PerunDialogsModule {}


### PR DESCRIPTION
Password reset, when clicked on in profile, now opens a modal window instead of redirecting to separate application.
* Created a new password reset dialog
* Modified password-reset component to use this new dialog.