### PR TITLE
feat(admin): display also indirect managers

### DIFF
--- a/apps/admin-gui/src/app/shared/components/managers-page/managers-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/managers-page/managers-page.component.html
@@ -34,7 +34,7 @@
 
       <mat-form-field data-cy="role-filter" class="me-2 mt-2">
         <mat-label>{{'SHARED.COMPONENTS.MANAGERS_PAGE.SELECT_ROLE' | translate}}</mat-label>
-        <mat-select (selectionChange)="refreshUsers()" [(value)]="selectedRole">
+        <mat-select (selectionChange)="refreshUsers(true)" [(value)]="selectedRole">
           <mat-option
             attr.data-cy="{{role.roleName | lowercase}}"
             *ngFor="let role of availableRoles"
@@ -44,6 +44,14 @@
         </mat-select>
       </mat-form-field>
 
+      <mat-checkbox
+        *ngIf="complementaryObject.beanName.includes('Group')"
+        (change)="showIndirectAdmins = !showIndirectAdmins; refreshUsers()"
+        [checked]="showIndirectAdmins"
+        color="primary">
+        {{'SHARED.COMPONENTS.MANAGERS_PAGE.SHOW_INDIRECT_ADMINS' | translate}}
+      </mat-checkbox>
+
       <ng-template #spinner>
         <perun-web-apps-loading-table></perun-web-apps-loading-table>
       </ng-template>
@@ -51,6 +59,7 @@
         <app-users-list
           *perunWebAppsLoader="loading; indicator: spinner"
           [disableSelf]="disableSelf"
+          [directAdmins]="directAdminsIds"
           [tableId]="tableId"
           [disableRouting]="!routeAuth || disableRouting"
           [displayedColumns]="displayedUserColumns"

--- a/apps/admin-gui/src/app/shared/components/users-list/users-list.component.html
+++ b/apps/admin-gui/src/app/shared/components/users-list/users-list.component.html
@@ -17,7 +17,7 @@
       matSortDisableClear>
       <ng-container
         matColumnDef="select"
-        *ngIf="{all: dataSource | isAllSelected: selection.selected.length} as selected">
+        *ngIf="{all: dataSource | isAllSelected: selection.selected.length :canBeSelected} as selected">
         <th *matHeaderCellDef class="align-checkbox" mat-header-cell>
           <mat-checkbox
             (change)="$event ? masterToggle() : null"
@@ -28,16 +28,27 @@
             color="primary">
           </mat-checkbox>
         </th>
-        <td *matCellDef="let row" class="static-column-size align-checkbox" mat-cell>
-          <mat-checkbox
-            (change)="$event ? selection.toggle(row) : null"
-            (click)="$event.stopPropagation()"
-            [aria-label]="selection.isSelected(row) | checkboxLabel | translate: {name: row | userFullName}"
-            [checked]="selection.isSelected(row)"
-            [disabled]="disableSelf && row.id === principalId && !authResolver.isPerunAdmin()"
-            attr.data-cy="{{row.firstName | lowercase}}-checkbox"
-            color="primary">
-          </mat-checkbox>
+        <td
+          *matCellDef="let row"
+          class="static-column-size align-checkbox"
+          mat-cell
+          (mouseenter)="disabledRouting = true"
+          (mouseleave)="disabledRouting = disableRouting"
+          [class.cursor-default]="!canBeSelected(row)">
+          <span
+            matTooltip="{{'MANAGERS_LIST.INDIRECT_DISABLED_TOOLTIP' | translate}}"
+            [matTooltipPosition]="'above'"
+            [matTooltipDisabled]="canBeSelected(row)">
+            <mat-checkbox
+              (change)="$event ? selection.toggle(row) : null"
+              (click)="$event.stopPropagation()"
+              [aria-label]="selection.isSelected(row) | checkboxLabel | translate: {name: row | userFullName}"
+              [checked]="selection.isSelected(row)"
+              [disabled]="disableSelf && row.id === principalId && !authResolver.isPerunAdmin() || !canBeSelected(row)"
+              attr.data-cy="{{row.firstName | lowercase}}-checkbox"
+              color="primary">
+            </mat-checkbox>
+          </span>
         </td>
       </ng-container>
       <ng-container matColumnDef="user">
@@ -99,8 +110,8 @@
       <tr
         *matRowDef="let user; columns: displayedColumns;"
         [class.cursor-pointer]="!disableRouting"
-        [routerLink]="disableRouting ? null : (routeToAdmin ? ['/admin/users', user.id] : ['/myProfile/service-identities', user.id])"
-        [perunWebAppsMiddleClickRouterLink]="disableRouting ? null : (routeToAdmin ? ['/admin/users', user.id] : ['/myProfile/service-identities', user.id])"
+        [routerLink]="disableRouting || disabledRouting ? null : (routeToAdmin ? ['/admin/users', user.id] : ['/myProfile/service-identities', user.id])"
+        [perunWebAppsMiddleClickRouterLink]="disableRouting || disabledRouting ? null : (routeToAdmin ? ['/admin/users', user.id] : ['/myProfile/service-identities', user.id])"
         class="dark-hover-list-item"
         mat-row></tr>
     </table>

--- a/apps/admin-gui/src/app/shared/components/users-list/users-list.component.scss
+++ b/apps/admin-gui/src/app/shared/components/users-list/users-list.component.scss
@@ -1,3 +1,7 @@
 .cursor-pointer {
   cursor: pointer;
 }
+
+.cursor-default {
+  cursor: default;
+}

--- a/apps/admin-gui/src/app/shared/components/users-list/users-list.component.ts
+++ b/apps/admin-gui/src/app/shared/components/users-list/users-list.component.ts
@@ -42,11 +42,13 @@ export class UsersListComponent implements OnChanges {
   noUsersFoundLabel: string;
   @Input()
   disableSelf = false;
+  @Input() directAdmins: number[] = null;
 
   svgIcon = 'perun-service-identity-black';
   dataSource: MatTableDataSource<RichUser>;
   principalId: number;
   pageSizeOptions = TABLE_ITEMS_COUNT_OPTIONS;
+  disabledRouting = false;
   private sort: MatSort;
 
   constructor(
@@ -103,6 +105,9 @@ export class UsersListComponent implements OnChanges {
     }
   }
 
+  canBeSelected = (row: RichUser): boolean =>
+    this.directAdmins === null || this.directAdmins.includes(row.id);
+
   exportAllData(format: string): void {
     downloadData(
       getDataForExport(
@@ -157,7 +162,11 @@ export class UsersListComponent implements OnChanges {
   }
 
   isAllSelected(): boolean {
-    return this.tableCheckbox.isAllSelected(this.selection.selected.length, this.dataSource);
+    return this.tableCheckbox.isAllSelected(
+      this.selection.selected.length,
+      this.dataSource,
+      this.canBeSelected
+    );
   }
 
   masterToggle(): void {
@@ -169,7 +178,8 @@ export class UsersListComponent implements OnChanges {
       this.sort,
       this.child.paginator.pageSize,
       this.child.paginator.pageIndex,
-      false
+      true,
+      this.canBeSelected
     );
   }
 }

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -2451,7 +2451,8 @@
     "EMAIL": "Email",
     "LOGINS": "Logins",
     "PERSON": "Person",
-    "SERVICE": "Service"
+    "SERVICE": "Service",
+    "INDIRECT_DISABLED_TOOLTIP": "Indirect manager cannot be deleted"
   },
   "AUDIT_MESSAGES_LIST": {
     "ID": "Id",
@@ -2722,6 +2723,7 @@
         "REMOVE": "Remove",
         "SELECT_MODE": "Select mode",
         "SELECT_ROLE": "Select role",
+        "SHOW_INDIRECT_ADMINS": "Show also indirect managers",
         "USER": "Users",
         "GROUP": "Groups",
         "NO_MANAGERS": "This role has no managers.",


### PR DESCRIPTION
* Under the group on the managers page there is now available to optionally display also indirect managers of this group.