### PR TITLE
fix(admin): use renamed html tag for application dynamic list

### DIFF
--- a/apps/admin-gui/src/app/vos/pages/member-detail-page/member-applications/member-applications.component.html
+++ b/apps/admin-gui/src/app/vos/pages/member-detail-page/member-applications/member-applications.component.html
@@ -16,7 +16,7 @@
   <perun-web-apps-loading-table></perun-web-apps-loading-table>
 </ng-template>
 <div class="position-relative">
-  <app-applications-dynamic-list
+  <perun-web-apps-applications-dynamic-list
     *perunWebAppsLoader="loading$ | async; indicator: spinner"
     (loading$)="loading$ = $event"
     [tableId]="showAllDetails ? detailTableId : tableId"
@@ -26,5 +26,5 @@
     [states]=""
     [dateFrom]="dateFrom"
     [refreshTable]="refresh">
-  </app-applications-dynamic-list>
+  </perun-web-apps-applications-dynamic-list>
 </div>


### PR DESCRIPTION
* Due to recent move of this component from admin-gui folder to the lib folder was changed the prefix of the component, but it was not changed on member-applications page.