### PR TITLE
feat(admin): update User section Perun Admin menu

### DIFF
--- a/apps/admin-gui/src/app/admin/admin-routing.module.ts
+++ b/apps/admin-gui/src/app/admin/admin-routing.module.ts
@@ -11,15 +11,12 @@ import { UserDestinationGraphComponent } from './pages/admin-page/admin-visualiz
 import { AdminUsersComponent } from './pages/admin-page/admin-users/admin-users.component';
 import { AdminUserDetailPageComponent } from './pages/admin-user-detail-page/admin-user-detail-page.component';
 import { UserOverviewComponent } from '../users/pages/user-detail-page/user-overview/user-overview.component';
-import { UserOrganizationsComponent } from '../users/pages/user-detail-page/user-organizations/user-organizations.component';
-import { UserGroupsComponent } from '../users/pages/user-detail-page/user-groups/user-groups.component';
 import { UserAttributesComponent } from '../users/pages/user-detail-page/user-attributes/user-attributes.component';
 import { AdminExtSourcesComponent } from './pages/admin-page/admin-ext-sources/admin-ext-sources.component';
 import { UserRolesComponent } from '../users/pages/user-detail-page/user-settings/user-roles/user-roles.component';
 import { UserSettingsServiceIdentitiesComponent } from '../users/pages/user-detail-page/user-settings/user-settings-service-identities/user-settings-service-identities.component';
 import { UserIdentitiesComponent } from '../users/pages/user-detail-page/user-identities/user-identities.component';
 import { AdminServicesComponent } from './pages/admin-page/admin-services/admin-services.component';
-import { UserResourcesComponent } from '../users/pages/user-detail-page/user-resources/user-resources.component';
 import { IdentityDetailComponent } from '../shared/components/identity-detail/identity-detail.component';
 import { ServiceDetailPageComponent } from './pages/admin-page/admin-services/service-detail-page/service-detail-page.component';
 import { ServiceOverviewComponent } from './pages/admin-page/admin-services/service-detail-page/service-overview/service-overview.component';
@@ -27,7 +24,6 @@ import { ServiceRequiredAttributesComponent } from './pages/admin-page/admin-ser
 import { UserSettingsAssociatedUsersComponent } from '../users/pages/user-detail-page/user-settings/user-settings-associated-users/user-settings-associated-users.component';
 import { ServiceDestinationsComponent } from './pages/admin-page/admin-services/service-detail-page/service-destinations/service-destinations.component';
 import { AdminOwnersComponent } from './pages/admin-page/admin-owners/admin-owners.component';
-import { UserFacilitiesComponent } from '../users/pages/user-detail-page/user-facilities/user-facilities.component';
 import { UserAccountsComponent } from '../users/pages/user-detail-page/user-accounts/user-accounts.component';
 import { AdminAuditLogComponent } from './pages/admin-page/admin-audit-log/admin-audit-log.component';
 import { AdminConsentHubsComponent } from './pages/admin-page/admin-consent-hubs/admin-consent-hubs.component';
@@ -35,6 +31,7 @@ import { AdminSearcherComponent } from './pages/admin-page/admin-searcher/admin-
 import { RouteAuthGuardService } from '../shared/route-auth-guard.service';
 import { UserBansComponent } from '../users/pages/user-detail-page/user-bans/user-bans.component';
 import { AdminBlockedLoginsComponent } from './pages/admin-page/admin-blocked-logins/admin-blocked-logins.component';
+import { UserAssignmentsComponent } from '../users/pages/user-detail-page/user-assignments/user-assignments.component';
 
 const routes: Routes = [
   {
@@ -136,34 +133,19 @@ const routes: Routes = [
         data: { animation: 'UserAccountsPage' },
       },
       {
+        path: 'assignments',
+        component: UserAssignmentsComponent,
+        data: { animation: 'UserAssignmentsPage' },
+      },
+      {
         path: 'attributes',
         component: UserAttributesComponent,
         data: { animation: 'UserAttributesPage' },
       },
       {
-        path: 'organizations',
-        component: UserOrganizationsComponent,
-        data: { animation: 'UserOrganizationsPage', showPrincipal: false },
-      },
-      {
-        path: 'groups',
-        component: UserGroupsComponent,
-        data: { animation: 'UserGroupsPage', showPrincipal: false },
-      },
-      {
         path: 'identities',
         component: UserIdentitiesComponent,
         data: { animation: 'UserIdentitiesPage' },
-      },
-      {
-        path: 'facilities',
-        component: UserFacilitiesComponent,
-        data: { animation: 'UserFacilitiesPage' },
-      },
-      {
-        path: 'resources',
-        component: UserResourcesComponent,
-        data: { animation: 'UserRoles' },
       },
       {
         path: 'identities/:identityId',

--- a/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.html
+++ b/apps/admin-gui/src/app/shared/components/two-entity-attribute-page/two-entity-attribute-page.component.html
@@ -7,7 +7,7 @@
   >
 
   <div *ngIf="entityValues.length !== 0">
-    <div class="flex-row">
+    <div *ngIf="showSelect" class="flex-row">
       <perun-web-apps-group-search-select
         *ngIf="secondEntity === 'group'"
         (groupSelected)="specifySecondEntity($event)"

--- a/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
+++ b/apps/admin-gui/src/app/shared/side-menu/side-menu-item.service.ts
@@ -628,20 +628,6 @@ export class SideMenuItemService {
       activatedRegex: `${regex}$`,
     });
 
-    // Organizations
-    links.push({
-      label: 'MENU_ITEMS.ADMIN.ORGANIZATIONS',
-      url: [`${path}/organizations`],
-      activatedRegex: `${regex}/organizations`,
-    });
-
-    // Groups
-    links.push({
-      label: 'MENU_ITEMS.ADMIN.GROUPS',
-      url: [`${path}/groups`],
-      activatedRegex: `${regex}/groups`,
-    });
-
     // Accounts
     links.push({
       label: 'MENU_ITEMS.USER.ACCOUNTS',
@@ -649,25 +635,18 @@ export class SideMenuItemService {
       activatedRegex: `${regex}/accounts`,
     });
 
+    // Assignments
+    links.push({
+      label: 'MENU_ITEMS.USER.ASSIGNMENTS',
+      url: [`${path}/assignments`],
+      activatedRegex: `${regex}/assignments`,
+    });
+
     // Identities
     links.push({
       label: 'MENU_ITEMS.USER.IDENTITIES',
       url: [`${path}/identities`],
       activatedRegex: `${regex}/identities`,
-    });
-
-    // Facilities
-    links.push({
-      label: 'MENU_ITEMS.USER.FACILITIES',
-      url: [`${path}/facilities`],
-      activatedRegex: `${regex}/facilities`,
-    });
-
-    // Resources
-    links.push({
-      label: 'MENU_ITEMS.USER.RESOURCES',
-      url: [`${path}/resources`],
-      activatedRegex: `${regex}/resources`,
     });
 
     // Attributes

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-accounts/user-accounts.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-accounts/user-accounts.component.html
@@ -1,90 +1,93 @@
 <h1 class="page-title">{{'USER_DETAIL.ACCOUNTS.TITLE' | translate}}</h1>
-<mat-spinner class="ms-auto me-auto" *ngIf="initLoading"></mat-spinner>
-<div class="d-flex">
-  <perun-web-apps-vo-search-select
-    *ngIf="!(initLoading || vos.length === 0)"
-    class="w-50"
-    [vos]="vos"
-    (voSelected)="loadMember($event)">
-  </perun-web-apps-vo-search-select>
-</div>
-<mat-tab-group *ngIf="!(initLoading || vos.length === 0)" mat-stretch-tabs="false">
-  <mat-tab>
-    <ng-template matTabLabel>
-      {{'USER_DETAIL.ACCOUNTS.STATUS' | translate}}
-    </ng-template>
-    <ng-template matTabContent>
-      <mat-spinner class="ms-auto me-auto" *ngIf="loading"></mat-spinner>
-      <div *ngIf="!loading">
-        <div class="mt-4 mb-4">
-          <span class="subtitle me-2">{{'USER_DETAIL.ACCOUNTS.MEMBER' | translate}}:</span>
-          <a
-            class="member-link"
-            [perunWebAppsMiddleClickRouterLink]="['/organizations', selectedVo.id.toString(), 'members', member.id.toString()]"
-            (auxclick)="$event.preventDefault()"
-            [routerLink]="['/organizations', selectedVo.id, 'members', member.id]"
-            >{{member.id}}
-          </a>
+<ng-template #spinner1>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div *perunWebAppsLoader="initLoading; indicator: spinner1">
+  <div class="d-flex">
+    <perun-web-apps-vo-search-select
+      *ngIf="!(initLoading || vos.length === 0)"
+      class="w-50"
+      [vos]="vos"
+      (voSelected)="loadMember($event)">
+    </perun-web-apps-vo-search-select>
+  </div>
+  <mat-tab-group *ngIf="!(initLoading || vos.length === 0)" mat-stretch-tabs="false">
+    <mat-tab>
+      <ng-template matTabLabel>
+        {{'USER_DETAIL.ACCOUNTS.STATUS' | translate}}
+      </ng-template>
+      <ng-template matTabContent>
+        <mat-spinner class="ms-auto me-auto" *ngIf="loading"></mat-spinner>
+        <div *ngIf="!loading">
+          <div class="mt-4 mb-4">
+            <span class="subtitle me-2">{{'USER_DETAIL.ACCOUNTS.MEMBER' | translate}}:</span>
+            <a
+              class="member-link"
+              [perunWebAppsMiddleClickRouterLink]="['/organizations', selectedVo.id.toString(), 'members', member.id.toString()]"
+              (auxclick)="$event.preventDefault()"
+              [routerLink]="['/organizations', selectedVo.id, 'members', member.id]"
+              >{{member.id}}
+            </a>
+          </div>
+          <mat-card appearance="outlined" class="mat-elevation-z3 membership-card">
+            <perun-web-apps-member-overview-membership [member]="member" [voId]="selectedVo.id">
+            </perun-web-apps-member-overview-membership>
+          </mat-card>
+          <p class="mt-4 subtitle">{{'USER_DETAIL.ACCOUNTS.GROUPS' | translate}}</p>
+          <perun-web-apps-groups-list
+            [groups]="groups"
+            [memberId]="member?.id"
+            [memberGroupStatus]="member.groupStatus"
+            (refreshTable)="loadMember(selectedVo)"
+            [displayedColumns]="['id', 'recent', 'name', 'description', 'expiration', 'groupStatus']">
+          </perun-web-apps-groups-list>
         </div>
-        <mat-card appearance="outlined" class="mat-elevation-z3 membership-card">
-          <perun-web-apps-member-overview-membership [member]="member" [voId]="selectedVo.id">
-          </perun-web-apps-member-overview-membership>
-        </mat-card>
-        <p class="mt-4 subtitle">{{'USER_DETAIL.ACCOUNTS.GROUPS' | translate}}</p>
-        <perun-web-apps-groups-list
+      </ng-template>
+    </mat-tab>
+
+    <mat-tab *perunWebAppsLoader="loading; indicator: spinner1">
+      <ng-template matTabLabel>
+        {{'USER_DETAIL.ACCOUNTS.MEMBER_ATT' | translate}}
+      </ng-template>
+      <ng-template matTabContent>
+        <mat-spinner class="ms-auto me-auto" *ngIf="loading"></mat-spinner>
+        <app-one-entity-attribute-page *ngIf="!loading" [entity]="'member'" [entityId]="member.id">
+        </app-one-entity-attribute-page>
+      </ng-template>
+    </mat-tab>
+
+    <mat-tab *perunWebAppsLoader="loading; indicator: spinner1">
+      <ng-template matTabLabel>
+        {{'USER_DETAIL.ACCOUNTS.MEMBER_GROUP_ATT' | translate}}
+      </ng-template>
+      <ng-template matTabContent>
+        <mat-spinner class="ms-auto me-auto" *ngIf="loading"></mat-spinner>
+        <app-two-entity-attribute-page
           *ngIf="!loading"
-          [groups]="groups"
-          [memberId]="member?.id"
-          [memberGroupStatus]="member.groupStatus"
-          (refreshTable)="loadMember(selectedVo)"
-          [displayedColumns]="['id', 'recent', 'name', 'description', 'expiration', 'groupStatus']">
-        </perun-web-apps-groups-list>
-      </div>
-    </ng-template>
-  </mat-tab>
+          [firstEntity]="'member'"
+          [firstEntityId]="member.id"
+          [secondEntity]="'group'"></app-two-entity-attribute-page>
+      </ng-template>
+    </mat-tab>
 
-  <mat-tab>
-    <ng-template matTabLabel>
-      {{'USER_DETAIL.ACCOUNTS.MEMBER_ATT' | translate}}
-    </ng-template>
-    <ng-template matTabContent>
-      <mat-spinner *ngIf="loading"></mat-spinner>
-      <app-one-entity-attribute-page *ngIf="!loading" [entity]="'member'" [entityId]="member.id">
-      </app-one-entity-attribute-page>
-    </ng-template>
-  </mat-tab>
+    <mat-tab>
+      <ng-template matTabLabel>
+        {{'USER_DETAIL.ACCOUNTS.MEMBER_RESOURCE_ATT' | translate}}
+      </ng-template>
+      <ng-template matTabContent>
+        <mat-spinner class="ms-auto me-auto" *ngIf="loading"></mat-spinner>
+        <app-two-entity-attribute-page
+          *ngIf="!loading"
+          [firstEntity]="'member'"
+          [firstEntityId]="member.id"
+          [secondEntity]="'resource'"></app-two-entity-attribute-page>
+      </ng-template>
+    </mat-tab>
+  </mat-tab-group>
 
-  <mat-tab>
-    <ng-template matTabLabel>
-      {{'USER_DETAIL.ACCOUNTS.MEMBER_GROUP_ATT' | translate}}
-    </ng-template>
-    <ng-template matTabContent>
-      <mat-spinner *ngIf="loading"></mat-spinner>
-      <app-two-entity-attribute-page
-        *ngIf="!loading"
-        [firstEntity]="'member'"
-        [firstEntityId]="member.id"
-        [secondEntity]="'group'"></app-two-entity-attribute-page>
-    </ng-template>
-  </mat-tab>
-
-  <mat-tab>
-    <ng-template matTabLabel>
-      {{'USER_DETAIL.ACCOUNTS.MEMBER_RESOURCE_ATT' | translate}}
-    </ng-template>
-    <ng-template matTabContent>
-      <mat-spinner *ngIf="loading"></mat-spinner>
-      <app-two-entity-attribute-page
-        *ngIf="!loading"
-        [firstEntity]="'member'"
-        [firstEntityId]="member.id"
-        [secondEntity]="'resource'"></app-two-entity-attribute-page>
-    </ng-template>
-  </mat-tab>
-</mat-tab-group>
-
-<perun-web-apps-alert
-  alert_type="warn"
-  *ngIf="!initLoading && vos.length === 0"
-  >{{'USER_DETAIL.ACCOUNTS.NO_VOS' | translate}}</perun-web-apps-alert
->
+  <perun-web-apps-alert
+    alert_type="warn"
+    *ngIf="!initLoading && vos.length === 0"
+    >{{'USER_DETAIL.ACCOUNTS.NO_VOS' | translate}}</perun-web-apps-alert
+  >
+</div>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-assignments/user-assignments.component.html
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-assignments/user-assignments.component.html
@@ -1,0 +1,64 @@
+<h1 class="page-title">{{'USER_DETAIL.ASSIGNMENTS.TITLE' | translate}}</h1>
+<ng-template #spinner1>
+  <perun-web-apps-loading-table></perun-web-apps-loading-table>
+</ng-template>
+<div *perunWebAppsLoader="initLoading; indicator: spinner1">
+  <div class="d-flex">
+    <perun-web-apps-facility-search-select
+      *ngIf="!(initLoading || facilities.length === 0)"
+      class="w-50"
+      [facilities]="facilities"
+      (facilitySelected)="loadFacility($event)">
+    </perun-web-apps-facility-search-select>
+  </div>
+  <mat-tab-group *ngIf="!(initLoading || facilities.length === 0)" mat-stretch-tabs="false">
+    <mat-tab>
+      <ng-template matTabLabel>
+        {{'USER_DETAIL.ASSIGNMENTS.OVERVIEW' | translate}}
+      </ng-template>
+      <ng-template matTabContent>
+        <p class="mt-4 subtitle">{{'USER_DETAIL.ASSIGNMENTS.RESOURCES' | translate}}</p>
+        <perun-web-apps-resources-list
+          *perunWebAppsLoader="loading; indicator: spinner1"
+          [resources]="resources"
+          [displayedColumns]="['id', 'name', 'vo', 'description']">
+        </perun-web-apps-resources-list>
+      </ng-template>
+    </mat-tab>
+    <mat-tab>
+      <ng-template matTabLabel>
+        {{'USER_DETAIL.ASSIGNMENTS.USER_FACILITY_ATT' | translate}}
+      </ng-template>
+      <ng-template matTabContent>
+        <mat-spinner class="ms-auto me-auto" *ngIf="loading"></mat-spinner>
+        <app-two-entity-attribute-page
+          *ngIf="!loading"
+          [firstEntity]="'user'"
+          [firstEntityId]="userId"
+          [secondEntity]="'facility'"
+          [specificSecondEntity]="selectedFacility"></app-two-entity-attribute-page>
+      </ng-template>
+    </mat-tab>
+
+    <mat-tab>
+      <ng-template matTabLabel>
+        {{'USER_DETAIL.ASSIGNMENTS.MEMBER_RESOURCE_ATT' | translate}}
+      </ng-template>
+      <ng-template matTabContent>
+        <mat-spinner class="ms-auto me-auto" *ngIf="loading"></mat-spinner>
+        <app-two-entity-attribute-page
+          *ngIf="!loading"
+          [firstEntity]="'user'"
+          [firstEntityId]="userId"
+          [secondEntity]="'resource'"
+          [facilityId]="selectedFacility.id"></app-two-entity-attribute-page>
+      </ng-template>
+    </mat-tab>
+  </mat-tab-group>
+
+  <perun-web-apps-alert
+    alert_type="warn"
+    *ngIf="!initLoading && facilities.length === 0"
+    >{{'USER_DETAIL.ASSIGNMENTS.NO_FACILITIES' | translate}}</perun-web-apps-alert
+  >
+</div>

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-assignments/user-assignments.component.scss
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-assignments/user-assignments.component.scss
@@ -1,0 +1,3 @@
+.subtitle {
+  font-size: 1.2rem;
+}

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-assignments/user-assignments.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-assignments/user-assignments.component.ts
@@ -1,0 +1,54 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import {
+  FacilitiesManagerService,
+  Facility,
+  Member,
+  Resource,
+} from '@perun-web-apps/perun/openapi';
+import { compareFnName } from '@perun-web-apps/perun/utils';
+
+@Component({
+  selector: 'app-perun-web-apps-user-assignments',
+  templateUrl: './user-assignments.component.html',
+  styleUrls: ['./user-assignments.component.scss'],
+})
+export class UserAssignmentsComponent implements OnInit {
+  initLoading = true;
+  loading = false;
+  facilities: Facility[] = [];
+  selectedFacility: Facility = null;
+  member: Member = null;
+  resources: Resource[] = [];
+  userId: number;
+  constructor(private route: ActivatedRoute, private facilityService: FacilitiesManagerService) {}
+
+  ngOnInit(): void {
+    this.initLoading = true;
+    this.route.parent.params.subscribe((params) => {
+      this.userId = Number(params['userId']);
+      this.facilityService.getAssignedFacilitiesByUser(this.userId).subscribe({
+        next: (facilities) => {
+          this.facilities = facilities;
+          if (this.facilities.length) {
+            this.loadFacility(this.facilities.sort(compareFnName)[0]);
+          }
+          this.initLoading = false;
+        },
+        error: () => (this.initLoading = false),
+      });
+    });
+  }
+
+  loadFacility(facility: Facility): void {
+    this.loading = true;
+    this.selectedFacility = facility;
+    this.facilityService.getAssignedRichResourcesForFacility(facility.id).subscribe({
+      next: (resources) => {
+        this.resources = resources;
+        this.loading = false;
+      },
+      error: () => (this.loading = false),
+    });
+  }
+}

--- a/apps/admin-gui/src/app/users/pages/user-detail-page/user-overview/user-overview.component.ts
+++ b/apps/admin-gui/src/app/users/pages/user-detail-page/user-overview/user-overview.component.ts
@@ -100,20 +100,7 @@ export class UserOverviewComponent implements OnInit {
   }
 
   private setItems(urlStart: string): void {
-    this.items = [
-      {
-        cssIcon: 'perun-vo',
-        url: `${urlStart}/organizations`,
-        label: 'MENU_ITEMS.ADMIN.ORGANIZATIONS',
-        style: 'user-btn',
-      },
-      {
-        cssIcon: 'perun-group',
-        url: `${urlStart}/groups`,
-        label: 'MENU_ITEMS.ADMIN.GROUPS',
-        style: 'user-btn',
-      },
-    ];
+    this.items = [];
     if (!this.inMyProfile) {
       this.items.push(
         {
@@ -123,21 +110,30 @@ export class UserOverviewComponent implements OnInit {
           style: 'user-btn',
         },
         {
+          cssIcon: 'perun-facility-white',
+          url: `${urlStart}/assignments`,
+          label: 'MENU_ITEMS.USER.ASSIGNMENTS',
+          style: 'user-btn',
+        },
+        {
           cssIcon: 'perun-identity',
           url: `${urlStart}/identities`,
           label: 'MENU_ITEMS.USER.IDENTITIES',
           style: 'user-btn',
-        },
+        }
+      );
+    } else {
+      this.items.push(
         {
-          cssIcon: 'perun-facility-white',
-          url: `${urlStart}/facilities`,
-          label: 'MENU_ITEMS.USER.FACILITIES',
+          cssIcon: 'perun-vo',
+          url: `${urlStart}/organizations`,
+          label: 'MENU_ITEMS.ADMIN.ORGANIZATIONS',
           style: 'user-btn',
         },
         {
-          cssIcon: 'perun-resource',
-          url: `${urlStart}/resources`,
-          label: 'MENU_ITEMS.USER.RESOURCES',
+          cssIcon: 'perun-group',
+          url: `${urlStart}/groups`,
+          label: 'MENU_ITEMS.ADMIN.GROUPS',
           style: 'user-btn',
         }
       );

--- a/apps/admin-gui/src/app/users/users.module.ts
+++ b/apps/admin-gui/src/app/users/users.module.ts
@@ -69,6 +69,7 @@ import { ServiceIdentityAuthenticationComponent } from './pages/user-detail-page
 import { ServiceIdentityAuthenticationOverviewComponent } from './pages/user-detail-page/user-settings/user-settings-service-identities/service-identity-authentication/service-identity-authentication-overview/service-identity-authentication-overview.component';
 import { ServiceIdentityCertificatesComponent } from './pages/user-detail-page/user-settings/user-settings-service-identities/service-identity-authentication/service-identity-certificates/service-identity-certificates.component';
 import { UserBansComponent } from './pages/user-detail-page/user-bans/user-bans.component';
+import { UserAssignmentsComponent } from './pages/user-detail-page/user-assignments/user-assignments.component';
 @NgModule({
   declarations: [
     UserDetailPageComponent,
@@ -90,6 +91,7 @@ import { UserBansComponent } from './pages/user-detail-page/user-bans/user-bans.
     DashboardRecentlyViewedButtonFieldComponent,
     UserFacilitiesComponent,
     UserAccountsComponent,
+    UserAssignmentsComponent,
     ServiceIdentityDetailPageComponent,
     ServiceIdentityOverviewComponent,
     UserSettingsDataQuotasComponent,

--- a/apps/admin-gui/src/assets/i18n/en.json
+++ b/apps/admin-gui/src/assets/i18n/en.json
@@ -1099,6 +1099,7 @@
       "ENTITY": "User",
       "USER_TYPE": "User type",
       "ACCOUNTS": "Accounts",
+      "ASSIGNMENTS": "Assignments",
       "MAILING_LISTS": "Mailing lists opt-out",
       "DATA_QUOTAS": "Data quotas",
       "BANS": "Bans",
@@ -2706,6 +2707,14 @@
       "MEMBER_GROUP_ATT": "Member-Group attributes",
       "MEMBER_RESOURCE_ATT": "Member-Resource attributes",
       "NO_VOS": "User is not member of any organization."
+    },
+    "ASSIGNMENTS": {
+      "TITLE": "Assignments",
+      "OVERVIEW": "Overview",
+      "RESOURCES": "Resources",
+      "USER_FACILITY_ATT": "User-Facility attributes",
+      "MEMBER_RESOURCE_ATT": "Member-Resource attributes",
+      "NO_FACILITIES": "User is not assigned to any facilities."
     },
     "SETTINGS": {
       "ATTRIBUTES": {

--- a/libs/perun/openapi/src/lib/api/usersManager.service.ts
+++ b/libs/perun/openapi/src/lib/api/usersManager.service.ts
@@ -59,6 +59,8 @@ import { PaginatedRichUsers } from '../model/paginatedRichUsers';
 // @ts-ignore
 import { PerunException } from '../model/perunException';
 // @ts-ignore
+import { Resource } from '../model/resource';
+// @ts-ignore
 import { RichResource } from '../model/richResource';
 // @ts-ignore
 import { RichUser } from '../model/richUser';
@@ -2646,6 +2648,130 @@ export class UsersManagerService {
       requestUrl = helperUrl.toString();
     }
     return this.httpClient.get<Array<RichResource>>(requestUrl, {
+      context: localVarHttpContext,
+      params: localVarQueryParameters,
+      responseType: <any>responseType_,
+      withCredentials: this.configuration.withCredentials,
+      headers: localVarHeaders,
+      observe: observe,
+      reportProgress: reportProgress,
+    });
+  }
+
+  /**
+   * Get all resources associated with the user on the facility
+   * @param facility id of Facility
+   * @param user id of User
+   * @param useNon if set to true sends the request to the backend server as 'non' instead of the usual (oauth, krb...).
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public getAssociatedResourcesForUser(
+    facility: number,
+    user: number,
+    useNon?: boolean,
+    observe?: 'body',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<Array<Resource>>;
+  public getAssociatedResourcesForUser(
+    facility: number,
+    user: number,
+    useNon?: boolean,
+    observe?: 'response',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpResponse<Array<Resource>>>;
+  public getAssociatedResourcesForUser(
+    facility: number,
+    user: number,
+    useNon?: boolean,
+    observe?: 'events',
+    reportProgress?: boolean,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<HttpEvent<Array<Resource>>>;
+  public getAssociatedResourcesForUser(
+    facility: number,
+    user: number,
+    useNon: boolean = false,
+    observe: any = 'body',
+    reportProgress: boolean = false,
+    options?: { httpHeaderAccept?: 'application/json'; context?: HttpContext }
+  ): Observable<any> {
+    if (facility === null || facility === undefined) {
+      throw new Error(
+        'Required parameter facility was null or undefined when calling getAssociatedResourcesForUser.'
+      );
+    }
+    if (user === null || user === undefined) {
+      throw new Error(
+        'Required parameter user was null or undefined when calling getAssociatedResourcesForUser.'
+      );
+    }
+
+    let localVarQueryParameters = new HttpParams({ encoder: this.encoder });
+    if (facility !== undefined && facility !== null) {
+      localVarQueryParameters = this.addToHttpParams(
+        localVarQueryParameters,
+        <any>facility,
+        'facility'
+      );
+    }
+    if (user !== undefined && user !== null) {
+      localVarQueryParameters = this.addToHttpParams(localVarQueryParameters, <any>user, 'user');
+    }
+
+    let localVarHeaders = this.defaultHeaders;
+
+    let localVarCredential: string | undefined;
+    // authentication (BasicAuth) required
+    localVarCredential = this.configuration.lookupCredential('BasicAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Basic ' + localVarCredential);
+    }
+
+    // authentication (BearerAuth) required
+    localVarCredential = this.configuration.lookupCredential('BearerAuth');
+    if (localVarCredential) {
+      localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+    }
+
+    let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+    if (localVarHttpHeaderAcceptSelected === undefined) {
+      // to determine the Accept header
+      const httpHeaderAccepts: string[] = ['application/json'];
+      localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    }
+    if (localVarHttpHeaderAcceptSelected !== undefined) {
+      localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+    }
+
+    let localVarHttpContext: HttpContext | undefined = options && options.context;
+    if (localVarHttpContext === undefined) {
+      localVarHttpContext = new HttpContext();
+    }
+
+    let responseType_: 'text' | 'json' | 'blob' = 'json';
+    if (localVarHttpHeaderAcceptSelected) {
+      if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+        responseType_ = 'text';
+      } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+        responseType_ = 'json';
+      } else {
+        responseType_ = 'blob';
+      }
+    }
+
+    let requestUrl = `${this.configuration.basePath}/json/usersManager/getAssociatedResources`;
+    if (useNon) {
+      // replace the authentication part of url with 'non' authentication
+      let helperUrl = new URL(requestUrl);
+      let path = helperUrl.pathname.split('/');
+      path[1] = 'non';
+      helperUrl.pathname = path.join('/');
+      requestUrl = helperUrl.toString();
+    }
+    return this.httpClient.get<Array<Resource>>(requestUrl, {
       context: localVarHttpContext,
       params: localVarQueryParameters,
       responseType: <any>responseType_,


### PR DESCRIPTION
* 'Organizations' and 'Groups' pages were removed from the admin version of the 'User' section since information from both of these pages is contained in 'Accounts'
* 'Resources' and 'Facilities' pages were merged into new 'Assignments' page that works similarly to 'Accounts'
* Updated two entity attribute component to allow fixed second entity and did some necessary tweaks to allow displaying Member-Resource attributes per resource in fixed facility
* Fixed a bug where the initial selected object didn't match the displayed attributes on two-entity attributes page
* Aligned loading spinner on 'Accounts' page
* Updated openapi

DEPLOYMENT NOTE: Removed 'Organizations', 'Groups', 'Resources' and 'Facilities' pages from the admin version of the User section. Refer admins to 'Accounts' page for more clear info on VOs/Groups and to new 'Assignments' page for info on Facilities/Resources