### PR TITLE
fix(lib): display just one alert on login page

### DIFF
--- a/libs/perun/login/src/lib/login-screen-service-access/login-screen-service-access.component.html
+++ b/libs/perun/login/src/lib/login-screen-service-access/login-screen-service-access.component.html
@@ -5,7 +5,10 @@
       <perun-web-apps-alert *ngIf="wrongUsernameOrPassword" alert_type="error">
         {{'SHARED_LIB.PERUN.LOGIN_SERVICE_ACCESS.WRONG_LOGIN_OR_PASSWORD' | translate}}
       </perun-web-apps-alert>
-      <perun-web-apps-alert *ngIf="afterLogout" class="mb-2" alert_type="success">
+      <perun-web-apps-alert
+        *ngIf="afterLogout && !wrongUsernameOrPassword"
+        class="mb-2"
+        alert_type="success">
         {{'SHARED_LIB.PERUN.LOGIN.LOGOUT_INFO' | translate}}
       </perun-web-apps-alert>
       <mat-form-field appearance="outline" subscriptSizing="dynamic">


### PR DESCRIPTION
* When the user is logged out from service-access, he/she can see the info alter about successfull log out. Then if the user try to log in again with incorrect credentials, another alert will be displayed, but the old one used to be still presented on login page.