### PR TITLE
refactor(admin): unify complementaryObject parameter

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-group-manager-dialog/add-group-manager-dialog.component.ts
@@ -1,7 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { TranslateService } from '@ngx-translate/core';
-import { NotificatorService } from '@perun-web-apps/perun/services';
+import { NotificatorService, PerunTranslateService } from '@perun-web-apps/perun/services';
 import { ActivatedRoute, Router } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
 import { Observable } from 'rxjs';
@@ -9,9 +8,9 @@ import { UntypedFormControl } from '@angular/forms';
 import { map, startWith } from 'rxjs/operators';
 import {
   AuthzResolverService,
-  Facility,
   Group,
   GroupsManagerService,
+  PerunBean,
   RoleManagementRules,
   Vo,
   VosManagerService,
@@ -21,7 +20,7 @@ import { TABLE_SELECT_GROUP_MANAGER_DIALOG } from '@perun-web-apps/config/table-
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 
 export interface AddGroupManagerDialogData {
-  complementaryObject: Vo | Group | Facility;
+  complementaryObject: PerunBean;
   availableRoles: RoleManagementRules[];
   theme: string;
   selectedRole: Role;
@@ -60,15 +59,13 @@ export class AddGroupManagerDialogComponent implements OnInit {
     private authzService: AuthzResolverService,
     private voService: VosManagerService,
     private groupService: GroupsManagerService,
-    private translate: TranslateService,
+    private translate: PerunTranslateService,
     private notificator: NotificatorService,
     protected route: ActivatedRoute,
     protected router: Router
   ) {
-    translate.get('DIALOGS.ADD_GROUPS.TITLE').subscribe((value: string) => (this.title = value));
-    translate
-      .get('DIALOGS.ADD_GROUPS.SUCCESS')
-      .subscribe((value: string) => (this.successMessage = value));
+    this.title = this.translate.instant('DIALOGS.ADD_GROUPS.TITLE');
+    this.successMessage = this.translate.instant('DIALOGS.ADD_GROUPS.SUCCESS');
   }
 
   displayFn(vo?: Vo): string | undefined {

--- a/apps/admin-gui/src/app/shared/components/dialogs/add-manager-dialog/add-manager-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/add-manager-dialog/add-manager-dialog.component.ts
@@ -1,17 +1,18 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { TranslateService } from '@ngx-translate/core';
-import { NotificatorService, StoreService } from '@perun-web-apps/perun/services';
+import {
+  NotificatorService,
+  PerunTranslateService,
+  StoreService,
+} from '@perun-web-apps/perun/services';
 import { SelectionModel } from '@angular/cdk/collections';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
   AuthzResolverService,
-  Facility,
-  Group,
+  PerunBean,
   RichUser,
   RoleManagementRules,
   UsersManagerService,
-  Vo,
 } from '@perun-web-apps/perun/openapi';
 import { Role } from '@perun-web-apps/perun/models';
 import { TABLE_ADD_MANAGER } from '@perun-web-apps/config/table-config';
@@ -19,7 +20,7 @@ import { Urns } from '@perun-web-apps/perun/urns';
 import { UntypedFormControl, Validators } from '@angular/forms';
 
 export interface AddManagerDialogData {
-  complementaryObject: Vo | Group | Facility;
+  complementaryObject: PerunBean;
   theme: string;
   availableRoles: RoleManagementRules[];
   selectedRole: Role;
@@ -48,16 +49,14 @@ export class AddManagerDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) private data: AddManagerDialogData,
     private authzService: AuthzResolverService,
     private usersService: UsersManagerService,
-    private translate: TranslateService,
+    private translate: PerunTranslateService,
     private notificator: NotificatorService,
     private storeService: StoreService,
     protected route: ActivatedRoute,
     protected router: Router
   ) {
-    translate.get('DIALOGS.ADD_MANAGERS.TITLE').subscribe((value: string) => (this.title = value));
-    translate
-      .get('DIALOGS.ADD_MANAGERS.SUCCESS')
-      .subscribe((value: string) => (this.successMessage = value));
+    this.title = this.translate.instant('DIALOGS.ADD_MANAGERS.TITLE');
+    this.successMessage = this.translate.instant('DIALOGS.ADD_MANAGERS.SUCCESS');
   }
 
   ngOnInit(): void {

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-group-manager-dialog/remove-group-manager-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-group-manager-dialog/remove-group-manager-dialog.component.ts
@@ -1,13 +1,12 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
-import { NotificatorService } from '@perun-web-apps/perun/services';
-import { TranslateService } from '@ngx-translate/core';
-import { AuthzResolverService, Facility, Group, Vo } from '@perun-web-apps/perun/openapi';
+import { NotificatorService, PerunTranslateService } from '@perun-web-apps/perun/services';
+import { AuthzResolverService, Group, PerunBean } from '@perun-web-apps/perun/openapi';
 import { Role } from '@perun-web-apps/perun/models';
 
 export interface RemoveGroupDialogData {
-  complementaryObject: Vo | Group | Facility;
+  complementaryObject: PerunBean;
   groups: Group[];
   role: Role;
   theme: string;
@@ -28,7 +27,7 @@ export class RemoveGroupManagerDialogComponent implements OnInit {
     public dialogRef: MatDialogRef<RemoveGroupManagerDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: RemoveGroupDialogData,
     private notificator: NotificatorService,
-    private translate: TranslateService,
+    private translate: PerunTranslateService,
     private authzService: AuthzResolverService
   ) {}
 
@@ -49,18 +48,13 @@ export class RemoveGroupManagerDialogComponent implements OnInit {
         authorizedGroups: this.data.groups.map((group) => group.id),
         complementaryObject: this.data.complementaryObject,
       })
-      .subscribe(
-        () => {
-          this.translate.get('DIALOGS.REMOVE_GROUPS.SUCCESS').subscribe(
-            (successMessage: string) => {
-              this.notificator.showSuccess(successMessage);
-              this.loading = false;
-              this.dialogRef.close(true);
-            },
-            () => (this.loading = false)
-          );
+      .subscribe({
+        next: () => {
+          this.notificator.showSuccess(this.translate.instant('DIALOGS.REMOVE_GROUPS.SUCCESS'));
+          this.loading = false;
+          this.dialogRef.close(true);
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
   }
 }

--- a/apps/admin-gui/src/app/shared/components/dialogs/remove-manager-dialog/remove-manager-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/remove-manager-dialog/remove-manager-dialog.component.ts
@@ -1,13 +1,17 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
-import { GuiAuthResolver, NotificatorService, StoreService } from '@perun-web-apps/perun/services';
-import { TranslateService } from '@ngx-translate/core';
-import { AuthzResolverService, Facility, Group, RichUser, Vo } from '@perun-web-apps/perun/openapi';
+import {
+  GuiAuthResolver,
+  NotificatorService,
+  PerunTranslateService,
+  StoreService,
+} from '@perun-web-apps/perun/services';
+import { AuthzResolverService, PerunBean, RichUser } from '@perun-web-apps/perun/openapi';
 import { Role } from '@perun-web-apps/perun/models';
 
 export interface RemoveManagerDialogData {
-  complementaryObject: Vo | Group | Facility;
+  complementaryObject: PerunBean;
   managers: RichUser[];
   role: Role;
   theme: string;
@@ -29,7 +33,7 @@ export class RemoveManagerDialogComponent implements OnInit {
     public dialogRef: MatDialogRef<RemoveManagerDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: RemoveManagerDialogData,
     private notificator: NotificatorService,
-    private translate: TranslateService,
+    private translate: PerunTranslateService,
     private authzService: AuthzResolverService,
     private store: StoreService,
     private authService: GuiAuthResolver
@@ -55,18 +59,13 @@ export class RemoveManagerDialogComponent implements OnInit {
         users: this.data.managers.map((manager) => manager.id),
         complementaryObject: this.data.complementaryObject,
       })
-      .subscribe(
-        () => {
-          this.translate.get('DIALOGS.REMOVE_MANAGERS.SUCCESS').subscribe(
-            (successMessage: string) => {
-              this.notificator.showSuccess(successMessage);
-              this.loading = false;
-              this.dialogRef.close(true);
-            },
-            () => (this.loading = false)
-          );
+      .subscribe({
+        next: () => {
+          this.notificator.showSuccess(this.translate.instant('DIALOGS.REMOVE_MANAGERS.SUCCESS'));
+          this.loading = false;
+          this.dialogRef.close(true);
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
   }
 }

--- a/apps/admin-gui/src/app/shared/components/managers-page/managers-page.component.ts
+++ b/apps/admin-gui/src/app/shared/components/managers-page/managers-page.component.ts
@@ -7,12 +7,10 @@ import { RemoveGroupManagerDialogComponent } from '../dialogs/remove-group-manag
 import { AddGroupManagerDialogComponent } from '../dialogs/add-group-manager-dialog/add-group-manager-dialog.component';
 import {
   AuthzResolverService,
-  Facility,
   Group,
-  Resource,
+  PerunBean,
   RichUser,
   RoleManagementRules,
-  Vo,
 } from '@perun-web-apps/perun/openapi';
 import { Urns } from '@perun-web-apps/perun/urns';
 import { TABLE_GROUP_MANAGERS_PAGE } from '@perun-web-apps/config/table-config';
@@ -32,7 +30,7 @@ import { mergeMap, tap } from 'rxjs/operators';
 })
 export class ManagersPageComponent implements OnInit {
   @HostBinding('class.router-component') true;
-  @Input() complementaryObject: Group | Vo | Facility | Resource;
+  @Input() complementaryObject: PerunBean;
   @Input() availableRoles: RoleManagementRules[];
   @Input() complementaryObjectType: string;
   @Input() theme: string;

--- a/libs/perun/openapi/src/lib/api/authzResolver.service.ts
+++ b/libs/perun/openapi/src/lib/api/authzResolver.service.ts
@@ -330,7 +330,7 @@ export class AuthzResolverService {
    * Get all groups of managers (authorizedGroups) for complementaryObject and role
    * @param role
    * @param complementaryObjectId Property id of complementaryObject to get managers for
-   * @param complementaryObjectName Property beanName of complementaryObject, meaning object type (Vo | Group | Facility | ... )
+   * @param complementaryObjectName Property beanName of complementaryObject, meaning object type (supported object types: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
    * @param useNon if set to true sends the request to the backend server as 'non' instead of the usual (oauth, krb...).
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
@@ -472,7 +472,7 @@ export class AuthzResolverService {
    * Get all valid richUser administrators (for group-based rights, status must be VALID for both Vo and group) for complementary object and role with specified attributes.
    * @param role
    * @param complementaryObjectId Property id of complementaryObject to get managers for
-   * @param complementaryObjectName Property beanName of complementaryObject, meaning object type (Vo | Group | Facility | ... )
+   * @param complementaryObjectName Property beanName of complementaryObject, meaning object type (supported object types: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
    * @param specificAttributes list of specified attributes which are needed in object richUser
    * @param allUserAttributes When true, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes
    * @param onlyDirectAdmins When true, return only direct users of the complementary object for role with specific attributes

--- a/libs/perun/openapi/src/lib/model/setRoleWithGroupComplementaryObject.ts
+++ b/libs/perun/openapi/src/lib/model/setRoleWithGroupComplementaryObject.ts
@@ -12,7 +12,7 @@
 import { PerunBean } from './perunBean';
 
 /**
- * input to unsetRoleWithUserComplementaryObject
+ * input to unsetRoleWithUserComplementaryObject (supported objects: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
  */
 export interface SetRoleWithGroupComplementaryObject {
   role: string;

--- a/libs/perun/openapi/src/lib/model/setRoleWithGroupComplementaryObjects.ts
+++ b/libs/perun/openapi/src/lib/model/setRoleWithGroupComplementaryObjects.ts
@@ -18,7 +18,7 @@ export interface SetRoleWithGroupComplementaryObjects {
   role: string;
   authorizedGroup?: number;
   /**
-   * List of complementary objects
+   * List of complementary objects (supported objects: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
    */
   complementaryObjects?: Array<PerunBean>;
 }

--- a/libs/perun/openapi/src/lib/model/setRoleWithUserComplementaryObject.ts
+++ b/libs/perun/openapi/src/lib/model/setRoleWithUserComplementaryObject.ts
@@ -12,7 +12,7 @@
 import { PerunBean } from './perunBean';
 
 /**
- * input to setRoleWithUserComplementaryObject
+ * input to setRoleWithUserComplementaryObject (supported objects: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
  */
 export interface SetRoleWithUserComplementaryObject {
   role: string;

--- a/libs/perun/openapi/src/lib/model/setRoleWithUserComplementaryObjects.ts
+++ b/libs/perun/openapi/src/lib/model/setRoleWithUserComplementaryObjects.ts
@@ -21,7 +21,7 @@ export interface SetRoleWithUserComplementaryObjects {
    */
   user?: number;
   /**
-   * List of complementary objects
+   * List of complementary objects (supported objects: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
    */
   complementaryObjects?: Array<PerunBean>;
 }

--- a/libs/perun/openapi/src/lib/model/unsetRoleWithGroupComplementaryObject.ts
+++ b/libs/perun/openapi/src/lib/model/unsetRoleWithGroupComplementaryObject.ts
@@ -12,7 +12,7 @@
 import { PerunBean } from './perunBean';
 
 /**
- * input to unsetRoleWithUserComplementaryObject
+ * input to unsetRoleWithUserComplementaryObject (supported objects: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
  */
 export interface UnsetRoleWithGroupComplementaryObject {
   role: string;

--- a/libs/perun/openapi/src/lib/model/unsetRoleWithGroupComplementaryObjects.ts
+++ b/libs/perun/openapi/src/lib/model/unsetRoleWithGroupComplementaryObjects.ts
@@ -18,7 +18,7 @@ export interface UnsetRoleWithGroupComplementaryObjects {
   role: string;
   authorizedGroup?: number;
   /**
-   * List of complementary objects
+   * List of complementary objects (supported objects: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
    */
   complementaryObjects?: Array<PerunBean>;
 }

--- a/libs/perun/openapi/src/lib/model/unsetRoleWithUserComplementaryObject.ts
+++ b/libs/perun/openapi/src/lib/model/unsetRoleWithUserComplementaryObject.ts
@@ -12,7 +12,7 @@
 import { PerunBean } from './perunBean';
 
 /**
- * input to unsetRoleWithUserComplementaryObject
+ * input to unsetRoleWithUserComplementaryObject (supported objects: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
  */
 export interface UnsetRoleWithUserComplementaryObject {
   role: string;

--- a/libs/perun/openapi/src/lib/model/unsetRoleWithUserComplementaryObjects.ts
+++ b/libs/perun/openapi/src/lib/model/unsetRoleWithUserComplementaryObjects.ts
@@ -21,7 +21,7 @@ export interface UnsetRoleWithUserComplementaryObjects {
    */
   user?: number;
   /**
-   * List of complementary objects
+   * List of complementary objects (supported objects: Group | RichGroup | Vo | Resource | Facility | SecurityTeam )
    */
   complementaryObjects?: Array<PerunBean>;
 }


### PR DESCRIPTION
* Regenerate openapi with new comments about supported objects for complementaryObjet(s) parameter.
* Unify a type of complementaryObject variable to PerunBean object across classes in admin-gui.
* The information about supported objects has been left just in openapi documentation to avoid future need of changing it on several places.
* Little refactor of edited files has been done.