### PR TITLE
feat(profile): consolidator config uses full url

### DIFF
--- a/apps/user-profile/src/app/pages/identities-page/identities-page.component.ts
+++ b/apps/user-profile/src/app/pages/identities-page/identities-page.component.ts
@@ -143,11 +143,8 @@ export class IdentitiesPageComponent implements OnInit {
       });
     } else {
       this.registrarManagerService.getConsolidatorToken().subscribe((token) => {
-        const type = this.storage.getPerunPrincipal().extSourceType;
-        const consolidatorBaseUrl = this.storage.getProperty('consolidator_base_url');
-        window.location.href = `${consolidatorBaseUrl}${
-          type?.endsWith('X509') ? 'cert' : 'fed'
-        }-ic/ic/?target_url=${window.location.href}&token=${token}`;
+        const consolidatorUrl = this.storage.getProperty('consolidator_url');
+        window.location.href = `${consolidatorUrl}?target_url=${window.location.href}&token=${token}`;
       });
     }
   }

--- a/apps/user-profile/src/assets/config/defaultConfig.json
+++ b/apps/user-profile/src/assets/config/defaultConfig.json
@@ -28,7 +28,7 @@
     "urn:perun:user:attribute-def:def:login-namespace:egi-ui",
     "urn:perun:user:attribute-def:def:login-namespace:sitola"
   ],
-  "consolidator_base_url": "https://perun-dev.cesnet.cz/",
+  "consolidator_url": "https://perun-dev.cesnet.cz/cert-ic/ic/",
   "registrar_base_url": "https://perun-dev.cesnet.cz/fed/registrar/",
   "use_localhost_linker_url": false,
   "password_help": {

--- a/libs/perun/models/src/lib/ConfigProperties.ts
+++ b/libs/perun/models/src/lib/ConfigProperties.ts
@@ -186,7 +186,7 @@ export interface PerunConfig {
   // User profile specific
   // Required
   displayed_tabs: string[];
-  consolidator_base_url: string;
+  consolidator_url: string;
   registrar_base_url: string;
   mfa: ProfileMFA;
   preferred_unix_group_names: string[];


### PR DESCRIPTION
* Changed the consolidator_base_url property to consolidator_url, which now includes the full url, thus no fed/cert rerouting is done in code.

BREAKING CHANGE: The consolidator_base_url config property needs to be changed to consolidator_url and include the complete url.