### PR TITLE
refactor: get rid of UntypedFormBuilder

### DIFF
--- a/apps/admin-gui/src/app/shared/components/dialogs/create-attribute-definition-dialog/create-attribute-definition-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/create-attribute-definition-dialog/create-attribute-definition-dialog.component.ts
@@ -6,7 +6,7 @@ import {
   AttributePolicyCollection,
   AttributesManagerService,
 } from '@perun-web-apps/perun/openapi';
-import { UntypedFormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { BehaviorSubject, of, zip } from 'rxjs';
 import { AttributeRightsService, NotificatorService } from '@perun-web-apps/perun/services';
@@ -73,7 +73,7 @@ export class CreateAttributeDefinitionDialogComponent {
 
   constructor(
     private dialogRef: MatDialogRef<CreateAttributeDefinitionDialogComponent>,
-    private formBuilder: UntypedFormBuilder,
+    private formBuilder: FormBuilder,
     private attributeService: AttributesManagerService,
     private attributeRightsService: AttributeRightsService,
     private notificator: NotificatorService,
@@ -120,15 +120,15 @@ export class CreateAttributeDefinitionDialogComponent {
           )
         )
       )
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.notificator.showSuccess(
             this.translate.instant('DIALOGS.CREATE_ATTRIBUTE_DEFINITION.SUCCESS') as string
           );
           this.dialogRef.close(true);
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
   }
 
   cancel(): void {

--- a/apps/admin-gui/src/app/shared/components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/dialogs/edit-attribute-definition-dialog/edit-attribute-definition-dialog.component.ts
@@ -16,7 +16,7 @@ import { TABLE_ENTITYLESS_ATTRIBUTE_KEYS } from '@perun-web-apps/config/table-co
 import { Clipboard } from '@angular/cdk/clipboard';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { startWith, switchMap } from 'rxjs/operators';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 
 export interface EditAttributeDefinitionDialogData {
   attDef: AttributeDefinition;
@@ -41,7 +41,7 @@ export class EditAttributeDefinitionDialogComponent implements OnInit {
   finalReadGlobal: boolean;
   finalWriteOperations: boolean;
   finalWriteGlobal: boolean;
-  attributeControl: UntypedFormGroup = this.formBuilder.group({
+  attributeControl = this.formBuilder.group({
     name: [this.attDef.displayName, Validators.required],
     description: [this.attDef.description, Validators.required],
   });
@@ -59,7 +59,7 @@ export class EditAttributeDefinitionDialogComponent implements OnInit {
     private clipboard: Clipboard,
     private attributesManager: AttributesManagerService,
     private serviceService: ServicesManagerService,
-    private formBuilder: UntypedFormBuilder,
+    private formBuilder: FormBuilder,
     private attributeRightsService: AttributeRightsService
   ) {}
 
@@ -167,7 +167,7 @@ export class EditAttributeDefinitionDialogComponent implements OnInit {
   }
 
   private updateAttribute(): void {
-    this.attDef.displayName = this.attributeControl.get('name').value as string;
-    this.attDef.description = this.attributeControl.get('description').value as string;
+    this.attDef.displayName = this.attributeControl.value.name;
+    this.attDef.description = this.attributeControl.value.description;
   }
 }

--- a/apps/admin-gui/src/app/shared/components/set-login-dialog/set-login-dialog.component.ts
+++ b/apps/admin-gui/src/app/shared/components/set-login-dialog/set-login-dialog.component.ts
@@ -1,13 +1,12 @@
 import { AfterViewInit, ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, ValidatorFn, Validators } from '@angular/forms';
+import { FormBuilder, ValidatorFn, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { AttributesManagerService, UsersManagerService } from '@perun-web-apps/perun/openapi';
 import {
-  AttributesManagerService,
-  MembersManagerService,
-  UsersManagerService,
-} from '@perun-web-apps/perun/openapi';
-import { ApiRequestConfigurationService, NotificatorService } from '@perun-web-apps/perun/services';
-import { TranslateService } from '@ngx-translate/core';
+  ApiRequestConfigurationService,
+  NotificatorService,
+  PerunTranslateService,
+} from '@perun-web-apps/perun/services';
 import { loginAsyncValidator } from '@perun-web-apps/perun/namespace-password-form';
 import { CustomValidators } from '@perun-web-apps/perun/utils';
 
@@ -22,48 +21,46 @@ export interface SetLoginDialogComponentData {
   styleUrls: ['./set-login-dialog.component.scss'],
 })
 export class SetLoginDialogComponent implements OnInit, AfterViewInit {
-  formGroup: UntypedFormGroup;
+  formGroup = this.formBuilder.group(
+    {
+      namespaceCtrl: ['Not selected'],
+      loginCtrl: [
+        '',
+        [
+          Validators.pattern('^[a-z][a-z0-9_-]+$'),
+          Validators.maxLength(15),
+          Validators.minLength(2),
+        ],
+      ],
+      passwordCtrl: [
+        '',
+        Validators.required,
+        [loginAsyncValidator(null, this.usersManagerService, this.apiRequestConfiguration)],
+      ],
+      passwordAgainCtrl: [''],
+      generatePasswordCtrl: [true],
+    },
+    {
+      validators: CustomValidators.passwordMatchValidator as ValidatorFn,
+    }
+  );
   processing = false;
   userId: number;
 
   constructor(
     private dialogRef: MatDialogRef<SetLoginDialogComponent>,
     @Inject(MAT_DIALOG_DATA) private data: SetLoginDialogComponentData,
-    private formBuilder: UntypedFormBuilder,
+    private formBuilder: FormBuilder,
     private usersManagerService: UsersManagerService,
-    private membersManagerService: MembersManagerService,
     private attributesManagerService: AttributesManagerService,
     private apiRequestConfiguration: ApiRequestConfigurationService,
     private notificator: NotificatorService,
-    private translate: TranslateService,
+    private translate: PerunTranslateService,
     private cd: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
     this.userId = this.data.userId;
-    this.formGroup = this.formBuilder.group(
-      {
-        namespaceCtrl: ['Not selected'],
-        loginCtrl: [
-          '',
-          [
-            Validators.pattern('^[a-z][a-z0-9_-]+$'),
-            Validators.maxLength(15),
-            Validators.minLength(2),
-          ],
-        ],
-        passwordCtrl: [
-          '',
-          Validators.required,
-          [loginAsyncValidator(null, this.usersManagerService, this.apiRequestConfiguration)],
-        ],
-        passwordAgainCtrl: [''],
-        generatePasswordCtrl: [true],
-      },
-      {
-        validators: CustomValidators.passwordMatchValidator as ValidatorFn,
-      }
-    );
   }
 
   ngAfterViewInit(): void {
@@ -73,8 +70,8 @@ export class SetLoginDialogComponent implements OnInit, AfterViewInit {
 
   onSetLogin(): void {
     this.processing = true;
-    const namespace = (this.formGroup.get('namespaceCtrl').value as string).toLowerCase();
-    const inputLogin = this.formGroup.get('loginCtrl').value as string;
+    const namespace = this.formGroup.value.namespaceCtrl.toLowerCase();
+    const inputLogin = this.formGroup.value.loginCtrl;
 
     if (inputLogin) {
       this.setLogin(namespace, inputLogin);
@@ -84,76 +81,74 @@ export class SetLoginDialogComponent implements OnInit, AfterViewInit {
         .getUserAttributeByName(this.userId, 'urn:perun:user:attribute-def:core:lastName')
         .subscribe((attr) => {
           const lastName = attr.value as string;
-          this.usersManagerService.generateAccountForName(namespace, lastName).subscribe(
-            (params) => {
+          this.usersManagerService.generateAccountForName(namespace, lastName).subscribe({
+            next: (params) => {
               const login = params[namespaceUrn];
               this.setLogin(namespace, login);
             },
-            () => (this.processing = false)
-          );
+            error: () => (this.processing = false),
+          });
         });
     }
   }
 
   setLogin(namespace: string, login: string): void {
-    this.usersManagerService.setLogin(this.userId, login, namespace).subscribe(
-      () => {
-        this.notificator.showSuccess(
-          this.translate.instant('DIALOGS.SET_LOGIN.SUCCESS_LOGIN') as string
-        );
+    this.usersManagerService.setLogin(this.userId, login, namespace).subscribe({
+      next: () => {
+        this.notificator.showSuccess(this.translate.instant('DIALOGS.SET_LOGIN.SUCCESS_LOGIN'));
         this.setPassword();
       },
-      () => {
+      error: () => {
         this.processing = false;
-      }
-    );
+      },
+    });
   }
 
   setPassword(): void {
-    const namespace: string = (this.formGroup.get('namespaceCtrl').value as string).toLowerCase();
-    const password: string = this.formGroup.get('passwordCtrl').value as string;
-    const generateRandom: boolean = this.formGroup.get('generatePasswordCtrl').value as boolean;
+    const namespace: string = this.formGroup.value.namespaceCtrl.toLowerCase();
+    const password: string = this.formGroup.value.passwordCtrl;
+    const generateRandom: boolean = this.formGroup.value.generatePasswordCtrl;
 
     if (generateRandom) {
       if (!this.formGroup.get('loginCtrl').value) {
         return; // password already set when account was generated
       }
-      this.usersManagerService.reserveRandomPassword(this.userId, namespace).subscribe(
-        () => {
-          this.usersManagerService.validatePasswordForUser(this.userId, namespace).subscribe(
-            () => {
+      this.usersManagerService.reserveRandomPassword(this.userId, namespace).subscribe({
+        next: () => {
+          this.usersManagerService.validatePasswordForUser(this.userId, namespace).subscribe({
+            next: () => {
               this.dialogRef.close(true);
             },
-            () => {
+            error: () => {
               this.processing = false;
-            }
-          );
+            },
+          });
         },
-        () => {
+        error: () => {
           this.processing = false;
-        }
-      );
+        },
+      });
     } else {
       this.usersManagerService
         .reservePasswordForUser({ user: this.userId, namespace: namespace, password: password })
-        .subscribe(
-          () => {
-            this.usersManagerService.validatePasswordForUser(this.userId, namespace).subscribe(
-              () => {
+        .subscribe({
+          next: () => {
+            this.usersManagerService.validatePasswordForUser(this.userId, namespace).subscribe({
+              next: () => {
                 this.notificator.showSuccess(
-                  this.translate.instant('DIALOGS.SET_LOGIN.SUCCESS_PASSWORD') as string
+                  this.translate.instant('DIALOGS.SET_LOGIN.SUCCESS_PASSWORD')
                 );
                 this.dialogRef.close(true);
               },
-              () => {
+              error: () => {
                 this.processing = false;
-              }
-            );
+              },
+            });
           },
-          () => {
+          error: () => {
             this.processing = false;
-          }
-        );
+          },
+        });
     }
   }
 

--- a/apps/user-profile/src/app/components/dialogs/activate-local-account-dialog/activate-local-account-dialog.component.ts
+++ b/apps/user-profile/src/app/components/dialogs/activate-local-account-dialog/activate-local-account-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
-import { UntypedFormBuilder, ValidatorFn, Validators } from '@angular/forms';
+import { FormBuilder, ValidatorFn, Validators } from '@angular/forms';
 import { CustomValidators } from '@perun-web-apps/perun/utils';
 import { UsersManagerService } from '@perun-web-apps/perun/openapi';
 import { ApiRequestConfigurationService, NotificatorService } from '@perun-web-apps/perun/services';
@@ -41,7 +41,7 @@ export class ActivateLocalAccountDialogComponent {
     private userManager: UsersManagerService,
     private notificator: NotificatorService,
     private translate: TranslateService,
-    private formBuilder: UntypedFormBuilder,
+    private formBuilder: FormBuilder,
     private apiRequestConfiguration: ApiRequestConfigurationService
   ) {}
 
@@ -51,7 +51,7 @@ export class ActivateLocalAccountDialogComponent {
 
   activate(): void {
     this.loading = true;
-    const pwd: string = this.pwdForm.get('passwordCtrl').value as string;
+    const pwd: string = this.pwdForm.value.passwordCtrl;
     this.userManager
       .reservePasswordForUser({
         user: this.data.userId,
@@ -63,14 +63,14 @@ export class ActivateLocalAccountDialogComponent {
           this.userManager.validatePasswordForUser(this.data.userId, this.data.namespace)
         )
       )
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.notificator.showSuccess(
             this.translate.instant('DIALOGS.ACTIVATE_LOCAL_ACCOUNT.SUCCESS') as string
           );
           this.dialogRef.close();
         },
-        () => (this.loading = false)
-      );
+        error: () => (this.loading = false),
+      });
   }
 }

--- a/libs/perun/dialogs/src/lib/change-password-dialog/change-password-dialog.component.ts
+++ b/libs/perun/dialogs/src/lib/change-password-dialog/change-password-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { UsersManagerService } from '@perun-web-apps/perun/openapi';
-import { AbstractControl, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, ValidatorFn, Validators } from '@angular/forms';
 import { CustomValidators } from '@perun-web-apps/perun/utils';
 import { loginAsyncValidator } from '@perun-web-apps/perun/namespace-password-form';
 import { ApiRequestConfigurationService, NotificatorService } from '@perun-web-apps/perun/services';
@@ -18,7 +18,26 @@ export interface ChangePasswordDialogData {
   styleUrls: ['./change-password-dialog.component.css'],
 })
 export class ChangePasswordDialogComponent implements OnInit {
-  formGroup: UntypedFormGroup;
+  formGroup = this._formBuilder.group(
+    {
+      oldPasswordCtrl: ['', Validators.required],
+      passwordCtrl: [
+        '',
+        Validators.required,
+        [
+          loginAsyncValidator(
+            this.data.namespace,
+            this.usersManagerService,
+            this.apiRequestConfiguration
+          ),
+        ],
+      ],
+      passwordAgainCtrl: [''],
+    },
+    {
+      validators: CustomValidators.passwordMatchValidator as ValidatorFn,
+    }
+  );
   oldPwd: AbstractControl;
   showOldPassword = false;
   loading: boolean;
@@ -29,7 +48,7 @@ export class ChangePasswordDialogComponent implements OnInit {
   constructor(
     private dialogRef: MatDialogRef<ChangePasswordDialogComponent>,
     @Inject(MAT_DIALOG_DATA) private data: ChangePasswordDialogData,
-    private _formBuilder: UntypedFormBuilder,
+    private _formBuilder: FormBuilder,
     private usersManagerService: UsersManagerService,
     private apiRequestConfiguration: ApiRequestConfigurationService,
     private notificator: NotificatorService,
@@ -41,26 +60,6 @@ export class ChangePasswordDialogComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.formGroup = this._formBuilder.group(
-      {
-        oldPasswordCtrl: ['', Validators.required],
-        passwordCtrl: [
-          '',
-          Validators.required,
-          [
-            loginAsyncValidator(
-              this.data.namespace,
-              this.usersManagerService,
-              this.apiRequestConfiguration
-            ),
-          ],
-        ],
-        passwordAgainCtrl: [''],
-      },
-      {
-        validators: CustomValidators.passwordMatchValidator,
-      }
-    );
     this.oldPwd = this.formGroup.get('oldPasswordCtrl');
     this.newPwd = this.formGroup.get('passwordCtrl');
     this.newPwdAgain = this.formGroup.get('passwordAgainCtrl');


### PR DESCRIPTION
* In admin-gui, user-profile and libs we can use typed FormBuilder instead of untyped since the FormBuilder can create typed FormGroup according to the default values of defined form group items.
* Some other refactoring was made in changed files (use PerunTranslateService, use non-deprecated type of subscribe).