### PR TITLE
fix(admin): key 'resources' duplicated in localStorage

### DIFF
--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
@@ -524,7 +524,7 @@ export class SideMenuItemService {
         url: [`/organizations/${vo.id}/resources`],
         activatedRegex: '/organizations/\\d+/resources$',
         children: children,
-        showChildren: 'resources',
+        showChildren: 'resourcesExpandable',
       });
     }
 

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-overview/vo-overview.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-overview/vo-overview.component.html
@@ -4,7 +4,7 @@
   <perun-web-apps-expandable-tiles
     [items]="resourcesItems"
     [title]="'MENU_ITEMS.VO.RESOURCES'"
-    [sectionId]="'resources'">
+    [sectionId]="'resourcesExpandable'">
   </perun-web-apps-expandable-tiles>
   <perun-web-apps-expandable-tiles
     [items]="settingsItems"

--- a/libs/perun/models/src/lib/ExpandabelTiles.ts
+++ b/libs/perun/models/src/lib/ExpandabelTiles.ts
@@ -1,1 +1,5 @@
-export type ExpandableSectionId = 'settings' | 'resources' | 'visualizer' | 'authentication';
+export type ExpandableSectionId =
+  | 'settings'
+  | 'resourcesExpandable'
+  | 'visualizer'
+  | 'authentication';

--- a/libs/perun/services/src/lib/expanded-tiles-store.service.ts
+++ b/libs/perun/services/src/lib/expanded-tiles-store.service.ts
@@ -16,7 +16,7 @@ export class ExpandedTilesStoreService {
   // Right now there is no check if all sections are initialized and needs to be kept manually updated
   private sections: ExpandableSectionId[] = [
     'settings',
-    'resources',
+    'resourcesExpandable',
     'visualizer',
     'authentication',
   ];

--- a/libs/perun/utils/src/lib/perun-utils.ts
+++ b/libs/perun/utils/src/lib/perun-utils.ts
@@ -267,7 +267,7 @@ export function getRecentlyVisitedItems(key: string): RecentItem[] {
  * @param key of localStorage
  * @param item entity that was visited
  */
-export function addRecentlyVisited(key: string, item: Vo | Facility | Group): void {
+export function addRecentlyVisited(key: string, item: Vo | Facility | Group | Resource): void {
   if (localStorage.getItem(key) === null) {
     // if user not have any in local storage
     const recent: number[] = [];


### PR DESCRIPTION
* Expandable tiles functionality added 'resources' as a new key to localStorage, but this key had been already used by recently visited functionality.
* This caused that if expandable functionality change the value in localStorage to 'true', the resource list will be broken due to recently visited functionality.
* Key for expandable tiles in localStorage is changed to 'resourcesExpandable'.