### PR TITLE
fix(admin): disable to add new form item during the data loading

### DIFF
--- a/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/group-detail-page/group-settings/group-settings-application-form/group-settings-application-form.component.html
@@ -53,6 +53,7 @@
 
     <button
       *ngIf="editAuth"
+      [disabled]="loadingTable"
       (click)="add()"
       color="accent"
       class="me-2 action-button"

--- a/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.html
+++ b/apps/admin-gui/src/app/vos/pages/vo-detail-page/vo-settings/vo-settings-application-form/vo-settings-application-form.component.html
@@ -41,6 +41,7 @@
 
     <button
       *ngIf="editAuth"
+      [disabled]="loadingTable"
       (click)="add()"
       color="accent"
       class="me-2 action-button"


### PR DESCRIPTION
* Add button is now disabled when the data are loading - we want to avoid potential bug (edge case) when new item is locally added to the list and then is rewritten by asynchronously loaded data from BE.