### PR TITLE
fix(admin): edit variable for sidemenu submenu active text color

### DIFF
--- a/apps/admin-gui/src/_styles.scss
+++ b/apps/admin-gui/src/_styles.scss
@@ -442,7 +442,7 @@ mat.$theme-ignore-duplication-warnings: true;
   color: var(--admin-color-text);
 
   &:hover {
-    color: #000000;
+    color: var(--admin-color-text);
   }
 }
 

--- a/apps/admin-gui/src/app/core/services/common/admin-gui-config.service.ts
+++ b/apps/admin-gui/src/app/core/services/common/admin-gui-config.service.ts
@@ -98,7 +98,7 @@ export class AdminGuiConfigService {
     },
     {
       configValue: 'sidemenu_submenu_active_text_color',
-      cssVariable: '--sidemenu-submenu-active-test-color',
+      cssVariable: '--sidemenu-submenu-active-text-color',
     },
     {
       configValue: 'sidemenu_submenu_hover_text_color',


### PR DESCRIPTION
* Fix a misspelling in cssVariable name for side_submenu_active_text_color variable.