### PR TITLE
feat: merge configs on initialization

### DIFF
--- a/libs/config/src/lib/app-config.service.ts
+++ b/libs/config/src/lib/app-config.service.ts
@@ -128,20 +128,20 @@ export class AppConfigService {
         .get('/assets/config/instanceConfig.json', {
           headers: this.getNoCacheHeaders(),
         })
-        .subscribe(
-          (config: PerunConfig) => {
-            this.storeService.setInstanceConfig(config);
+        .subscribe({
+          next: (config: PerunConfig) => {
+            this.storeService.mergeConfig(config);
             const branding = document.location.hostname;
             if (config?.['brandings']?.[branding]) {
-              this.storeService.setBanding(branding);
+              this.storeService.mergeConfig(config?.['brandings']?.[branding]);
             }
             resolve();
           },
-          () => {
+          error: () => {
             // console.log('instance config not detected');
             resolve();
-          }
-        );
+          },
+        });
     });
   }
 


### PR DESCRIPTION
* values from configs (default, instance, brandings) are now merged when loading instead of fetching them on each 'getProperty()' call