### PR TITLE
feat: close session expired dialog in all tabs

### DIFF
--- a/libs/perun/services/src/lib/auth.service.ts
+++ b/libs/perun/services/src/lib/auth.service.ts
@@ -33,7 +33,21 @@ export class AuthService {
         this.filterShortname = String(params['idpFilter']);
       }
     });
+
+    // The storage event of the Window interface fires when a storage area (localStorage) has been modified in the context of another document.
+    window.addEventListener('storage', this.closeSessionDialogsForOtherTabs);
   }
+
+  closeSessionDialogsForOtherTabs = (event: StorageEvent): void => {
+    // Check if user authenticated in other tab and if so close the session expiration dialog
+    if (event.key === 'access_token' && this.oauthService.hasValidAccessToken()) {
+      this.dialog.openDialogs.forEach((dialog) => {
+        if (dialog.id === 'SessionExpirationDialog') {
+          dialog.close();
+        }
+      });
+    }
+  };
 
   loadOidcConfigData(): void {
     this.oauthService.configure(this.getClientConfig());


### PR DESCRIPTION
The reauthentication of user in multiple tabs works fine. However the session expired dialog stayed present aand prevented usage of the app. This is no longer the case