### PR TITLE
feat: remove access for service-accounts

### DIFF
--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -3104,6 +3104,11 @@
         "USER_DONT_EXIST": {
           "TITLE": "The requested user (by Id or external identity) doesn't exist."
         },
+        "USER_NOT_ALLOWED": {
+          "TITLE": "Access not allowed",
+          "MESSAGE": "Service accounts are not allowed to access this application.",
+          "REDIRECT": "Redirect to login page"
+        },
         "TABLE_OPTIONS": {
           "EXPORT_TO_FILE": "Export to file",
           "ALL_DATA": "All data",

--- a/apps/consolidator/src/assets/i18n/en.json
+++ b/apps/consolidator/src/assets/i18n/en.json
@@ -76,6 +76,11 @@
           "REMOVE": "Remove",
           "SUCCESS": "User account successfully removed"
         }
+      },
+      "USER_NOT_ALLOWED": {
+        "TITLE": "Access not allowed",
+        "MESSAGE": "Service accounts are not allowed to access this application.",
+        "REDIRECT": "Redirect to login page"
       }
     },
     "CONSOLIDATOR": {

--- a/apps/linker/src/assets/i18n/en.json
+++ b/apps/linker/src/assets/i18n/en.json
@@ -35,6 +35,11 @@
         "FOCUS_ON_MFA_DIALOG": {
           "MODAL": "Modal window is opened.",
           "MODAL_WARNING": "Please check your browser settings if no modal window is open."
+        },
+        "USER_NOT_ALLOWED": {
+          "TITLE": "Access not allowed",
+          "MESSAGE": "Service accounts are not allowed to access this application.",
+          "REDIRECT": "Redirect to login page"
         }
       }
     },

--- a/apps/password-reset/src/assets/i18n/cs.json
+++ b/apps/password-reset/src/assets/i18n/cs.json
@@ -38,6 +38,11 @@
         "USER_DONT_EXIST": {
           "TITLE": "Požadovaný uživatel (dle ID nebo externí identity) neexistuje."
         },
+        "USER_NOT_ALLOWED": {
+          "TITLE": "Přístup není povolen",
+          "MESSAGE": "Servisní účty (Service account) nemají povolen přístup k této aplikaci.",
+          "REDIRECT": "Přesměrovaní na přihlášení"
+        },
         "SESSION_EXPIRATION": {
           "TITLE": "Platnost přihlášení vypršela",
           "DESCRIPTION": "Byli jste automaticky odhlášeni. Pro pokračování se znovu přihlaste.",

--- a/apps/password-reset/src/assets/i18n/en.json
+++ b/apps/password-reset/src/assets/i18n/en.json
@@ -38,6 +38,11 @@
         "USER_DONT_EXIST": {
           "TITLE": "Requested user (by ID or external identity) doesn't exist."
         },
+        "USER_NOT_ALLOWED": {
+          "TITLE": "Access not allowed",
+          "MESSAGE": "Service accounts are not allowed to access this application.",
+          "REDIRECT": "Redirect to login page"
+        },
         "SESSION_EXPIRATION": {
           "TITLE": "Session expiration",
           "DESCRIPTION": "Your session has expired. Please sign in to continue.",

--- a/apps/publications/src/assets/i18n/en.json
+++ b/apps/publications/src/assets/i18n/en.json
@@ -356,6 +356,11 @@
         "USER_DONT_EXIST": {
           "TITLE": "Requested user (by ID or external identity) doesn't exist."
         },
+        "USER_NOT_ALLOWED": {
+          "TITLE": "Access not allowed",
+          "MESSAGE": "Service accounts are not allowed to access this application.",
+          "REDIRECT": "Redirect to login page"
+        },
         "TABLE_OPTIONS": {
           "EXPORT_TO_FILE": "Export to file",
           "ALL_DATA": "All data",

--- a/apps/user-profile/src/assets/i18n/cs.json
+++ b/apps/user-profile/src/assets/i18n/cs.json
@@ -309,6 +309,11 @@
         "USER_DONT_EXIST": {
           "TITLE": "Požadovaný uživatel (dle ID nebo externí identity) neexistuje."
         },
+        "USER_NOT_ALLOWED": {
+          "TITLE": "Přístup není povolen",
+          "MESSAGE": "Servisní účty (Service account) nemají povolen přístup k této aplikaci.",
+          "REDIRECT": "Přesměrovaní na přihlášení"
+        },
         "TABLE_OPTIONS": {
           "EXPORT_TO_FILE": "Exportovat do souboru",
           "ALL_DATA": "Všechna data",

--- a/apps/user-profile/src/assets/i18n/en.json
+++ b/apps/user-profile/src/assets/i18n/en.json
@@ -353,6 +353,11 @@
         "USER_DONT_EXIST": {
           "TITLE": "Requested user (by ID or external identity) doesn't exist."
         },
+        "USER_NOT_ALLOWED": {
+          "TITLE": "Access not allowed",
+          "MESSAGE": "Service accounts are not allowed to access this application.",
+          "REDIRECT": "Redirect to login page"
+        },
         "TABLE_OPTIONS": {
           "EXPORT_TO_FILE": "Export to file",
           "ALL_DATA": "All data",

--- a/libs/general/src/index.ts
+++ b/libs/general/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/general.module';
 export * from './lib/server-down-dialog/server-down-dialog.component';
 export * from './lib/user-dont-exist-dialog/user-dont-exist-dialog.component';
 export * from './lib/prevent-proxy-overload-dialog/prevent-proxy-overload-dialog.component';
+export * from './lib/user-not-allowed-access/user-not-allowed-access.component';

--- a/libs/general/src/lib/general.module.ts
+++ b/libs/general/src/lib/general.module.ts
@@ -6,17 +6,20 @@ import { MatButtonModule } from '@angular/material/button';
 import { UserDontExistDialogComponent } from './user-dont-exist-dialog/user-dont-exist-dialog.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { PreventProxyOverloadDialogComponent } from './prevent-proxy-overload-dialog/prevent-proxy-overload-dialog.component';
+import { UserNotAllowedAccessComponent } from './user-not-allowed-access/user-not-allowed-access.component';
 
 @NgModule({
   imports: [CommonModule, MatDialogModule, MatButtonModule, TranslateModule],
   exports: [
     ServerDownDialogComponent,
     UserDontExistDialogComponent,
+    UserNotAllowedAccessComponent,
     PreventProxyOverloadDialogComponent,
   ],
   declarations: [
     ServerDownDialogComponent,
     UserDontExistDialogComponent,
+    UserNotAllowedAccessComponent,
     PreventProxyOverloadDialogComponent,
   ],
 })

--- a/libs/general/src/lib/user-not-allowed-access/user-not-allowed-access.component.html
+++ b/libs/general/src/lib/user-not-allowed-access/user-not-allowed-access.component.html
@@ -1,0 +1,11 @@
+<h1 mat-dialog-title>
+  {{'SHARED_LIB.PERUN.COMPONENTS.USER_NOT_ALLOWED.TITLE' | translate}}
+</h1>
+<div mat-dialog-content class="dialog-container">
+  {{'SHARED_LIB.PERUN.COMPONENTS.USER_NOT_ALLOWED.MESSAGE' | translate}}
+</div>
+<div mat-dialog-actions>
+  <button mat-flat-button class="ms-auto" color="accent" (click)="redirect()">
+    {{'SHARED_LIB.PERUN.COMPONENTS.USER_NOT_ALLOWED.REDIRECT' | translate}}
+  </button>
+</div>

--- a/libs/general/src/lib/user-not-allowed-access/user-not-allowed-access.component.ts
+++ b/libs/general/src/lib/user-not-allowed-access/user-not-allowed-access.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'perun-web-apps-user-dont-exist-dialog',
+  templateUrl: './user-not-allowed-access.component.html',
+  styleUrls: ['./user-not-allowed-access.component.scss'],
+})
+export class UserNotAllowedAccessComponent {
+  constructor(public dialogRef: MatDialogRef<UserNotAllowedAccessComponent>) {}
+
+  redirect(): void {
+    this.dialogRef.close();
+  }
+}

--- a/libs/perun/services/src/lib/init-auth.service.ts
+++ b/libs/perun/services/src/lib/init-auth.service.ts
@@ -12,6 +12,7 @@ import { OAuthInfoEvent, OAuthService } from 'angular-oauth2-oidc';
 import { filter } from 'rxjs/operators';
 import { firstValueFrom, timer } from 'rxjs';
 import { MfaHandlerService } from './mfa-handler.service';
+import { UserNotAllowedAccessComponent } from '@perun-web-apps/general';
 
 @Injectable({
   providedIn: 'root',
@@ -109,6 +110,14 @@ export class InitAuthService {
       if (perunPrincipal.user === null) {
         const config = getDefaultDialogConfig();
         this.dialog.open(UserDontExistDialogComponent, config);
+      } else if (perunPrincipal.user.serviceUser) {
+        const config = getDefaultDialogConfig();
+        this.dialog
+          .open(UserNotAllowedAccessComponent, config)
+          .afterClosed()
+          .subscribe(() => {
+            this.authService.logout();
+          });
       } else {
         this.storeService.setPerunPrincipal(perunPrincipal);
         this.authResolver.init(perunPrincipal);


### PR DESCRIPTION
* service accounts are now not able to log in
* a new dialog has been added, that can redirect users to /login or /service-access
* the dialog logic is evaluated when principal is loading