### PR TITLE
chore: git action for PR state overview

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,1 @@
+name: PR status


### PR DESCRIPTION
Draft for PR state overview. Each PR could contain a list of items that need to be checked before it is considered ready to merge.
Example
- [ ] Code check
- [ ] Manually tested
- [x] Trust me, it works

Labels could be added for better insight on the pull request overview page. It is than possible to set up git action that would update the comment (run on label added) and mark check boxes based on assigned labels.
https://docs.github.com/en/github-ae@latest/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added
https://stackoverflow.com/questions/58468495/how-create-a-comment-on-commit-with-github-actions