### PR TITLE
fix(profile): support adding both fed and cert identity types

### DIFF
--- a/apps/user-profile/src/app/pages/identities-page/identities-page.component.html
+++ b/apps/user-profile/src/app/pages/identities-page/identities-page.component.html
@@ -1,6 +1,6 @@
 <div class="user-theme">
   <h1 class="page-title">{{'IDENTITIES.IDP' | customTranslate | translate}}</h1>
-  <button mat-flat-button color="accent" (click)="addIdentity()" [disabled]="loading">
+  <button mat-flat-button color="accent" (click)="addIdentity(false)" [disabled]="loading">
     {{'IDENTITIES.ADD' | customTranslate | translate}}
   </button>
   <button
@@ -23,7 +23,7 @@
 
   <div *ngIf="displayCertificates">
     <h1 class="page-title mt-5">{{'IDENTITIES.CERT' | customTranslate | translate}}</h1>
-    <button mat-flat-button color="accent" (click)="addIdentity()" [disabled]="loading">
+    <button mat-flat-button color="accent" (click)="addIdentity(true)" [disabled]="loading">
       {{'IDENTITIES.ADD' | customTranslate | translate}}
     </button>
     <button

--- a/apps/user-profile/src/app/pages/identities-page/identities-page.component.ts
+++ b/apps/user-profile/src/app/pages/identities-page/identities-page.component.ts
@@ -125,7 +125,7 @@ export class IdentitiesPageComponent implements OnInit {
     });
   }
 
-  addIdentity(): void {
+  addIdentity(cert: boolean): void {
     if (this.storage.getProperty('use_new_consolidator')) {
       this.openLinkerService.openLinkerWindow((result: LinkerResult) => {
         if (result === 'TOKEN_EXPIRED') {
@@ -143,7 +143,10 @@ export class IdentitiesPageComponent implements OnInit {
       });
     } else {
       this.registrarManagerService.getConsolidatorToken().subscribe((token) => {
-        const consolidatorUrl = this.storage.getProperty('consolidator_url');
+        let consolidatorUrl = this.storage.getProperty('consolidator_url');
+        if (cert) {
+          consolidatorUrl = this.storage.getProperty('consolidator_url_cert');
+        }
         window.location.href = `${consolidatorUrl}?target_url=${window.location.href}&token=${token}`;
       });
     }

--- a/apps/user-profile/src/assets/config/defaultConfig.json
+++ b/apps/user-profile/src/assets/config/defaultConfig.json
@@ -28,7 +28,8 @@
     "urn:perun:user:attribute-def:def:login-namespace:egi-ui",
     "urn:perun:user:attribute-def:def:login-namespace:sitola"
   ],
-  "consolidator_url": "https://perun-dev.cesnet.cz/cert-ic/ic/",
+  "consolidator_url": "https://perun-dev.cesnet.cz/allfed-ic/ic/",
+  "consolidator_url_cert": "https://perun-dev.cesnet.cz/cert-ic/ic/",
   "registrar_base_url": "https://perun-dev.cesnet.cz/fed/registrar/",
   "use_localhost_linker_url": false,
   "password_help": {

--- a/libs/perun/models/src/lib/ConfigProperties.ts
+++ b/libs/perun/models/src/lib/ConfigProperties.ts
@@ -187,6 +187,7 @@ export interface PerunConfig {
   // Required
   displayed_tabs: string[];
   consolidator_url: string;
+  consolidator_url_cert: string;
   registrar_base_url: string;
   mfa: ProfileMFA;
   preferred_unix_group_names: string[];


### PR DESCRIPTION
DEPLOYMENT NOTE: Added new config option "consolidator_url_cert" in order to support different URLs for consolidator with federated and certificate authentication.