### PR TITLE
feat(admin): check disabled and hidden dependencies for application items

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-application-form-item-dialog/delete-application-form-item-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-application-form-item-dialog/delete-application-form-item-dialog.component.html
@@ -1,10 +1,15 @@
 <h1 mat-dialog-title>{{'DIALOGS.DELETE_APPLICATION_FORM_ITEM.TITLE' | translate}}</h1>
 <div class="dialog-container" mat-dialog-content>
-  <div class="pb-2 fw-bold">
-    {{'DIALOGS.DELETE_APPLICATION_FORM_ITEM.INFO_1' | translate}}
+  <div *ngIf="!deletionDisabled">
+    <div class="pb-2 fw-bold">
+      {{'DIALOGS.DELETE_APPLICATION_FORM_ITEM.INFO_1' | translate}}
+    </div>
+    <div>{{'DIALOGS.DELETE_APPLICATION_FORM_ITEM.INFO_2' | translate}}</div>
+    <div class="pb-4 pt-2">{{'DIALOGS.DELETE_APPLICATION_FORM_ITEM.INFO_3' | translate}}</div>
   </div>
-  <div>{{'DIALOGS.DELETE_APPLICATION_FORM_ITEM.INFO_2' | translate}}</div>
-  <div class="pb-4 pt-2">{{'DIALOGS.DELETE_APPLICATION_FORM_ITEM.INFO_3' | translate}}</div>
+  <perun-web-apps-alert *ngIf="deletionDisabled" alert_type="error">
+    {{data.errorMessage}}
+  </perun-web-apps-alert>
 </div>
 <div mat-dialog-actions>
   <button (click)="onCancel()" class="ms-auto" mat-stroked-button>
@@ -12,6 +17,7 @@
   </button>
   <button
     (click)="submit()"
+    [disabled]="deletionDisabled"
     class="ms-2"
     color="warn"
     data-cy="delete-application-form-item-dialog"

--- a/apps/admin-gui/src/app/shared/components/dialogs/delete-application-form-item-dialog/delete-application-form-item-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/delete-application-form-item-dialog/delete-application-form-item-dialog.component.ts
@@ -1,5 +1,9 @@
-import { Component } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+export interface DeleteApplicationFormItemDialogData {
+  errorMessage: string;
+}
 
 @Component({
   selector: 'app-delete-application-form-item-dialog',
@@ -7,7 +11,14 @@ import { MatDialogRef } from '@angular/material/dialog';
   styleUrls: ['./delete-application-form-item-dialog.component.scss'],
 })
 export class DeleteApplicationFormItemDialogComponent {
-  constructor(private dialogRef: MatDialogRef<DeleteApplicationFormItemDialogComponent>) {}
+  deletionDisabled: boolean;
+
+  constructor(
+    private dialogRef: MatDialogRef<DeleteApplicationFormItemDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: DeleteApplicationFormItemDialogData
+  ) {
+    this.deletionDisabled = this.data.errorMessage?.length !== 0;
+  }
 
   onCancel(): void {
     this.dialogRef.close(false);

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.html
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component.html
@@ -67,7 +67,8 @@
                 <perun-web-apps-selection-item-search-select
                   [attributes]="sourceAttributes"
                   [selectedAttribute]="applicationFormItem.perunSourceAttribute"
-                  (itemSelected)="applicationFormItem.perunSourceAttribute = $event.value"
+                  (itemSelected)="applicationFormItem.perunSourceAttribute = $event.value; loadWarning(itemType.SOURCE)"
+                  [warning]="displayWarningForSourceAttr ? warningMessage : ''"
                   [asGroup]="!!data.group"
                   [type]="itemType.SOURCE">
                 </perun-web-apps-selection-item-search-select>
@@ -81,7 +82,8 @@
                 <perun-web-apps-selection-item-search-select
                   [attributes]="destinationAttributes"
                   [selectedAttribute]="applicationFormItem.perunDestinationAttribute"
-                  (itemSelected)="applicationFormItem.perunDestinationAttribute = $event.value"
+                  (itemSelected)="applicationFormItem.perunDestinationAttribute = $event.value; loadWarning(itemType.DESTINATION)"
+                  [warning]="displayWarningForDestinationAttr ? warningMessage : ''"
                   [asGroup]="!!data.group"
                   [type]="itemType.DESTINATION">
                 </perun-web-apps-selection-item-search-select>

--- a/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.ts
+++ b/apps/admin-gui/src/app/vos/components/application-form-list/application-form-list.component.ts
@@ -11,8 +11,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatTable } from '@angular/material/table';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { DeleteApplicationFormItemDialogComponent } from '../../../shared/components/dialogs/delete-application-form-item-dialog/delete-application-form-item-dialog.component';
-import { NotificatorService } from '@perun-web-apps/perun/services';
-import { TranslateService } from '@ngx-translate/core';
+import { NotificatorService, PerunTranslateService } from '@perun-web-apps/perun/services';
 import { EditApplicationFormItemDialogComponent } from '../../../shared/components/dialogs/edit-application-form-item-dialog/edit-application-form-item-dialog.component';
 import { ApplicationForm, ApplicationFormItem } from '@perun-web-apps/perun/openapi';
 import { getDefaultDialogConfig } from '@perun-web-apps/perun/utils';
@@ -67,37 +66,37 @@ export class ApplicationFormListComponent implements OnInit, OnChanges {
     private dialog: MatDialog,
     private notificator: NotificatorService,
     private router: Router,
-    private translate: TranslateService
+    private translate: PerunTranslateService
   ) {}
 
   ngOnInit(): void {
     // labels for hidden and disabled icons
     this.ifEmpty = this.translate.instant(
       'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.IF_EMPTY'
-    ) as string;
+    );
     this.ifPrefilled = this.translate.instant(
       'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.IF_PREFILLED'
-    ) as string;
+    );
 
     // tooltips for hidden and disabled icons
     this.alwaysDisabled = this.translate.instant(
       'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.ALWAYS_DISABLED_HINT'
-    ) as string;
+    );
     this.alwaysHidden = this.translate.instant(
       'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.ALWAYS_HIDDEN_HINT'
-    ) as string;
+    );
     this.isDisabledIf = this.translate.instant(
       'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.DISABLED_IF_HINT'
-    ) as string;
+    );
     this.isHiddenIf = this.translate.instant(
       'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.HIDDEN_IF_HINT'
-    ) as string;
+    );
     this.isEmpty = this.translate.instant(
       'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.IS_EMPTY_HINT'
-    ) as string;
+    );
     this.isPrefilled = this.translate.instant(
       'VO_DETAIL.SETTINGS.APPLICATION_FORM.DISABLED_HIDDEN_ICON.IS_PREFILLED_HINT'
-    ) as string;
+    );
   }
 
   ngOnChanges(): void {
@@ -188,8 +187,33 @@ export class ApplicationFormListComponent implements OnInit, OnChanges {
   }
 
   delete(applicationFormItem: ApplicationFormItem): void {
+    let errorMessage = '';
+    const hiddenDependencyForItem = this.applicationFormItems.find(
+      (item) => item.hiddenDependencyItemId === applicationFormItem.id
+    );
+    const disabledDependencyForItem = this.applicationFormItems.find(
+      (item) => item.disabledDependencyItemId === applicationFormItem.id
+    );
+    if (hiddenDependencyForItem || disabledDependencyForItem) {
+      errorMessage = this.translate.instant(
+        'DIALOGS.APPLICATION_FORM_EDIT_ITEM.DEPENDENCY_ERROR_MESSAGE',
+        hiddenDependencyForItem
+          ? {
+              dependency: 'hidden',
+              shortname: hiddenDependencyForItem.shortname,
+            }
+          : {
+              dependency: 'disabled',
+              shortname: disabledDependencyForItem.shortname,
+            }
+      );
+    }
+
     const config = getDefaultDialogConfig();
     config.width = '500px';
+    config.data = {
+      errorMessage: errorMessage,
+    };
 
     const dialog = this.dialog.open(DeleteApplicationFormItemDialogComponent, config);
     dialog.afterClosed().subscribe((deleteItem) => {

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1376,6 +1376,8 @@
       "SOURCE_ATTRIBUTE_DESCRIPTION": "Select attribute, which will be used to pre-fill form value. You can select also organization attributes.",
       "DESTINATION_ATTRIBUTE": "Destination attribute",
       "DESTINATION_ATTRIBUTE_DESCRIPTION": "Select attribute, where will be submitted value stored after accepting user`s application.",
+      "DEPENDENCY_WARNING_MESSAGE": "Be careful when changing this attribute - this item is a {{dependency}} dependency for item {{shortname}}",
+      "DEPENDENCY_ERROR_MESSAGE": "You can't delete this item because it is a {{dependency}} dependency for item {{shortname}}",
       "FEDERATION_ATTRIBUTE": "Federation attribute",
       "FEDERATION_ATTRIBUTE_DESCRIPTION": "Select federation attribute to get pre-filed value from.",
       "REQUIRED": "Required",

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.css
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.css
@@ -18,3 +18,8 @@
 .black {
   color: black;
 }
+
+.warning {
+  color: darkorange;
+  font-weight: bold;
+}

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.html
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.html
@@ -1,5 +1,5 @@
 <div class="d-flex flex-row align-items-center gap-4">
-  <mat-form-field class="w-100 pb-0">
+  <mat-form-field class="w-100 pb-0" subscriptSizing="dynamic">
     <mat-label>{{selectPlaceholder}}</mat-label>
     <mat-select
       [required]="required"
@@ -50,6 +50,7 @@
         </mat-option>
       </cdk-virtual-scroll-viewport>
     </mat-select>
+    <mat-hint *ngIf="warning?.length !== 0" class="warning">{{warning}}</mat-hint>
   </mat-form-field>
 
   <perun-web-apps-deselect-button

--- a/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.ts
+++ b/libs/perun/components/src/lib/entity-search-select/entity-search-select.component.ts
@@ -38,6 +38,7 @@ export class EntitySearchSelectComponent<T extends PerunBean>
   @Input() highlightOption = false;
   @Input() theme = '';
   @Input() required = false;
+  @Input() warning: string;
   @Output() entitySelected = new EventEmitter<T | T[]>();
   @Output() selectClosed = new EventEmitter<boolean>();
   @ViewChild('scrollViewport', { static: false }) scrollViewport: CdkVirtualScrollViewport;

--- a/libs/perun/components/src/lib/selection-item-search-select/selection-item-search-select.component.html
+++ b/libs/perun/components/src/lib/selection-item-search-select/selection-item-search-select.component.html
@@ -5,6 +5,7 @@
   [searchFunction]="searchFunction"
   [mainTextFunction]="nameFunction"
   [secondaryTextFunction]="shortNameFunction"
+  [warning]="warning"
   [selectPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.SELECTION_ITEM_SEARCH_SELECT.SELECT_ITEM' | translate"
   [findPlaceholder]="'SHARED_LIB.PERUN.COMPONENTS.SELECTION_ITEM_SEARCH_SELECT.FIND_ITEM' | translate"
   [noEntriesText]="'SHARED_LIB.PERUN.COMPONENTS.SELECTION_ITEM_SEARCH_SELECT.NO_ITEM_FOUND' | translate">

--- a/libs/perun/components/src/lib/selection-item-search-select/selection-item-search-select.component.ts
+++ b/libs/perun/components/src/lib/selection-item-search-select/selection-item-search-select.component.ts
@@ -28,6 +28,7 @@ export class SelectionItemSearchSelectComponent implements OnInit {
   @Input() selectedAttribute: string;
   @Input() type: ItemType;
   @Input() asGroup = false;
+  @Input() warning: string;
   @Output() itemSelected = new EventEmitter<SelectionItem>();
 
   items: SelectionItem[] = [];


### PR DESCRIPTION
* Provide a warning message when trying to change source or destination attribute for items which are marked as hidden or disabled dependency for another form item.
* Display an error in dialog when trying to delete an item which is marked as hidden or disabled dependency for another form item (it used to throw an uncatched exception).